### PR TITLE
feat(seo): ランキング詳細 title に 1 位県を含めて差別化 + canonical 漏れ補完 (#77)

### DIFF
--- a/apps/web/src/app/fishing-ports/page.tsx
+++ b/apps/web/src/app/fishing-ports/page.tsx
@@ -20,6 +20,9 @@ export const metadata: Metadata = {
   title: "漁港マップ | 統計で見る都道府県",
   description:
     "日本全国の漁港2,896港を地図上で可視化。第1種〜特定第3種の種別・管理者情報。国土数値情報（漁港データ）を使用。",
+  alternates: {
+    canonical: "/fishing-ports",
+  },
 };
 
 export default async function FishingPortsPage() {

--- a/apps/web/src/app/ports/page.tsx
+++ b/apps/web/src/app/ports/page.tsx
@@ -22,6 +22,9 @@ export const metadata: Metadata = {
   title: "港湾統計マップ | 統計で見る都道府県",
   description:
     "日本の甲種港湾171港の海上出入貨物量・入港船舶隻数を地図上で可視化。港湾別ランキングと年度推移。国土交通省 港湾調査（港湾統計年報）のデータを使用。",
+  alternates: {
+    canonical: "/ports",
+  },
 };
 
 export default async function PortsPage() {

--- a/apps/web/src/features/ranking/utils/generate-meta-data.ts
+++ b/apps/web/src/features/ranking/utils/generate-meta-data.ts
@@ -27,17 +27,13 @@ import type { Metadata } from "next";
  */
 function buildMetaDescription({
   itemName,
-  unit,
-  rankingValues,
+  summary,
   selectedYear,
 }: {
   itemName: string;
-  unit: string;
-  rankingValues: RankingValue[];
+  summary: ReturnType<typeof buildRankingSummary>;
   selectedYear?: string;
 }): string {
-  const summary = buildRankingSummary(rankingValues, unit);
-
   if (!summary) {
     return selectedYear
       ? `${itemName}の${selectedYear}年度都道府県別ランキング。地図やグラフで47都道府県を比較できます。`
@@ -80,15 +76,23 @@ export function generateRankingPageMetaData({
   const itemName = getRankingTitle(rankingItem);
   const unit = rankingItem.unit || "";
 
-  const defaultTitle = areaType === "city"
+  // title 差別化（T1-CANONICAL-01 / #77）
+  // 同一テンプレート title での Google 重複判定を防ぐため、1 位県名と単位付き値を含める。
+  // seoTitle が DB に明示的に設定されていればそちらを優先。
+  const summary = buildRankingSummary(rankingValues, unit);
+  const fallbackTitle = areaType === "city"
     ? `${itemName} 市区町村ランキング`
     : `${itemName} 都道府県別ランキング`;
-  const title = rankingItem.seoTitle ?? defaultTitle;
+  const differentiatedTitle = summary?.top1Name
+    ? areaType === "city"
+      ? `${itemName}ランキング｜1位 ${summary.top1Name} | 市区町村比較`
+      : `${itemName}ランキング｜1位 ${summary.top1Name} | 47都道府県比較`
+    : fallbackTitle;
+  const title = rankingItem.seoTitle ?? differentiatedTitle;
 
   const description = rankingItem.seoDescription ?? buildMetaDescription({
     itemName,
-    unit,
-    rankingValues,
+    summary,
     selectedYear,
   });
 


### PR DESCRIPTION
## Summary (T1-CANONICAL-01 / #77)

GSC で「重複 user canonical 無し」と判定されている 534 URL の根本対策 Phase 2。

### 発見した根本原因（Phase 1 監査）
- D1 の ranking_items: **1,987 件中 seo_title 設定済み 8 件（0.4%）**
- 残り 99.6% が `{itemName} 都道府県別ランキング` という同一テンプレート title
- canonical tag 自体は 38/41 pages で正しく設定済み（OK）→ 問題は title 類似性

### 修正内容
1. **ランキング詳細の default title を差別化**
   - Before: `総人口 都道府県別ランキング`
   - After: `総人口ランキング｜1位 東京都 | 47都道府県比較`
   - 1,979 ページ全てで 1 位県名が入り differentiated になる
2. **canonical 漏れ 2 pages を補完**: `/fishing-ports`, `/ports`

## 期待効果
- 重複 user canonical 無し 534 URL → 50%+ 削減
- Organic clicks / impressions 向上の可能性（indexing 改善による）

## Test plan
- [x] \`tsc --noEmit\` pass
- [x] \`eslint\` pass
- [x] \`vitest run ranking/utils\` pass (20 tests)
- [ ] 本番デプロイ後: \`curl stats47.jp/ranking/total-population | grep title\` で差別化された title を確認
- [ ] 14 日後: GSC カバレッジレポートで「重複」URL 数の推移を確認

## 関連
- Issue: #77
- Phase 1 audit: #77 comment
- 元 Issue: #25（分割元）

🤖 Generated with [Claude Code](https://claude.com/claude-code)