### PR TITLE
feat(seo): E-E-A-T 構造化データ拡充 (#76)

### DIFF
--- a/apps/web/src/app/about/page.tsx
+++ b/apps/web/src/app/about/page.tsx
@@ -25,6 +25,10 @@ import {
 import { Separator } from "@stats47/components/atoms/ui/separator";
 import { ExternalLink, Instagram, MapPin, Youtube, Briefcase, Target } from "lucide-react";
 
+import { getRequiredBaseUrl } from "@/lib/env";
+import { buildOperatorPersonSchema } from "@/lib/structured-data/person";
+import { buildOrganizationSchema } from "@/lib/structured-data/scripts";
+
 import type { Metadata } from "next";
 
 interface AboutSectionProps {
@@ -72,8 +76,44 @@ export const metadata: Metadata = {
 };
 
 export default function AboutPage() {
+  const baseUrl = getRequiredBaseUrl();
+  // E-E-A-T 構造化データ（#76 T3-EEAT-02）
+  const personSchema = buildOperatorPersonSchema(baseUrl);
+  const organizationSchema = buildOrganizationSchema(baseUrl);
+  const aboutPageSchema = {
+    "@context": "https://schema.org",
+    "@type": "AboutPage",
+    name: "このサイトについて | 統計で見る都道府県",
+    url: `${baseUrl}/about`,
+    mainEntity: {
+      "@type": "Person",
+      name: "KAZU",
+      url: `${baseUrl}/about`,
+    },
+    about: {
+      "@type": "Organization",
+      name: "統計で見る都道府県",
+      url: baseUrl,
+    },
+    inLanguage: "ja",
+  };
+
   return (
     <main className="px-4 py-6 md:px-6 md:py-8">
+      {/* 構造化データ: Person (運営者) / Organization / AboutPage */}
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(personSchema) }}
+      />
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(organizationSchema) }}
+      />
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(aboutPageSchema) }}
+      />
+
       {/* ページヘッダー */}
       <div className="mb-6 md:mb-8">
         <h1 className="text-2xl font-bold mb-4">このサイトについて</h1>

--- a/apps/web/src/app/blog/[slug]/page.tsx
+++ b/apps/web/src/app/blog/[slug]/page.tsx
@@ -29,6 +29,8 @@ import {
 
 import { getRequiredBaseUrl } from "@/lib/env";
 import { AdSenseAd, RANKING_SIDEBAR_TOP, RANKING_PAGE_SIDEBAR } from "@/lib/google-adsense";
+import { buildPersonAsAuthor } from "@/lib/structured-data/person";
+import { buildPublisherOrganization } from "@/lib/structured-data/scripts";
 
 
 import type { Metadata } from "next";
@@ -152,6 +154,8 @@ export default async function BlogPostPage({ params }: PageProps) {
 
     const baseUrl = getRequiredBaseUrl();
     const R2_PUBLIC_URL = process.env.NEXT_PUBLIC_R2_PUBLIC_URL || "https://storage.stats47.jp";
+    // E-E-A-T 強化（#76）: author を Person に変更、publisher に logo 追加。
+    // frontmatter.author / reviewedBy で記事ごとの上書きも可能。
     const articleJsonLd = {
         "@context": "https://schema.org",
         "@type": "Article",
@@ -161,16 +165,23 @@ export default async function BlogPostPage({ params }: PageProps) {
         url: `${baseUrl}/blog/${slug}`,
         datePublished: article.publishedAt ?? undefined,
         dateModified: article.updatedAt ?? article.publishedAt ?? undefined,
-        author: {
-            "@type": "Organization",
-            name: "Stats47",
-            url: baseUrl,
-        },
-        publisher: {
-            "@type": "Organization",
-            name: "Stats47",
-            url: baseUrl,
-        },
+        author: article.frontmatter.author
+            ? {
+                "@type": "Person",
+                name: article.frontmatter.author,
+                url: `${baseUrl}/about`,
+            }
+            : buildPersonAsAuthor(baseUrl),
+        ...(article.frontmatter.reviewedBy
+            ? {
+                reviewedBy: {
+                    "@type": "Person",
+                    name: article.frontmatter.reviewedBy,
+                    url: `${baseUrl}/about`,
+                },
+            }
+            : {}),
+        publisher: buildPublisherOrganization(baseUrl),
     };
 
     return (

--- a/apps/web/src/lib/structured-data/person.ts
+++ b/apps/web/src/lib/structured-data/person.ts
@@ -1,0 +1,48 @@
+/**
+ * 運営者 Person schema（E-E-A-T、#76 T3-EEAT-02）
+ *
+ * stats47 の運営者 (KAZU) を表現する schema.org/Person。
+ * Article の author と /about の主体として使用する。
+ */
+
+/** 運営者の SNS・外部プロフィール URL */
+export const OPERATOR_SOCIAL_URLS = [
+  "https://note.com/stats47",
+  "https://x.com/stats47jp",
+  "https://www.instagram.com/stats47jp/",
+  "https://www.youtube.com/@stats47jp",
+] as const;
+
+/** Person schema を生成する */
+export function buildOperatorPersonSchema(baseUrl: string) {
+  return {
+    "@context": "https://schema.org",
+    "@type": "Person",
+    name: "KAZU",
+    url: `${baseUrl}/about`,
+    jobTitle: "データ可視化コンサルタント / 元県庁職員（20 年）",
+    description:
+      "20 年間、自治体職員として統計の作る側・使う側の両方に身を置いた経験を活かし、公的統計を現代の UI/UX で再設計する stats47 を運営。",
+    worksFor: {
+      "@type": "Organization",
+      name: "統計で見る都道府県",
+      url: baseUrl,
+    },
+    sameAs: [...OPERATOR_SOCIAL_URLS],
+  };
+}
+
+/** Article の author 用（inline、@context は親に含まれる） */
+export function buildPersonAsAuthor(baseUrl: string) {
+  return {
+    "@type": "Person",
+    name: "KAZU",
+    url: `${baseUrl}/about`,
+    jobTitle: "データ可視化コンサルタント",
+    worksFor: {
+      "@type": "Organization",
+      name: "統計で見る都道府県",
+      url: baseUrl,
+    },
+  };
+}

--- a/apps/web/src/lib/structured-data/scripts.ts
+++ b/apps/web/src/lib/structured-data/scripts.ts
@@ -5,6 +5,40 @@
  * JSON-LD script タグ文字列を返す。
  */
 
+import { OPERATOR_SOCIAL_URLS } from "./person";
+
+/** ロゴ URL（publisher Organization で共通参照） */
+function logoImageObject(baseUrl: string) {
+  return {
+    "@type": "ImageObject",
+    url: `${baseUrl}/logo.png`,
+  };
+}
+
+/** root Organization schema（layout と publisher で共通参照） */
+export function buildOrganizationSchema(baseUrl: string) {
+  return {
+    "@context": "https://schema.org",
+    "@type": "Organization",
+    name: "統計で見る都道府県",
+    alternateName: "Stats47",
+    url: baseUrl,
+    logo: logoImageObject(baseUrl),
+    description: "あなたの県は何位？1,800以上の統計で47都道府県をランキング・比較・分析",
+    sameAs: [...OPERATOR_SOCIAL_URLS],
+  };
+}
+
+/** Article publisher 用（inline、@context は親に含まれる） */
+export function buildPublisherOrganization(baseUrl: string) {
+  return {
+    "@type": "Organization",
+    name: "統計で見る都道府県",
+    url: baseUrl,
+    logo: logoImageObject(baseUrl),
+  };
+}
+
 /**
  * WebSite と Organization の JSON-LD スクリプトタグ文字列を返す
  */
@@ -26,13 +60,7 @@ export function generateWebSiteStructuredDataScripts(baseUrl: string): string {
     },
   };
 
-  const organizationSchema = {
-    "@context": "https://schema.org",
-    "@type": "Organization",
-    name: "統計で見る都道府県",
-    url: baseUrl,
-    description: "あなたの県は何位？1,800以上の統計で47都道府県をランキング・比較・分析",
-  };
+  const organizationSchema = buildOrganizationSchema(baseUrl);
 
   return [
     `<script type="application/ld+json">${JSON.stringify(webSiteSchema)}</script>`,

--- a/packages/types/src/article.ts
+++ b/packages/types/src/article.ts
@@ -18,4 +18,8 @@ export interface ArticleFrontmatter {
   published?: boolean;
   rankingKey?: string;
   affiliate?: AffiliateProduct;
+  /** 執筆者。Article JSON-LD の author Person.name に使われる。未指定時は運営者 (KAZU) */
+  author?: string;
+  /** 校閲者。Article JSON-LD の reviewedBy Person.name に使われる（任意） */
+  reviewedBy?: string;
 }


### PR DESCRIPTION
## Summary (T3-EEAT-02 / #76)

Google の E-E-A-T シグナルを構造化データで直接伝達。#25 で /about ページ本体は
実装済だが HTML テキストだけでは indirect。schema.org で author Person / Organization /
AboutPage を明示してクローラが読めるようにする。

## 変更
- 新設 `lib/structured-data/person.ts` で Person schema ビルダー
- 拡張 `scripts.ts` で Organization に logo + sameAs（SNS URL 4 本）追加
- Article JSON-LD: author を Organization → **Person (KAZU)** に変更
  - frontmatter.author / reviewedBy で記事単位の上書きも可能
- /about に AboutPage + Person + Organization の 3 つの JSON-LD を配置

## 期待効果
- SERP の Rich Results 表示率 UP（authorship, knowledge panel）
- Google Knowledge Graph への organization + person 情報登録
- E-E-A-T スコア底上げ → CTR 副次的改善

## Test plan
- [x] tsc / eslint / vitest (340 tests) pass
- [ ] デプロイ後 [Google Rich Results Test](https://search.google.com/test/rich-results) で /about / /blog/{slug} を検証
- [ ] GSC の「拡張」レポートで Article / AboutPage の表示を 14 日後確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)