### PR TITLE
feat(analytics): Cloudflare コスト継続監視スキル + MCP 導入

### DIFF
--- a/.claude/skills/analytics/cloudflare-cost-improvement/SKILL.md
+++ b/.claude/skills/analytics/cloudflare-cost-improvement/SKILL.md
@@ -1,0 +1,195 @@
+---
+name: cloudflare-cost-improvement
+description: Cloudflare Workers / D1 / R2 の月次コストと主要メトリクス（D1 rows read、Workers CPU ms、storage、月額課金）を追跡し、budget 超過を検知・施策と効果を記録する。Use when user says "Cloudflare コスト確認", "D1 使用量", "Workers CPU 使用量", "請求書チェック", or when analyzing Cloudflare invoices / cost anomalies.
+---
+
+Cloudflare の月次コスト・リソース使用量を **時系列で追跡**し、打った施策と効果を記録するスキル。
+
+Cloudflare の請求は月次（前月 15 日〜当月 14 日集計、翌 15 日請求）。施策効果の測定は「デプロイから 14 日以上経過した観測値」で判定する。
+
+## 用途
+
+- 月次請求額と主要メトリクスを継続的に記録したい
+- budget（無料枠・警告・エラー閾値）を超過した指標を検知したい
+- 打った施策（ISR 追加、キャッシュ調整等）の効果を測定したい
+- 次に着手すべき改善候補を参照したい
+- Cloudflare 請求書を受領したら数値をスナップショットとして残したい
+
+## 管理ファイル
+
+- **`reference/improvement-log.md`** — メイン成果物（Baseline / Action Log / Observation Log / Next Actions）
+- **`reference/budgets.json`** — メトリクス別の budget（無料枠・警告・エラー閾値）
+- **`reference/weekly-snapshots/YYYY-Www.json`** — 月次（または臨時）スナップショット
+
+## 引数
+
+```
+$ARGUMENTS — [mode]
+             mode:
+               - status  (デフォルト) : improvement-log.md を読んで現状を要約
+               - observe : 最新メトリクスをスナップショットとして記録 + budget 判定
+               - action  : 新しい施策を Action Log に追加
+               - next    : Next Actions から次の候補を提示
+               - invoice : 請求書 PDF から月次スナップショットを作成
+```
+
+## 手順
+
+### Step 1: データソースの特定
+
+Cloudflare メトリクス取得の優先順:
+
+1. **Cloudflare Observability MCP** (`cloudflare-observability`) — Workers logs / analytics 取得に利用
+2. **Cloudflare GraphQL MCP** (`cloudflare-graphql`) — より柔軟な分析クエリ（D1 query-level, Workers by route）
+3. **Cloudflare Dashboard（ユーザー手動共有）** — MCP 未接続時のフォールバック。ユーザーにスクショ or CSV 提供を依頼
+4. **月次請求書 PDF** — `~/Downloads/*.pdf` 内。`invoice` モードで処理
+
+MCP 接続状況の確認:
+- `.mcp.json` に `cloudflare-observability` と `cloudflare-graphql` の 2 つが登録済み
+- 初回利用時はブラウザで OAuth 認可が必要
+- 接続失敗時は手動データ提供を促す
+
+### Step 2: mode 別の処理
+
+#### mode = status（デフォルト）
+
+```
+reference/improvement-log.md を Read し、以下を要約:
+- 最新スナップショット（3.1 月次メトリクス履歴の最終行）
+- 現在進行中の施策（Action Log で実測効果が PENDING のもの）
+- budget 超過中のメトリクス
+- 次に観測すべき日付（Next Actions の監視タスク）
+```
+
+#### mode = observe
+
+```
+1. データ取得:
+   a. MCP 利用可能なら cloudflare-graphql で月次メトリクス取得
+      （clause: "zone/accounts analytics for last N days"）
+   b. MCP 未接続ならユーザーに Dashboard Analytics のスクショ or CSV を依頼
+   c. 請求書到着後なら invoice モードを案内
+
+2. 必須メトリクス:
+   - d1_rows_read (月次合計)
+   - d1_rows_written
+   - d1_storage_gb (最新値 = GB-month)
+   - workers_cpu_ms (月次合計)
+   - workers_requests_standard
+
+3. reference/weekly-snapshots/YYYY-Www.json に保存:
+   - 命名: ISO Week（2026-W20 等）
+   - period_start / period_end を明記
+   - source: "Cloudflare GraphQL API via MCP" or "manual entry from dashboard"
+
+4. budgets.json としきい値比較:
+   - warning_threshold <= 値 < error_threshold → WARNING
+   - 値 >= error_threshold → ERROR
+   - alerts 配列に記録
+
+5. improvement-log.md 更新:
+   - 3.1 月次メトリクス履歴 に 1 行追記
+   - 施策効果サマリの自動計算（gsc-improvement Step 2.observe.7 と同じロジック）:
+     * 経過日数 < 14 → PENDING
+     * 経過日数 >= 14 かつ |実測/想定| >= 80% → FULL_EFFECT ✅
+     * 20% <= ... < 80% → PARTIAL_EFFECT ⚠️
+     * < 20% → NO_EFFECT ❌
+     * 逆方向 → ADVERSE 🚨
+   - Action Log 各施策の「実測効果」テーブルにも同じ行を追記
+
+6. 出力:
+   - budget 超過アラートを先頭で強調
+   - 判定変化（PENDING → FULL/PARTIAL 等）をハイライト
+   - ADVERSE があれば注意喚起
+```
+
+#### mode = action
+
+```
+1. 必須フィールド確認（欠落時は追加質問）:
+   - **施策 ID**: `T{Tier}-{Category}-{連番}`
+     - Tier: T1（即効）/ T2（戦略）/ T3（要調査）
+     - Category: D1READ / D1WRITE / D1STORAGE / CPUMS / REQUESTS / R2 / CACHE など
+   - **ターゲット指標**: d1_rows_read / workers_cpu_ms など
+   - **想定効果値**: 削減率 or 絶対値 delta
+   - **デプロイ日**: YYYY-MM-DD
+   - **PR / コミット hash**
+   - **変更内容サマリ**
+   - **変更ファイルリスト**
+
+2. improvement-log.md の Action Log に追加（gsc-improvement と同じフォーマット）
+
+3. 「実測効果」テーブル初期化（observe で自動追記される）
+```
+
+#### mode = next
+
+```
+improvement-log.md の Next Actions セクションから優先度上位 3 件を提示。
+Tier 順（Tier 1 → 2 → 3）で消化する原則。
+```
+
+#### mode = invoice
+
+```
+1. 引数で PDF パス指定、または ~/Downloads/*.pdf の最新から自動検出
+2. PDF を Read（Read tool は PDF 対応）
+3. 以下を抽出:
+   - Invoice number / Date of issue / Date due
+   - Period（Mar 15 – Apr 14, 2026 のような表記）
+   - 各 line item の Qty（超過量）と Amount
+   - Total / Tax rate / Total in JPY（Tax Addendum ページ）
+4. weekly-snapshots/YYYY-Www.json として保存:
+   - source: "Cloudflare invoice IN-XXXXXX"
+   - period_start / period_end
+   - metrics 各項目に billable_overage と billable_amount_usd を記録
+   - cost_summary に subtotal / tax / total / exchange_rate_jpy
+5. budget 判定 + improvement-log.md に 1 行追記
+6. 請求額・超過指標をユーザーに報告
+```
+
+### Step 3: 共通ルール
+
+- **ログは append-only** — 過去エントリは改変しない
+- **日付は絶対日付**（`2026-05-05`）。「今月」「先月」は使わない
+- **数値はソース明示** — "invoice IN-62466340" or "Cloudflare GraphQL API at 2026-04-21"
+- **施策は 1 PR 1 ID** — 複数目的の PR は分割
+- **想定効果値はデプロイ前に明記** — 後付けバイアス防止
+- **月次請求到着時は必ず invoice モード実行** — 14 日の集計ギャップがあるため、この記録を起点に判定
+
+## MCP の使い方（参考）
+
+### observability MCP で Workers logs / analytics を取得
+
+Claude 内で自然文で呼び出し可能:
+- 「過去 24h の Workers errors を取得」→ `mcp__cloudflare-observability__workers_logs_search` 等
+- 「特定 route の CPU time を取得」→ analytics クエリ
+
+### graphql MCP で詳細メトリクス
+
+Cloudflare GraphQL Analytics API を直接叩ける。D1 query レベルの分析にも対応:
+- 「月次の d1AnalyticsAdaptive の集計を取得」
+- 「workersInvocationsAdaptive by scriptName」
+
+### 初回利用時の OAuth
+
+```
+ブラウザで https://dash.cloudflare.com にログイン済みであること
+MCP 接続時に Cloudflare の認可画面が開く → Allow
+成功すると Claude が MCP ツールを呼べるようになる
+```
+
+## 関連スキル
+
+- `/performance-improvement` — PSI / Lighthouse（速度系）の改善ログ
+- `/gsc-improvement` — GSC（SEO 系）の改善ログ
+- `/ga4-improvement` — GA4（行動分析）の改善ログ
+- `/knowledge` — 恒久的な学び（本 skill は進行中、knowledge は確定した学び）
+- `/sync-remote-d1` — ローカル D1 → 本番 D1 の push
+- `/r2-du` — R2 ディスク使用量
+
+## 前提
+
+- `.mcp.json` に `cloudflare-observability` と `cloudflare-graphql` が登録済み
+- Cloudflare アカウントへのブラウザログイン済み（OAuth 認可用）
+- `reference/budgets.json` / `reference/improvement-log.md` が初期化済み

--- a/.claude/skills/analytics/cloudflare-cost-improvement/reference/budgets.json
+++ b/.claude/skills/analytics/cloudflare-cost-improvement/reference/budgets.json
@@ -1,0 +1,82 @@
+{
+  "version": 1,
+  "description": "Cloudflare Workers / D1 / R2 の月次使用量としきい値。2026-04-15 の請求書 IN-62466340（$26.62）を基準に設定。",
+  "source": "invoice IN-62466340 (Mar 15 – Apr 14, 2026), Workers Paid plan $5/mo",
+  "schema": {
+    "metric_key": "計測対象メトリクス",
+    "unit": "単位",
+    "free_tier_monthly": "Workers Paid 無料枠/月",
+    "warning_threshold": "警告しきい値（無料枠の N%）",
+    "error_threshold": "エラーしきい値（超過確定）",
+    "operator": "<= | >=",
+    "severity": "warning | error"
+  },
+  "budgets": [
+    {
+      "metric_key": "d1_rows_read",
+      "unit": "rows",
+      "free_tier_monthly": 25000000000,
+      "warning_threshold": 20000000000,
+      "error_threshold": 25000000000,
+      "operator": "<=",
+      "severity_warning": "warning",
+      "severity_error": "error",
+      "note": "Apr 2026 実績 39.5B（超過 14.5B = $14.53）。PR-A/B デプロイ後の目標は 10B 以下"
+    },
+    {
+      "metric_key": "d1_rows_written",
+      "unit": "rows",
+      "free_tier_monthly": 50000000,
+      "warning_threshold": 40000000,
+      "error_threshold": 50000000,
+      "operator": "<=",
+      "severity_warning": "warning",
+      "severity_error": "error",
+      "note": "Apr 2026 実績 ~0（書き込みはシード・投入時のみ）"
+    },
+    {
+      "metric_key": "d1_storage_gb",
+      "unit": "GB",
+      "free_tier_monthly": 5,
+      "warning_threshold": 4.5,
+      "error_threshold": 5,
+      "operator": "<=",
+      "severity_warning": "warning",
+      "severity_error": "error",
+      "note": "Apr 2026 実績 ~6GB（超過 1GB = $0.75）"
+    },
+    {
+      "metric_key": "workers_cpu_ms",
+      "unit": "CPU ms",
+      "free_tier_monthly": 30000000,
+      "warning_threshold": 25000000,
+      "error_threshold": 30000000,
+      "operator": "<=",
+      "severity_warning": "warning",
+      "severity_error": "error",
+      "note": "Apr 2026 実績 225M（超過 195M = $3.92）。PR-C デプロイ後の目標は 45M 以下"
+    },
+    {
+      "metric_key": "workers_requests",
+      "unit": "requests",
+      "free_tier_monthly": 10000000,
+      "warning_threshold": 8000000,
+      "error_threshold": 10000000,
+      "operator": "<=",
+      "severity_warning": "warning",
+      "severity_error": "error",
+      "note": "Standard requests (bundled は別カウント)"
+    },
+    {
+      "metric_key": "total_cost_usd_monthly",
+      "unit": "USD",
+      "free_tier_monthly": 5,
+      "warning_threshold": 10,
+      "error_threshold": 15,
+      "operator": "<=",
+      "severity_warning": "warning",
+      "severity_error": "error",
+      "note": "Workers Paid サブスク $5 + 従量分。PR デプロイ後の目標は $6-10"
+    }
+  ]
+}

--- a/.claude/skills/analytics/cloudflare-cost-improvement/reference/improvement-log.md
+++ b/.claude/skills/analytics/cloudflare-cost-improvement/reference/improvement-log.md
@@ -1,0 +1,131 @@
+# Cloudflare コスト改善ログ
+
+Cloudflare Workers / D1 / R2 の月次コストと主要メトリクスを時系列で追跡し、打った施策と効果を記録する。
+
+請求は月次で前月 15 日〜当月 14 日の集計になるため、施策効果の測定は **14 日以上経過してから** 判定する。
+
+---
+
+## Baseline（2026-W15 = 2026-03-15〜04-14）
+
+| 指標 | 実績 | 無料枠 | 超過 | 課金額 |
+|---|---|---|---|---|
+| D1 Rows Read | 39,524,193,411 | 25B | 14.5B | **$14.53** |
+| Workers CPU ms | 225,488,730 | 30M | 195M | **$3.92** |
+| D1 Storage | 6 GB | 5 GB | 1 GB | $0.75 |
+| Workers Paid サブスク | 1 | - | - | $5.00 |
+| 消費税 (JPN 10%) | - | - | - | $2.42 |
+| **合計** | | | | **$26.62** |
+
+請求書: IN-62466340（2026-04-15 発行）
+
+---
+
+## Action Log
+
+### [T1-D1READ-01] sitemap.ts に ISR 24h キャッシュ
+
+**施策 ID**: `T1-D1READ-01`
+**Tier**: T1（即効・低リスク）
+**デプロイ日**: 2026-04-21（PR merge 済、本番デプロイは別途 `/deploy`）
+**PR**: https://github.com/uruhayato373/stats47/pull/7
+**コミット**: `28715f42`
+**ターゲット指標**: D1 Rows Read
+**想定効果値**: -50%（月 500M〜1B 削減）
+**観測予定日**: 2026-05-05 (MID), 2026-05-19 (FINAL)
+
+#### 変更内容
+- `apps/web/src/app/sitemap.ts` に `export const revalidate = 86400` 追加
+- Googlebot / Bingbot 等のクローラが sitemap.xml を取得するたびに `rankingItems` `categories` `articles` `articleTags` `surveys` を全行スキャンしていた問題を解消
+
+#### 実測効果
+| 観測日 | 経過日数 | D1 Rows Read delta | 判定 |
+|---|---|---|---|
+| （未観測） | - | - | PENDING |
+
+---
+
+### [T1-D1READ-02] /ports の force-dynamic → ISR 24h
+
+**施策 ID**: `T1-D1READ-02`
+**Tier**: T1
+**デプロイ日**: 2026-04-21（PR merge 済）
+**PR**: https://github.com/uruhayato373/stats47/pull/8
+**コミット**: `0b2a39bf`
+**ターゲット指標**: D1 Rows Read
+**想定効果値**: -30%（月 500M〜1B 追加削減）
+**観測予定日**: 2026-05-05 (MID), 2026-05-19 (FINAL)
+
+#### 変更内容
+- `apps/web/src/app/ports/page.tsx` の `export const dynamic = "force-dynamic"` を削除
+- `export const revalidate = 86400` + `loadPortData().catch(...)` の fallback 追加
+- force-dynamic は 2026-03-27 コミット `60b5fd1c` で CI ビルド失敗の回避策として追加されたものであり、意図した設計ではなかった
+
+#### 実測効果
+| 観測日 | 経過日数 | D1 Rows Read delta | 判定 |
+|---|---|---|---|
+| （未観測） | - | - | PENDING |
+
+---
+
+### [T1-CPUMS-01] OGP 画像を ISR 長期キャッシュ化
+
+**施策 ID**: `T1-CPUMS-01`
+**Tier**: T1
+**デプロイ日**: 2026-04-21（PR merge 済）
+**PR**: https://github.com/uruhayato373/stats47/pull/9
+**コミット**: `fce131bf`
+**ターゲット指標**: Workers CPU ms
+**想定効果値**: -80%（月 225M → 45M）
+**観測予定日**: 2026-05-05 (MID), 2026-05-19 (FINAL)
+
+#### 変更内容
+- `/areas/[areaCode]/opengraph-image.tsx`: `revalidate = 604800`（7 日）+ D1 失敗時 fallback
+- `/themes/[themeSlug]/opengraph-image.tsx`: `revalidate = 2592000`（30 日）+ `generateStaticParams` で 16 テーマ分事前生成
+- Satori による動的 PNG 生成を長期エッジキャッシュで代替
+
+#### 実測効果
+| 観測日 | 経過日数 | Workers CPU ms delta | 判定 |
+|---|---|---|---|
+| （未観測） | - | - | PENDING |
+
+---
+
+## Observation Log
+
+### 3.1 月次メトリクス履歴
+
+| スナップショット | 期間 | D1 Rows Read | Workers CPU ms | D1 Storage | 合計 $ | 備考 |
+|---|---|---|---|---|---|---|
+| 2026-W15 | Mar 15 – Apr 14 | 39.5B | 225M | 6GB | $26.62 | BASELINE。T1-D1READ-01/02 + T1-CPUMS-01 デプロイ前 |
+
+### 3.2 施策効果サマリ
+
+| 観測日 | 施策 ID | 経過日数 | ターゲット | 想定 delta | 実測 delta | 判定 |
+|---|---|---|---|---|---|---|
+| （まだなし） | | | | | | |
+
+---
+
+## Next Actions
+
+### Tier 1（即効・未実施）
+
+- **ランキング API route のキャッシュ見直し** — `/api/ranking-data/[rankingKey]` route の Cache-Control 設定確認
+- **`packages/ranking/*/list-ranking-values*.ts` に LIMIT 追加** — 安全装置として。WHERE 句で絞り込まれているため実質影響は小さいが、事故防止のため
+
+### Tier 2（戦略）
+
+- **D1 storage 削減** — `_backup` 系テーブル・古い migration 残骸の洗い出し
+- **R2 hot object 特定** — ランキング画像・AI 生成コンテンツの hit rate 確認
+
+### Tier 3（要調査）
+
+- **Bot トラフィックフィルタ** — Cloudflare Dashboard で bot score でフィルタ、スクレイパー遮断
+- **D1 read replica** — 将来のスケール時。現状は不要
+
+### 監視タスク
+
+- **2026-05-05（デプロイ後 14 日）**: MID observation 実施
+- **2026-05-19（デプロイ後 28 日）**: FINAL observation 実施
+- **2026-05-15（次の請求日）**: 実請求額で最終判定

--- a/.claude/skills/analytics/cloudflare-cost-improvement/reference/weekly-snapshots/2026-W15.json
+++ b/.claude/skills/analytics/cloudflare-cost-improvement/reference/weekly-snapshots/2026-W15.json
@@ -1,0 +1,81 @@
+{
+  "snapshot_id": "2026-W15",
+  "period_label": "Mar 15 – Apr 14, 2026 (月次請求)",
+  "period_start": "2026-03-15",
+  "period_end": "2026-04-14",
+  "source": "Cloudflare invoice IN-62466340 (manual entry)",
+  "recorded_at": "2026-04-21",
+  "metrics": {
+    "d1_rows_read": {
+      "value": 39524193411,
+      "unit": "rows",
+      "billable_overage": 14524193411,
+      "billable_amount_usd": 14.53,
+      "note": "無料枠 25B を 14.5B 超過。sitemap.ts と /ports の全行スキャンが主因。"
+    },
+    "d1_rows_written": {
+      "value": 0,
+      "unit": "rows",
+      "billable_overage": 0,
+      "billable_amount_usd": 0.0,
+      "note": "書き込みは /sync-remote-d1 の手動実行時のみ（月次請求期間内はゼロ）"
+    },
+    "d1_storage_gb": {
+      "value": 6,
+      "unit": "GB-month",
+      "billable_overage": 1,
+      "billable_amount_usd": 0.75,
+      "note": "5GB 無料枠 + 1GB 超過。古いテーブル整理で削減可能"
+    },
+    "workers_cpu_ms": {
+      "value": 225488730,
+      "unit": "CPU ms",
+      "billable_overage": 195488730,
+      "billable_amount_usd": 3.92,
+      "note": "OGP 画像の Satori 動的生成が主因"
+    },
+    "workers_requests_standard": {
+      "value": 0,
+      "unit": "requests",
+      "billable_overage": 0,
+      "billable_amount_usd": 0.0,
+      "note": "10M 無料枠内"
+    },
+    "subscription_workers_paid": {
+      "value": 1,
+      "unit": "month",
+      "billable_amount_usd": 5.0
+    }
+  },
+  "cost_summary": {
+    "subtotal_usd": 24.2,
+    "tax_usd": 2.42,
+    "tax_rate": 0.1,
+    "tax_region": "JAPAN",
+    "total_usd": 26.62,
+    "exchange_rate_jpy": 159.65,
+    "total_jpy": 4252
+  },
+  "alerts": [
+    {
+      "metric": "d1_rows_read",
+      "severity": "error",
+      "reason": "無料枠 25B を 58% 超過（14.5B 超過）"
+    },
+    {
+      "metric": "d1_storage_gb",
+      "severity": "error",
+      "reason": "無料枠 5GB を 20% 超過"
+    },
+    {
+      "metric": "workers_cpu_ms",
+      "severity": "error",
+      "reason": "無料枠 30M を 651% 超過（6.5 倍）"
+    },
+    {
+      "metric": "total_cost_usd_monthly",
+      "severity": "error",
+      "reason": "警告しきい値 $10 / エラーしきい値 $15 を突破（$26.62）"
+    }
+  ]
+}

--- a/.mcp.json
+++ b/.mcp.json
@@ -49,6 +49,14 @@
         "/Users/minamidaisuke/stats47"
       ],
       "env": {}
+    },
+    "cloudflare-observability": {
+      "type": "sse",
+      "url": "https://observability.mcp.cloudflare.com/sse"
+    },
+    "cloudflare-graphql": {
+      "type": "sse",
+      "url": "https://graphql.mcp.cloudflare.com/sse"
     }
   }
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,6 +40,7 @@ packages/
 | 実装計画・課題・アイデア | `docs/90_課題管理/` |
 | 各 feature の設計 | 各 `apps/*/src/features/*/README.md` |
 | GSC/GA4 の週次メトリクス snapshot と改善施策記録 | `.claude/skills/analytics/{gsc,ga4}-improvement/reference/` ★週次レビュー時に全件 CSV を git で積む |
+| Cloudflare 月次コスト・メトリクス snapshot と改善施策記録 | `.claude/skills/analytics/cloudflare-cost-improvement/reference/` ★請求書到着時に `/cloudflare-cost-improvement invoice` で snapshot を積む |
 | DB 操作全般（スキーマ・データ変更・シード） | `packages/database/README.md` ★DB操作時は必ず参照 |
 | R2 ストレージ・同期 | `packages/r2-storage/src/scripts/README.md` |
 | 国土数値情報 GIS データ（データセット一覧・パイプライン・ライセンス） | `docs/01_技術設計/08_国土数値情報GISデータ.md` |
@@ -143,6 +144,7 @@ packages/
 | GA4 週次 snapshot (CSV) + 改善ログ | `.claude/skills/analytics/ga4-improvement/reference/` |
 | PSI / Lighthouse スコア履歴 | `.claude/skills/analytics/performance-improvement/` |
 | PSI 閾値（budgets） | `.claude/skills/analytics/performance-improvement/budgets.json` |
+| Cloudflare 月次 snapshot + 改善ログ + budget | `.claude/skills/analytics/cloudflare-cost-improvement/reference/` |
 | SNS 投稿メトリクス時系列 | `.claude/skills/analytics/sns-metrics-improvement/snapshots/YYYY-MM-DD/metrics.csv`（書き込み: `.claude/scripts/lib/sns-metrics-store.cjs`） |
 | NSM 週次 JSON snapshot | `.claude/skills/management/nsm-experiment/reference/weekly-snapshots/YYYY-Www.json` |
 | 実験 state（PDCA） | `.claude/state/experiments.json` |


### PR DESCRIPTION
## Summary
Cloudflare 月次請求 \$26.62（IN-62466340）をきっかけに継続監視の仕組みを整備。

### 追加内容

**MCP（.mcp.json）** — 初回利用時にブラウザで OAuth 認可が必要
- `cloudflare-observability` (https://observability.mcp.cloudflare.com/sse)
- `cloudflare-graphql` (https://graphql.mcp.cloudflare.com/sse)

**スキル** (`.claude/skills/analytics/cloudflare-cost-improvement/`)
- `SKILL.md` — 5 モード（status / observe / action / next / invoice）
- `reference/budgets.json` — 6 メトリクス × 警告/エラーしきい値
- `reference/improvement-log.md` — Baseline + PR #7/#8/#9 の Action Log
- `reference/weekly-snapshots/2026-W15.json` — 初回 baseline（invoice IN-62466340）

**CLAUDE.md** — ドキュメント参照ガイドと記録先原則テーブルに追記

## 使い方

- `/cloudflare-cost-improvement` — 現状サマリ
- `/cloudflare-cost-improvement observe` — 最新メトリクス取得 + budget 判定
- `/cloudflare-cost-improvement invoice ~/Downloads/*.pdf` — 請求書から snapshot 作成
- `/cloudflare-cost-improvement action` — 施策記録
- `/cloudflare-cost-improvement next` — 次の改善候補提示

## Test plan
- [x] `.mcp.json` が valid JSON
- [ ] Claude Code 再起動後 `/mcp` で observability / graphql が listed
- [ ] ブラウザで OAuth 認可が完了する
- [ ] `/cloudflare-cost-improvement` で baseline が正しく読める
- [ ] 来月の請求到着時に `invoice` モードが機能する