### PR TITLE
docs: 自動化インベントリを新設（3 基盤 16 タスク一覧）

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,6 +46,7 @@ packages/
 | 国土数値情報 GIS データ（データセット一覧・パイプライン・ライセンス） | `docs/01_技術設計/08_国土数値情報GISデータ.md` |
 | 国土交通データプラットフォーム（MCP・カタログ一覧・ツール） | `docs/01_技術設計/09_国土交通データプラットフォーム.md` |
 | CI/CD・デプロイ | `.github/workflows/README.md` |
+| 自動化インベントリ（GitHub Actions / launchd / Claude Routine の全一覧） | `docs/01_技術設計/10_自動化インベントリ.md` ★新規追加・削除時は必ず更新 |
 | Pre-commit フック | `.husky/README.md` |
 | エラーハンドリング規約 | `docs/01_技術設計/05_エラーハンドリング規約.md` |
 | テスト構成・追加指針 | `apps/web/tests/README.md` |

--- a/docs/01_技術設計/10_自動化インベントリ.md
+++ b/docs/01_技術設計/10_自動化インベントリ.md
@@ -1,0 +1,172 @@
+# 自動化インベントリ
+
+stats47 の全自動化タスクの静的な真実源。**新規追加・削除時は PR でこのファイルを更新**すること。
+
+## いつ読むか
+- どの計測・処理が今動いているか確認したいとき
+- 新しい cron を追加する前に既存との重複チェック
+- 壊れた自動化を特定するとき（docs を見て `launchctl list` / `gh workflow list` / `RemoteTrigger list` と照合）
+
+## 運用ルール
+
+- **追加時**: PR で本 docs に 1 行追加 + 変更理由を Issue で記録
+- **壊れた時**: Issue 起票（label: `automation-broken`）、直ったら close、docs 変更不要（状態は Issue 側）
+- **削除時**: PR で docs 行削除 + 関連 Issue に "deprecated" コメント
+- **月 1 健康診断**: 月初に 3 基盤と docs が一致しているか確認
+
+## 全実行基盤の概観
+
+| 基盤 | 用途 | 前提 | 停止方法 |
+|---|---|---|---|
+| GitHub Actions | 公開 / 冪等な処理（PSI / GSC / GA4 / AdSense / Security） | PC 非依存 | workflow 削除 or disable |
+| launchd (ローカル Mac) | ブラウザセッション / ローカル資源必須 (D1 / Chrome profile) | Mac 起動必要 | `launchctl unload` |
+| Claude Routine (Anthropic remote) | AI エージェント実行（/weekly-review など）、人間判断を自動化 | ANTHROPIC API billing、`.claude/state/triggers.json` | `RemoteTrigger` で `enabled: false` |
+
+---
+
+## GitHub Actions（8 workflows）
+
+### 計測・レポート系（2026-04-24 導入）
+
+| workflow | cron (UTC) | 日本時間 | 目的 | 出力先 | 関連 |
+|---|---|---|---|---|---|
+| `.github/workflows/psi-audit-daily.yml` | `0 17 * * *` | 毎日 02:00 JST | PSI 19 URL × mobile+desktop 計測、閾値違反で `[PSI Alert]` Issue 起票 | `.claude/state/metrics/psi/` → develop に `[skip ci]` commit | #74 |
+| `.github/workflows/fetch-metrics-weekly.yml` | `0 11 * * 0` | 日曜 20:00 JST | GSC/GA4/AdSense 週次 snapshot | `.claude/skills/analytics/{gsc,ga4,adsense}-improvement/reference/snapshots/YYYY-Www/` + `.claude/state/metrics/` → develop commit | #67 |
+| `.github/workflows/weekly-metrics-issue.yml` | `0 0 * * 1` | 月曜 09:00 JST | `[Weekly Metrics] YYYY-Www` Issue 起票 | GitHub Issue | #67 |
+| `.github/workflows/youtube-audit-daily.yml` | `0 0 * * *` | 毎日 09:00 JST | YouTube シャドウバン診断、リスク検知で `[YouTube Alert]` Issue 起票 | `.claude/state/metrics/youtube/` + Issue | #91 playbook |
+
+### CI/CD・品質保証系（既存）
+
+| workflow | trigger | 目的 |
+|---|---|---|
+| `deploy-workers.yml` | push to main | Cloudflare Pages/Workers デプロイ |
+| `post-deploy-smoke.yml` | deploy 後 | Playwright smoke テスト（商用利用確認） |
+| `pr-quality-check.yml` | PR to main | lint / type-check / test / coverage |
+| `security-scan.yml` | push to main + 毎週日曜 UTC 00:00 | npm audit + CodeQL |
+
+---
+
+## launchd（4 agents、Mac 起動時のみ動作）
+
+| plist | schedule | 目的 | 呼び出す skill / script | 関連 |
+|---|---|---|---|---|
+| `com.stats47.backup-d1` | 毎日 03:47 | Remote D1 → R2 への日次バックアップ | `npm run backup:d1 --env production` | - |
+| `com.stats47.discover-trends` | 毎日 07:23 | トレンド発見バッチ | `npx claude-code -p /discover-trends-all` | - |
+| `com.stats47.weekly-review` | 月曜 08:07 | 週次レビュー生成（※ Claude Routine と重複、Phase 4 撤退予定） | `npx claude-code -p /weekly-review` | #67 Phase 4 |
+| `com.stats47.fetch-note-metrics` | 月曜 09:15 | note.com dashboard から全記事の view/comment/like 取得（Chrome Profile 1 必須） | `.claude/scripts/note/fetch-note-metrics.sh` | #89 |
+
+### plist の保管場所
+- 設定実体: `~/Library/LaunchAgents/com.stats47.*.plist`（gitignore 外、手元のみ）
+- wrapper script: `scripts/scheduled/*.sh`（git 管理）
+- ログ: `~/Library/Logs/stats47/<name>.log` + `.launchd.out` / `.launchd.err`
+
+### launchd の追加・削除
+
+```bash
+# load
+launchctl load ~/Library/LaunchAgents/com.stats47.<name>.plist
+
+# unload
+launchctl unload ~/Library/LaunchAgents/com.stats47.<name>.plist
+
+# 今すぐ実行（テスト）
+launchctl kickstart -k gui/$(id -u)/com.stats47.<name>
+
+# 一覧
+launchctl list | grep stats47
+```
+
+---
+
+## Claude Routine（Anthropic remote schedule）
+
+リモートで Anthropic サーバが cron fire → stats47 repo に対して claude-code 起動 → PR 作成。**PC 停止中でも動く**のが launchd との最大の違い。
+
+状態保存: `.claude/state/triggers.json`
+
+| id | name | cron (JST) | 用途 | 関連 |
+|---|---|---|---|---|
+| `trig_01QBPsFMqaxHdfaSqsjuzCDW` | stats47 weekly PDCA | 月曜 09:03 (3 0 * * 1 UTC) | `/weekly-review` → `/weekly-plan` → develop に PR | #49 (W18 plan) |
+| (予定) | stats47 YouTube weekly review | 月曜 09:15 | 直近 7 日の YouTube history → #91 に `## Weekly Review YYYY-Www` コメント追加 | #91 |
+| (one-off 発火時のみ) | YouTube Pause Expiry Reminder | pause 期限前日 09:00 | `[YouTube Pause Expiry Reminder]` 翌日解除予告 | #91 |
+| (one-off 発火時のみ) | YouTube Recovery Judgment | 復帰テスト 48h 後 09:00 | views を取得して pause 解除判定 | #91 |
+
+### Routine 管理コマンド
+
+```
+# 一覧
+RemoteTrigger list
+
+# 停止（無効化）
+RemoteTrigger update trigger_id={id} enabled=false
+
+# 削除
+RemoteTrigger delete trigger_id={id}
+```
+
+### 重複注意: weekly-review
+- launchd: 月曜 08:07（`/weekly-review` のみ）
+- Claude Routine: 月曜 09:03（`/weekly-review` + `/weekly-plan`）
+- 両方走ると review が 2 重起動 → **Phase 4 で launchd 版を停止予定**（CI 安定確認後）
+
+---
+
+## 基盤選定フロー（新規追加時の判断基準）
+
+```
+新しい自動化を追加したい
+  │
+  ├─ ブラウザ自動化 / ローカル資源必須？ (D1 / Chrome login / R2)
+  │    YES → launchd
+  │    NO ↓
+  │
+  ├─ AI エージェント（claude-code）に判断させたい？
+  │    YES → Claude Routine（PC 停止中でも動く）
+  │    NO ↓
+  │
+  └─ それ以外 → GitHub Actions（最も信頼性高い、PC 非依存）
+```
+
+### 具体例
+- **PSI 日次計測**: 外部 API 叩くだけ → **GitHub Actions** ✓
+- **GSC/GA4 fetch**: SA 鍵で API 叩く → **GitHub Actions** ✓（鍵を Secret に入れる前提）
+- **note.com dashboard 取得**: Chrome profile の persistent cookie 必須 → **launchd** ✓
+- **/weekly-review 実行**: AI が文章生成 + 判断 → **Claude Routine** ✓（PC 停止中でも動く、PR 作成まで完結）
+- **D1 バックアップ**: 認証鍵が手元のみ → **launchd** ✓
+
+---
+
+## 月次ヘルスチェック
+
+毎月初に 3 基盤と docs が一致しているか確認:
+
+```bash
+# 1 コマンドで全確認
+echo "=== GitHub Actions ===" && gh workflow list --repo uruhayato373/stats47 | grep -v disabled
+echo ""
+echo "=== launchd ===" && launchctl list | grep stats47
+echo ""
+echo "=== Claude Routine ===" && cat .claude/state/triggers.json | python3 -m json.tool
+echo ""
+echo "=== docs ==="
+grep -cE "^\| \`com.stats47\.|^\| \`\.github/workflows/|^\| \`trig_" docs/01_技術設計/10_自動化インベントリ.md
+```
+
+乖離があれば docs を PR で更新。破損があれば Issue 起票（label: `automation-broken`）。
+
+---
+
+## 関連ファイル
+
+- `scripts/scheduled/_common.sh` — launchd wrapper 共通 env/logger
+- `.claude/state/triggers.json` — Claude Routine 状態
+- `.claude/state/metrics/` — 各計測の snapshot 置き場
+- `~/Library/LaunchAgents/com.stats47.*.plist` — launchd 実体（手元のみ）
+- `~/Library/Logs/stats47/*.log` — 実行ログ（手元のみ）
+
+## 関連 Issue
+
+- #67: GitHub Actions 計測基盤 (Phase 1-3)
+- #74: PSI LCP 改善
+- #89: note.com メトリクス
+- #91: YouTube 運用 Playbook（Meta-Issue、恒久 open）


### PR DESCRIPTION
GitHub Actions (8) + launchd (4) + Claude Routine (4 planned) の全自動化タスクを 1 ページで俯瞰できる真実源。

新規追加・削除時は PR で更新、壊れた時は Issue で状態管理するハイブリッド方式。

## 関連
- #67 計測基盤 (GH Actions)
- #89 note metrics (launchd)
- #91 YouTube Playbook (Claude Routine)

🤖 Generated with [Claude Code](https://claude.com/claude-code)