### PR TITLE
feat(seo): ランキング title に年度 + 訴求語追加 (#77 Phase 3)

### DIFF
--- a/apps/web/src/features/ranking/utils/generate-meta-data.ts
+++ b/apps/web/src/features/ranking/utils/generate-meta-data.ts
@@ -77,16 +77,18 @@ export function generateRankingPageMetaData({
   const unit = rankingItem.unit || "";
 
   // title 差別化（T1-CANONICAL-01 / #77）
-  // 同一テンプレート title での Google 重複判定を防ぐため、1 位県名と単位付き値を含める。
+  // 同一テンプレート title での Google 重複判定を防ぐため、1 位県名と年度を含める。
+  // 「最新」「徹底比較」等の訴求語で CTR も向上狙い。
   // seoTitle が DB に明示的に設定されていればそちらを優先。
   const summary = buildRankingSummary(rankingValues, unit);
   const fallbackTitle = areaType === "city"
     ? `${itemName} 市区町村ランキング`
     : `${itemName} 都道府県別ランキング`;
+  const yearTag = displayYear ? `【${displayYear}年最新】` : "";
   const differentiatedTitle = summary?.top1Name
     ? areaType === "city"
-      ? `${itemName}ランキング｜1位 ${summary.top1Name} | 市区町村比較`
-      : `${itemName}ランキング｜1位 ${summary.top1Name} | 47都道府県比較`
+      ? `${itemName}ランキング${yearTag}1位 ${summary.top1Name}｜市区町村を徹底比較`
+      : `${itemName}ランキング${yearTag}1位 ${summary.top1Name}｜47都道府県を徹底比較`
     : fallbackTitle;
   const title = rankingItem.seoTitle ?? differentiatedTitle;
 


### PR DESCRIPTION
## Summary

#77 Phase 2 の延長。default title に「【{year}年最新】」と「徹底比較」を追加で CTR 底上げを狙う。

## Before → After
- `総人口ランキング｜1位 東京都 | 47都道府県比較`
- `総人口ランキング【2024年最新】1位 東京都｜47都道府県を徹底比較`

## 対象
1,979 ランキング詳細ページの default title。`seoTitle` 明示済み 8 件は維持。

## Test plan
- [x] tsc / vitest (340 tests) pass
- [ ] デプロイ後 `curl /ranking/total-population` で新 title 確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)