### PR TITLE
fix(ci): publish step で working tree リセット

### DIFF
--- a/.github/workflows/fetch-metrics-weekly.yml
+++ b/.github/workflows/fetch-metrics-weekly.yml
@@ -101,6 +101,10 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
+          # working tree の変更は /tmp/metrics-publish に退避済。branch 切替前にリセット。
+          git reset --hard HEAD
+          git clean -fd
+
           git fetch origin develop
           git checkout develop
           git pull --rebase origin develop

--- a/.github/workflows/psi-audit-daily.yml
+++ b/.github/workflows/psi-audit-daily.yml
@@ -69,6 +69,10 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
+          # working tree の変更は /tmp/psi-publish に退避済。branch 切替前にリセット。
+          git reset --hard HEAD
+          git clean -fd
+
           git fetch origin develop
           git checkout develop
           git pull --rebase origin develop


### PR DESCRIPTION
## Summary

fetch-metrics-weekly の初回 dispatch（run #24885051604）が以下で失敗:

\`\`\`
error: cannot pull with rebase: You have unstaged changes.
\`\`\`

### 原因

1. \`ref: main\` でチェックアウト
2. fetch スクリプトが \`.claude/state/metrics/*/history.csv\` 等を working tree で変更（main にもこのファイルが存在するため）
3. \`git checkout develop\` で切替（成功、でも変更は working tree に残る）
4. \`git pull --rebase origin develop\` が unstaged changes で失敗

### 修正

出力は既に \`/tmp/metrics-publish/\` にステージ済なので、branch 切替前に以下を追加:

\`\`\`bash
git reset --hard HEAD
git clean -fd
\`\`\`

PSI workflow も 2 回目以降の実行で同じ失敗を踏むため、同時修正。

## Test plan

- [ ] マージ後 \`gh workflow run fetch-metrics-weekly.yml --ref main -f week=2026-W17\` を再 dispatch
- [ ] develop に \`chore(metrics): weekly snapshot 2026-W17 [skip ci]\` commit が入ることを確認
- [ ] PSI も併せて再 dispatch

🤖 Generated with [Claude Code](https://claude.com/claude-code)