### PR TITLE
perf(web): OGP 画像を ISR 長期キャッシュ化（Workers CPU ms 削減 PR-C）

### DIFF
--- a/apps/web/src/app/areas/[areaCode]/opengraph-image.tsx
+++ b/apps/web/src/app/areas/[areaCode]/opengraph-image.tsx
@@ -6,13 +6,17 @@ export const alt = "地域の特徴";
 export const size = { width: 1200, height: 630 };
 export const contentType = "image/png";
 
+// ISR 7 日: OGP 画像は 47 都道府県 × 表示機会が限定的。Satori レンダリングは CPU 重いため長期キャッシュで Workers CPU ms を削減。
+export const revalidate = 604800;
+
 export default async function OGImage({
     params,
 }: {
     params: Promise<{ areaCode: string }>;
 }) {
     const { areaCode } = await params;
-    const profile = await getAreaProfileAction(areaCode);
+    // ビルド時 D1 未接続でも失敗させない（ISR で後から再生成）
+    const profile = await getAreaProfileAction(areaCode).catch(() => null);
 
     const areaName = profile?.areaName ?? "地域の特徴";
     const topStrengths = (profile?.strengths ?? []).slice(0, 3);

--- a/apps/web/src/app/themes/[themeSlug]/opengraph-image.tsx
+++ b/apps/web/src/app/themes/[themeSlug]/opengraph-image.tsx
@@ -6,6 +6,14 @@ export const alt = "テーマダッシュボード";
 export const size = { width: 1200, height: 630 };
 export const contentType = "image/png";
 
+// ISR 30 日: テーマ OGP は ALL_THEMES 設定のみを参照し内容が変わらない。最長キャッシュで Workers CPU ms を削減。
+export const revalidate = 2592000;
+
+// ALL_THEMES にある全テーマを静的生成（DB 依存なし）
+export function generateStaticParams() {
+  return ALL_THEMES.map((t) => ({ themeSlug: t.themeKey }));
+}
+
 export default async function OGImage({
   params,
 }: {


### PR DESCRIPTION
## Summary
- `/areas/[areaCode]/opengraph-image.tsx`: `revalidate = 604800` (7 日) + D1 失敗時 fallback
- `/themes/[themeSlug]/opengraph-image.tsx`: `revalidate = 2592000` (30 日) + `generateStaticParams` で 16 テーマ分事前生成

## 背景
\$26.62 の Cloudflare 請求調査（PR-A, PR-B に続く最終 PR）。

Workers CPU ms が月 225M（無料枠 30M を 6.5 倍超過）で \$3.92 課金されていた主因が、OGP 画像の Satori 動的生成だった。リクエストごとに 1200×630 の PNG を SVG から生成するため CPU を重く消費。

47 都道府県 + 16 テーマ = 63 種類の URL が、X や SNS で踏まれるたびに都度生成されていた。

## 効果見込み
- Workers CPU ms 削減: **-80%（月 225M → 推定 45M）**
- 無料枠 30M に近づくため追加課金ほぼゼロに

## トレードオフ
- 初回リクエスト（キャッシュミス）時は従来通り生成
- テーマ OGP: 30 日キャッシュ（ALL_THEMES 設定が不変なので影響なし）
- エリア OGP: 7 日キャッシュ（strength データが週次以下の頻度で変化するため許容）

## Test plan
- [x] 型チェック pass
- [ ] デプロイ後 `https://stats47.jp/areas/01000/opengraph-image` が 200 を返すこと
- [ ] `https://stats47.jp/themes/<slug>/opengraph-image` が 200 を返すこと
- [ ] X / Slack でリンクプレビューが正しく表示されること