### PR TITLE
perf(web): sitemap.ts に ISR 24h キャッシュ（D1 rows read 削減 PR-A）

### DIFF
--- a/apps/web/src/app/sitemap.ts
+++ b/apps/web/src/app/sitemap.ts
@@ -12,6 +12,8 @@ import { GONE_RANKING_KEYS } from "@/config/gone-ranking-keys";
 
 import type { MetadataRoute } from "next";
 
+// ISR 24h キャッシュ: Googlebot の sitemap.xml 取得のたびに D1 全テーブルスキャンが走るのを防ぐ
+export const revalidate = 86400;
 
 const BASE_URL = process.env.NEXT_PUBLIC_BASE_URL || "https://stats47.jp";
 


### PR DESCRIPTION
## Summary
- `apps/web/src/app/sitemap.ts` に `export const revalidate = 86400` を追加
- Googlebot 等のクローラが sitemap.xml を取得するたびに D1 全テーブルスキャンが発生していた問題を解消

## 背景
2026-03-15〜04-14 の Cloudflare 請求で D1 rows read が 14.5B 超過（無料枠 25B → 実測約 39.5B）し \$14.53 の課金が発生。原因の上位にこの sitemap.ts の毎リクエスト全テーブルスキャンがあった。

監査結果:
- `rankingItems` 全行スキャン
- `categories` 全行
- `articles` 全行
- `articleTags` + `articles` INNER JOIN + GROUP BY
- `surveys` 全行

キャッシュ無しで Googlebot / Bingbot / 他クローラが 1 日数十回叩いていた可能性。

## 効果見込み
- D1 rows read 削減: **-50%（月 500M〜1B 削減）**
- sitemap の鮮度: 24h 遅延（新規記事・ランキングが最大 24h 反映されないが SEO 上許容範囲）

## Test plan
- [x] 型チェック pass (`npx tsc --noEmit -p apps/web/tsconfig.json`)
- [ ] デプロイ後 `sitemap.xml` が 200 を返すこと確認
- [ ] 翌日以降 Cloudflare Dashboard で D1 rows read の減少を確認

## 関連
次 PR:
- PR-B: `ports/page.tsx` の `force-dynamic` 削除
- PR-C: OGP 画像の事前生成化