### PR TITLE
fix(ci): PSI Alert Issue 重複起票を防ぐ dedup 処理

### DIFF
--- a/.github/workflows/psi-audit-daily.yml
+++ b/.github/workflows/psi-audit-daily.yml
@@ -101,7 +101,14 @@ jobs:
           DATE=$(date -u +%Y-%m-%d)
           TITLE="[PSI Alert] しきい値割れ検知 ${DATE}"
           BODY_FILE=/tmp/psi-report/report.md
-          gh issue create \
-            --title "$TITLE" \
-            --label "psi-snapshot,auto-generated" \
-            --body-file "$BODY_FILE"
+
+          EXISTING=$(gh issue list --state open --label psi-snapshot --search "\"$TITLE\" in:title" --json number --jq '.[0].number // empty')
+          if [ -n "$EXISTING" ]; then
+            echo "Existing open issue #$EXISTING — appending comment instead of creating duplicate"
+            gh issue comment "$EXISTING" --body-file "$BODY_FILE"
+          else
+            gh issue create \
+              --title "$TITLE" \
+              --label "psi-snapshot,auto-generated" \
+              --body-file "$BODY_FILE"
+          fi


### PR DESCRIPTION
## Summary
- 同一日に PSI workflow が複数回 dispatch されても、2 回目以降は既存 open Issue にコメント追加する形に変更
- 新規 Issue 起票は 1 日あたり最初の違反時のみ

## 背景
2026-04-24 に PR #75 (TopoJSON client fetch) の LCP regression 検証で dispatch を 3 回実施した結果、同一タイトルの `[PSI Alert]` Issue が重複起票された (#73 / #85 / #96)。日次 cron では本来 1 日 1 回だが、手動 dispatch や cron 重複時に備えて dedup を入れる。

## Test plan
- [x] ローカルで yaml の構文確認
- [ ] merge 後、`gh workflow run psi-audit-daily.yml` で 2 回連続 dispatch → 1 Issue + 1 追加 comment になるか確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)