### PR TITLE
feat(psi): LCP 要素と CLS 主要レイアウトシフトを計測データに取り込む

### DIFF
--- a/.claude/scripts/psi/fetch-psi-audit.mjs
+++ b/.claude/scripts/psi/fetch-psi-audit.mjs
@@ -57,6 +57,50 @@ async function fetchPsi(url, strategy) {
   return res.json();
 }
 
+function extractLcpElement(audits) {
+  // 2026-04 時点の Lighthouse v13 では lcp-breakdown-insight の details.items
+  // が [subpart-table, node-info, ...] の配列になる（item に type:"node" が含まれる）。
+  const audit = audits["lcp-breakdown-insight"] || audits["largest-contentful-paint-element"];
+  if (!audit) return null;
+  const items = audit.details?.items || [];
+  const nodeItem = items.find((it) => it?.type === "node" || it?.nodeLabel || it?.selector);
+  if (!nodeItem) return null;
+  const breakdown = {};
+  const tableItem = items.find((it) => it?.type === "table" && Array.isArray(it?.items));
+  if (tableItem) {
+    for (const row of tableItem.items) {
+      if (row?.subpart && row?.duration != null) {
+        breakdown[row.subpart] = Math.round(row.duration);
+      }
+    }
+  }
+  return {
+    selector: nodeItem.selector || null,
+    node_label: nodeItem.nodeLabel || null,
+    snippet:
+      typeof nodeItem.snippet === "string" ? nodeItem.snippet.slice(0, 300) : null,
+    breakdown_ms: Object.keys(breakdown).length > 0 ? breakdown : null,
+  };
+}
+
+function extractLayoutShiftContributors(audits) {
+  const audit = audits["layout-shifts"] || audits["layout-shift-elements"];
+  if (!audit) return [];
+  const items = audit.details?.items || [];
+  return items.slice(0, 5).map((item) => {
+    const node = item?.node || {};
+    const causes = (item?.subItems?.items || [])
+      .map((s) => s?.cause)
+      .filter(Boolean);
+    return {
+      selector: node.selector || null,
+      node_label: node.nodeLabel || null,
+      score: item?.score ?? null,
+      causes: causes.length > 0 ? [...new Set(causes)] : [],
+    };
+  });
+}
+
 function extractSummary(data, url, strategy) {
   const lighthouse = data.lighthouseResult || {};
   const categories = lighthouse.categories || {};
@@ -99,6 +143,8 @@ function extractSummary(data, url, strategy) {
       FCP: field("FIRST_CONTENTFUL_PAINT_MS"),
       TTFB: field("EXPERIMENTAL_TIME_TO_FIRST_BYTE"),
     },
+    lcp_element: extractLcpElement(audits),
+    cls_contributors: extractLayoutShiftContributors(audits),
     analysis_utc: lighthouse.fetchTime || null,
     final_url: lighthouse.finalUrl || url,
   };

--- a/.claude/scripts/psi/psi-threshold-check.mjs
+++ b/.claude/scripts/psi/psi-threshold-check.mjs
@@ -231,6 +231,62 @@ function formatMarkdown(results, violations) {
       }
       lines.push("");
     }
+
+    const lcpViolated = new Set(
+      violations
+        .filter((v) => v.metric_key === "lcp_ms")
+        .map((v) => `${v.url}::${v.strategy}`)
+    );
+    const clsViolated = new Set(
+      violations
+        .filter((v) => v.metric_key === "cls")
+        .map((v) => `${v.url}::${v.strategy}`)
+    );
+
+    const lcpRows = results.filter(
+      (r) => !r.error && lcpViolated.has(`${r.url}::${r.strategy}`) && r.lcp_element
+    );
+    if (lcpRows.length > 0) {
+      lines.push("## LCP 要素（違反ページのみ）");
+      lines.push("");
+      lines.push("| URL | Strategy | LCP element | selector |");
+      lines.push("|---|---|---|---|");
+      for (const r of lcpRows) {
+        const path = r.url.replace(/^https?:\/\/[^/]+/, "") || "/";
+        const label = r.lcp_element.node_label || "-";
+        const selector = r.lcp_element.selector || "-";
+        lines.push(
+          `| ${path} | ${r.strategy} | ${label.slice(0, 60)} | \`${selector.slice(0, 80)}\` |`
+        );
+      }
+      lines.push("");
+    }
+
+    const clsRows = results.filter(
+      (r) =>
+        !r.error &&
+        clsViolated.has(`${r.url}::${r.strategy}`) &&
+        Array.isArray(r.cls_contributors) &&
+        r.cls_contributors.length > 0
+    );
+    if (clsRows.length > 0) {
+      lines.push("## CLS 主要レイアウトシフト（違反ページのみ）");
+      lines.push("");
+      for (const r of clsRows) {
+        const path = r.url.replace(/^https?:\/\/[^/]+/, "") || "/";
+        lines.push(`### ${path} (${r.strategy})`);
+        lines.push("");
+        lines.push("| # | score | element | selector |");
+        lines.push("|---|---|---|---|");
+        r.cls_contributors.forEach((c, i) => {
+          const label = (c.node_label || "-").slice(0, 60);
+          const selector = (c.selector || "-").slice(0, 80);
+          const score = c.score != null ? c.score.toFixed(4) : "-";
+          lines.push(`| ${i + 1} | ${score} | ${label} | \`${selector}\` |`);
+        });
+        lines.push("");
+      }
+    }
   } else {
     lines.push("## しきい値違反");
     lines.push("");


### PR DESCRIPTION
## Summary
- PSI fetch スクリプトに LCP 要素と CLS shift 主要要素の抽出を追加
- 違反があるページのみ Issue body に「LCP 要素」「CLS 主要レイアウトシフト」セクションを追加

## 背景
EXP-002 (PR #75) の ADVERSE 結末で得た教訓「LCP 要素の特定が先」の実装。
ローカル計測で `/ranking/total-population` mobile の LCP 要素が `img.leaflet-tile` と確定し、`resourceLoadDelay = 4,347ms` が支配的とわかった。今後の LCP 施策はデータで方向性を決められる。

## 変更ファイル
- `.claude/scripts/psi/fetch-psi-audit.mjs` — `extractLcpElement` / `extractLayoutShiftContributors` を追加
- `.claude/scripts/psi/psi-threshold-check.mjs` — lcp_ms / cls 違反ページに対してのみ詳細セクションを出力

## Test plan
- [x] ローカルで 1 URL 計測 → `lcp_element.selector` / `breakdown_ms` が入ることを確認
- [x] threshold-check で新セクションが markdown として出ることを確認
- [ ] merge 後の日次 PSI で `[PSI Alert]` Issue に LCP 要素表が入ることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)