### PR TITLE
perf(web): /ports の force-dynamic 削除 → ISR 24h（PR-B）

### DIFF
--- a/apps/web/src/app/ports/page.tsx
+++ b/apps/web/src/app/ports/page.tsx
@@ -1,4 +1,6 @@
-export const dynamic = "force-dynamic";
+// ISR 24h: 港湾統計は年次データのため頻繁な更新は不要。
+// force-dynamic を避けることで毎リクエストの ports + portStatistics 全行スキャンを削減。
+export const revalidate = 86400;
 
 import Link from "next/link";
 
@@ -23,7 +25,8 @@ export const metadata: Metadata = {
 };
 
 export default async function PortsPage() {
-  const { ports, years } = await loadPortData();
+  // ビルド時に D1 が利用できない場合は空データでレンダリング、ISR で再生成する
+  const { ports, years } = await loadPortData().catch(() => ({ ports: [], years: [] }));
 
   return (
     <div className="container mx-auto px-4 py-4 text-foreground">


### PR DESCRIPTION
## Summary
- `apps/web/src/app/ports/page.tsx` の `export const dynamic = 'force-dynamic'` を削除
- `export const revalidate = 86400` に置換（24h ISR）
- `loadPortData()` を `.catch()` で保護（ビルド時 D1 未接続に備え sitemap.ts と同じパターン）

## 背景
\$26.62 の Cloudflare 請求調査の一環（PR-A に続く）。

force-dynamic は 2026-03-27 のコミット 60b5fd1c で「CI ビルド失敗修正」として追加された回避策であり、意図した挙動ではなかった。これにより毎リクエストで以下のクエリが実行されていた:

- `SELECT year FROM port_statistics DISTINCT` (全年)
- `SELECT * FROM ports` (171 港)
- `SELECT * FROM port_statistics WHERE year = ?` (最新年 171×18 metrics ≒ 3000 行)

港湾統計は e-Stat の年次データなので 24h キャッシュで十分。

## 効果見込み
- D1 rows read 追加削減: **約 -30%（月 500M〜1B 削減）**
- /ports ページのレスポンス高速化（edge cache ヒット時）

## Test plan
- [x] 型チェック pass
- [ ] デプロイ後 /ports が 200 を返すこと
- [ ] 港湾マップの表示・年度切替が正常動作