### PR TITLE
perf(cls): /areas の AreaSelectorMap に aspect ratio 予約 (#79 Phase 1A)

### DIFF
--- a/apps/web/src/features/area-profile/components/AreaSelectorMap.tsx
+++ b/apps/web/src/features/area-profile/components/AreaSelectorMap.tsx
@@ -41,7 +41,9 @@ export function AreaSelectorMap() {
   );
 
   return (
-    <div className="overflow-hidden [&_rect.pref-box]:opacity-50 [&_svg]:mt-[-16%] [&_svg]:mb-[-10%]">
+    // aspect-[5/6] = 0.833 (height/width) ≒ TileGridMap の DEFAULT_ASPECT_RATIO 1.2 の逆数
+    // SSR 時点で正しい高さを予約して CLS を防ぐ（T2-CWV-04 / #79）
+    <div className="aspect-[5/6] overflow-hidden [&_rect.pref-box]:opacity-50 [&_svg]:mt-[-16%] [&_svg]:mb-[-10%]">
       <TileGridMap
         data={mapData}
         colorConfig={colorConfig}


### PR DESCRIPTION
## Summary (T2-CWV-04 / #79 Phase 1A)

/areas mobile CLS 0.324（閾値の 3.2 倍）の原因は AreaSelectorMap が dynamic({ssr: false}) で
空 div のまま SSR → hydration 時に TileGridMap が膨らむレイアウトシフト。

ラッパー div に \`aspect-[5/6]\` (width/height = 0.833) を追加して SSR 時点で
正しい高さを予約。TileGridMap の DEFAULT_ASPECT_RATIO 1.2 と一致。

## Test plan
- [x] tsc / eslint pass
- [ ] デプロイ後 PSI dispatch → /areas mobile CLS が <0.1 に下がることを確認
- [ ] /areas を実ブラウザで開いて見た目が崩れないことを確認（aspect ratio 予約で map 表示領域が変わる可能性）

## 残タスク

Phase 1B: /search mobile CLS 0.209 は別 PR（SearchPageSkeleton 調整）

🤖 Generated with [Claude Code](https://claude.com/claude-code)