### PR TITLE
feat(lcp): ランキング詳細で初期 map tile の preload tag を SSR で emit (#101 Phase A / EXP-003)

### DIFF
--- a/apps/web/src/app/ranking/[rankingKey]/page.tsx
+++ b/apps/web/src/app/ranking/[rankingKey]/page.tsx
@@ -45,6 +45,7 @@ import {
 import { fetchPrefectureTopology } from "@stats47/gis/geoshape";
 import { listActiveRankingKeys, listRankingValues, findSurveyById, listSurveys, findRankingItemsByGroupKey, type GroupRankingItem } from "@stats47/ranking/server";
 import { isOk } from "@stats47/types";
+import { getInitialMapTileUrls } from "@stats47/visualization/leaflet/constants";
 
 import {
   generateRankingBreadcrumbStructuredData,
@@ -225,6 +226,12 @@ export default async function RankingKeyPage({
   //     この Server Component 内でレンダリングし ReactNode として注入する。
   //   - RankingKeyPageClient 内の Client Component（RankingHighlights 等）は
   //     Client Component 同士なので直接 import して使用している。
+  // LCP 対策（#101 EXP-003）:
+  // ランキング詳細ページの LCP 要素は Leaflet map の中心 tile。
+  // Leaflet JS 実行後に tile URL が判明すると resourceLoadDelay が 4.3s と支配的なため、
+  // 初期ビュー (日本中心・zoom 5) の 4 タイルを SSR で preload して LCP を短縮する。
+  const initialTileUrls = getInitialMapTileUrls({ theme: "light_all", retina: true });
+
   return (
     <>
       {/* 構造化データ */}
@@ -236,6 +243,15 @@ export default async function RankingKeyPage({
         type="application/ld+json"
         dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumbStructuredData) }}
       />
+      {initialTileUrls.map((url, idx) => (
+        <link
+          key={url}
+          rel="preload"
+          as="image"
+          href={url}
+          fetchPriority={idx === 0 ? "high" : "auto"}
+        />
+      ))}
 
       {/* パンくずナビゲーション */}
       <div className="container mx-auto px-4 pt-4">

--- a/packages/visualization/src/leaflet/constants/tile-providers.ts
+++ b/packages/visualization/src/leaflet/constants/tile-providers.ts
@@ -64,3 +64,37 @@ export const JAPAN_CENTER: [number, number] = [36.5, 137.5];
 export const JAPAN_ZOOM = 5;
 export const JAPAN_MIN_ZOOM = 4;
 export const JAPAN_MAX_ZOOM = 14;
+
+/**
+ * 緯度経度から Slippy Map タイル座標に変換（OSM / CartoCDN / 地理院共通）
+ */
+function latLngToTile(lat: number, lng: number, zoom: number): { x: number; y: number } {
+  const n = 2 ** zoom;
+  const x = Math.floor(((lng + 180) / 360) * n);
+  const latRad = (lat * Math.PI) / 180;
+  const y = Math.floor(((1 - Math.log(Math.tan(latRad) + 1 / Math.cos(latRad)) / Math.PI) / 2) * n);
+  return { x, y };
+}
+
+/**
+ * LCP 対策: 初期ビュー（日本中心・zoom 5）で描画される tile URL を算出する。
+ * Server Component から <link rel="preload"> を emit して Leaflet JS 実行前に fetch を開始する。
+ *
+ * 2×2 = 4 タイル（中心タイル + 右・下・右下）を preload 対象とする。
+ * mobile viewport (375×500 @2x) で実際にレンダリングされる最小構成。
+ */
+export function getInitialMapTileUrls(options: {
+  theme: "light_all" | "dark_all";
+  retina?: boolean;
+}): string[] {
+  const { theme, retina = true } = options;
+  const { x: cx, y: cy } = latLngToTile(JAPAN_CENTER[0], JAPAN_CENTER[1], JAPAN_ZOOM);
+  const suffix = retina ? "@2x.png" : ".png";
+  const urls: string[] = [];
+  for (const dx of [0, 1]) {
+    for (const dy of [0, 1]) {
+      urls.push(`/tiles/${theme}/${JAPAN_ZOOM}/${cx + dx}/${cy + dy}${suffix}`);
+    }
+  }
+  return urls;
+}


### PR DESCRIPTION
## Summary
- ランキング詳細ページの `<head>` に初期 4 タイルの `<link rel="preload" as="image">` を emit
- 中心タイルのみ `fetchpriority="high"` を付与（PSI で LCP と確定している `/tiles/light_all/5/28/12@2x.png`）
- `@stats47/visualization/leaflet/constants` に `getInitialMapTileUrls` ヘルパー新設

## 背景・データ
- #74 EXP-002 (ADVERSE) の副産物として PSI から LCP element + breakdown を確定
- /ranking/total-population mobile LCP = 12.5s、**LCP 要素 = `img.leaflet-tile`**
- breakdown: **resourceLoadDelay 4,347ms が支配的 (62%)** — tile URL 発見の遅延が本質
- #101 EXP-003 の案 A を実装

## 実装方針
- Server Component で `<link rel="preload">` を emit → Next.js が `<head>` に hoist
- Leaflet JS 実行前に HTML パース時点で tile fetch を並行開始
- 帯域コスト: 4 タイル × ~15KB = ~60KB（light theme のみ）

## スコープ
- ランキング詳細 (/ranking/[key]) のみ
- 効果が出れば /themes/[key] /areas/[code] にも拡張

## Test plan
- [x] tsc pass
- [x] helper 出力 `/tiles/light_all/5/28/12@2x.png` 他 4 URL が PSI 観測の LCP タイルと一致
- [ ] merge → deploy → 翌日の日次 PSI で LCP が改善するか確認

## ADVERSE 予防
- SSR tree への `<link>` 追加のみ、client code に触れず
- preload が無駄になるケースも帯域 ~60KB のみ、挙動変化なし
- #74 ADVERSE の轍を踏まないため効果測定は PSI 実測で判断する

🤖 Generated with [Claude Code](https://claude.com/claude-code)