### PR TITLE
perf+seo: /themes LCP + area category title + Dataset schema 統合

### DIFF
--- a/apps/web/src/app/areas/[areaCode]/[categoryKey]/page.tsx
+++ b/apps/web/src/app/areas/[areaCode]/[categoryKey]/page.tsx
@@ -64,8 +64,11 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
         return { title: "ページが見つかりません" };
     }
 
-    const title = `${profile.areaName}の${category.categoryName}データ`;
-    const description = `${profile.areaName}の${category.categoryName}に関する統計データ。全国ランキングで比較。`;
+    // title / description 差別化（#77 Phase 5）
+    // 47 × N カテゴリで同一テンプレートだった title に「県名」「カテゴリ」「全国ランキング」を
+    // 組み合わせて多少でも重複を減らす。
+    const title = `${profile.areaName}の${category.categoryName}データ｜47都道府県ランキング比較`;
+    const description = `${profile.areaName}の${category.categoryName}分野の統計データ一覧。全国 47 都道府県で${profile.areaName}は何位か、グラフと地図で比較できます。`;
     const indexable = INDEXABLE_CATEGORIES.has(categoryKey);
 
     const baseUrl = process.env.NEXT_PUBLIC_BASE_URL || "https://stats47.jp";

--- a/apps/web/src/features/ranking/utils/generate-structured-data.ts
+++ b/apps/web/src/features/ranking/utils/generate-structured-data.ts
@@ -8,6 +8,8 @@
 import { getRankingTitle, type RankingItem, type RankingValue } from "@stats47/ranking";
 
 import { getRequiredBaseUrl } from "@/lib/env";
+import { buildPersonAsAuthor } from "@/lib/structured-data/person";
+import { buildPublisherOrganization } from "@/lib/structured-data/scripts";
 
 import { buildRankingSummary } from "./build-ranking-summary";
 
@@ -151,16 +153,10 @@ export function generateRankingPageStructuredData({
       itemName,
       selectedYear || "",
     ].filter(Boolean),
-    creator: {
-      "@type": "Organization",
-      name: "統計で見る都道府県",
-      url: baseUrl,
-    },
-    publisher: {
-      "@type": "Organization",
-      name: "統計で見る都道府県",
-      url: baseUrl,
-    },
+    // creator は統計を整理・公開した運営者 (Person)
+    creator: buildPersonAsAuthor(baseUrl),
+    // publisher は組織主体 (logo + sameAs 付き)
+    publisher: buildPublisherOrganization(baseUrl),
     license: {
       "@type": "CreativeWork",
       "@id": "https://www.stat.go.jp/info/riyou.html",

--- a/apps/web/src/features/theme-dashboard/components/ThemeDashboardTabbed.tsx
+++ b/apps/web/src/features/theme-dashboard/components/ThemeDashboardTabbed.tsx
@@ -37,10 +37,10 @@ import type { RankingValue } from "@stats47/ranking";
 export function ThemeDashboardTabbed({
   themeConfig,
   indicatorDataMap,
-  topology,
   pageCharts,
   kpiDataByArea,
 }: ThemeDashboardClientProps) {
+  // topology は ThemeLeafletMap 内で client-side 取得するように変更済（#74 同パターン）
   const tabIndicators = themeConfig.tabIndicators;
   const isBelowLg = useBreakpoint("belowLg");
 
@@ -153,7 +153,6 @@ export function ThemeDashboardTabbed({
     <ThemeLeafletMap
       rankingItem={currentRankingItem}
       rankingValues={currentValues}
-      topology={topology}
       selectedPrefectureCode={selectedPrefectureCode}
       onPrefectureClick={setSelectedPrefectureCode}
       yearCode={currentYear}

--- a/apps/web/src/features/theme-dashboard/components/ThemeLeafletMap.tsx
+++ b/apps/web/src/features/theme-dashboard/components/ThemeLeafletMap.tsx
@@ -15,7 +15,10 @@ const TileSwitcher = dynamic(
   { ssr: false }
 );
 
+import { fetchPrefectureTopologyAction } from "@/features/ranking/actions/fetch-prefecture-topology";
+
 import { useTheme } from "@/hooks/useTheme";
+
 
 import { fetchMunicipalityDrilldownAction } from "../actions";
 
@@ -35,7 +38,6 @@ const LeafletChoroplethMap = dynamic(
 interface ThemeLeafletMapProps {
   rankingItem: RankingItem;
   rankingValues: RankingValue[];
-  topology: TopoJSONTopology | null;
   selectedPrefectureCode: string | null;
   onPrefectureClick: (code: string | null) => void;
   /** ドリルダウン時に使用する年度コード（省略時: rankingItem.latestYear.yearCode） */
@@ -47,11 +49,14 @@ interface ThemeLeafletMapProps {
  *
  * - light/dark テーマ対応
  * - 都道府県クリック → 市区町村ドリルダウン
+ *
+ * TopoJSON はクライアント側で fetchPrefectureTopologyAction で取得する
+ * （Server Component で fetch して prop として渡すと 1.2MB HTML が発生、
+ *  T1-PSI-LCP-01 / #74 と同じパターン）
  */
 export function ThemeLeafletMap({
   rankingItem,
   rankingValues,
-  topology,
   selectedPrefectureCode,
   onPrefectureClick,
   yearCode,
@@ -62,6 +67,16 @@ export function ThemeLeafletMap({
   const [currentTile, setCurrentTile] = useState(tileOptions[0]);
   // eslint-disable-next-line react-hooks/set-state-in-effect -- sync tile on theme change
   useEffect(() => { setCurrentTile(tileOptions[0]); }, [isDark, tileOptions]);
+
+  // Client fetch topology (LCP 改善)
+  const [topology, setTopology] = useState<TopoJSONTopology | null>(null);
+  useEffect(() => {
+    let cancelled = false;
+    fetchPrefectureTopologyAction()
+      .then((result) => { if (!cancelled) setTopology(result); })
+      .catch(() => { if (!cancelled) setTopology(null); });
+    return () => { cancelled = true; };
+  }, []);
 
   // RankingItem → MapVisualizationConfig 変換
   const colorConfig: MapVisualizationConfig = useMemo(() => {

--- a/apps/web/src/features/theme-dashboard/components/ThemePageLayout.tsx
+++ b/apps/web/src/features/theme-dashboard/components/ThemePageLayout.tsx
@@ -70,7 +70,6 @@ export async function ThemePageLayout({ theme, data }: Props) {
       <ThemeDashboardClient
         themeConfig={theme}
         indicatorDataMap={data.indicatorDataMap}
-        topology={data.topology}
         pageCharts={pageCharts}
         kpiDataByArea={kpiDataByArea}
       />

--- a/apps/web/src/features/theme-dashboard/lib/load-consumer-prices-data.ts
+++ b/apps/web/src/features/theme-dashboard/lib/load-consumer-prices-data.ts
@@ -1,7 +1,6 @@
 import "server-only";
 
 import { fetchFormattedStats, type GetStatsDataParams } from "@stats47/estat-api/server";
-import { fetchPrefectureTopology } from "@stats47/gis/geoshape";
 
 
 import { logger } from "@/lib/logger";
@@ -44,16 +43,11 @@ export async function loadConsumerPricesData(
       cdTime: "2024000000",
     };
 
-    const [rawData, topology] = await Promise.all([
-      fetchFormattedStats(params).catch((error) => {
-        logger.error({ error }, "CPI テーマ: e-Stat データ取得失敗");
-        return [] as StatsSchema[];
-      }),
-      fetchPrefectureTopology().catch((error) => {
-        logger.error({ error }, "CPI テーマ: topology取得失敗");
-        return null;
-      }),
-    ]);
+    // topology はクライアント側で取得（#74 同パターン）
+    const rawData = await fetchFormattedStats(params).catch((error) => {
+      logger.error({ error }, "CPI テーマ: e-Stat データ取得失敗");
+      return [] as StatsSchema[];
+    });
 
     if (rawData.length === 0) return null;
 
@@ -118,7 +112,7 @@ export async function loadConsumerPricesData(
 
     if (Object.keys(indicatorDataMap).length === 0) return null;
 
-    return { indicatorDataMap, topology };
+    return { indicatorDataMap };
   } catch (error) {
     logger.error({ error }, "CPI テーマ: データ構築失敗");
     return null;

--- a/apps/web/src/features/theme-dashboard/lib/load-theme-data.ts
+++ b/apps/web/src/features/theme-dashboard/lib/load-theme-data.ts
@@ -4,14 +4,13 @@ import {
   fetchFormattedStats,
   type GetStatsDataParams,
 } from "@stats47/estat-api/server";
-import { fetchPrefectureTopology } from "@stats47/gis/geoshape";
 import {
   findRankingItem,
   fetchRankingValuesFromSource,
   filterOutNationalArea,
   rankByValue,
 } from "@stats47/ranking/server";
-import { isOk, type TopoJSONTopology } from "@stats47/types";
+import { isOk } from "@stats47/types";
 
 
 import { getEstatCacheStorage } from "@/features/stat-charts/server";
@@ -23,7 +22,7 @@ import type { RankingItem, RankingValue } from "@stats47/ranking";
 
 export interface ThemePageData {
   indicatorDataMap: Record<string, ThemeIndicatorData>;
-  topology: TopoJSONTopology | null;
+  // topology はクライアント側で取得（LCP 改善、#74 同パターン）
 }
 
 /**
@@ -93,12 +92,7 @@ export async function loadThemeData(
 
   if (validItems.length === 0) return null;
 
-  // 2. 全指標のデータ + TopoJSON を並列取得
-  const topologyPromise = fetchPrefectureTopology().catch((error) => {
-    logger.error({ error }, "テーマダッシュボード: topology取得失敗");
-    return null;
-  });
-
+  // 2. 全指標のデータを並列取得（topology はクライアント側で fetch、#74 同パターン）
   const valuesPromises = validItems.map(({ key, item }) => {
     const yearCode = item.latestYear?.yearCode;
     if (!yearCode)
@@ -111,10 +105,7 @@ export async function loadThemeData(
       });
   });
 
-  const [topology, ...valuesResults] = await Promise.all([
-    topologyPromise,
-    ...valuesPromises,
-  ]);
+  const valuesResults = await Promise.all(valuesPromises);
 
   // 3. indicatorDataMap を構築（availableYears を含む）
   const indicatorDataMap: Record<string, ThemeIndicatorData> = {};
@@ -132,5 +123,5 @@ export async function loadThemeData(
 
   if (Object.keys(indicatorDataMap).length === 0) return null;
 
-  return { indicatorDataMap, topology };
+  return { indicatorDataMap };
 }

--- a/apps/web/src/features/theme-dashboard/types.ts
+++ b/apps/web/src/features/theme-dashboard/types.ts
@@ -1,7 +1,6 @@
 import type { RankingItem, RankingValue } from "@stats47/ranking";
 import type {
   IndicatorPanelTab,
-  TopoJSONTopology,
 } from "@stats47/types";
 
 // ============================================================================
@@ -56,9 +55,10 @@ export interface ThemeDashboardClientProps {
   themeConfig: ThemeConfig;
   /** 全指標のプリロード済みデータ（rankingKey → data） */
   indicatorDataMap: Record<string, ThemeIndicatorData>;
-  /** TopoJSON */
-  topology: TopoJSONTopology | null;
-  /** DB 管理チャート（page_components + page_component_assignments） */
+  /**
+   * DB 管理チャート（page_components + page_component_assignments）
+   * TopoJSON は ThemeLeafletMap 内で client-side 取得するため prop から除外（#74 パターン）
+   */
   pageCharts?: import("@/features/stat-charts/services/load-page-components").PageComponent[];
   /** KPI カードの全都道府県データ（chartKey → areaCode → KpiCardClientProps） */
   kpiDataByArea?: Record<string, Record<string, import("@/features/stat-charts/components/cards/KpiCard/KpiCardClient").KpiCardClientProps>>;


### PR DESCRIPTION
## Summary

3 施策を 1 PR で:

1. **/themes LCP 改善** — /ranking と同じ TopoJSON HTML 埋込問題（1.2MB）を client fetch 化で解消
2. **/areas/[code]/[categoryKey] title 差別化** (#77 Phase 5) — 47×N カテゴリの重複 title に「47都道府県ランキング比較」追加
3. **Dataset schema 統合** (#76 延長) — creator/publisher を新 Person/Org ヘルパー経由に統一

## Test plan
- [x] tsc / eslint / vitest (340 tests) pass
- [ ] デプロイ後 `curl /themes/population-dynamics | wc -c` 200KB 以下を確認
- [ ] 次回 PSI で /themes LCP の改善確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)