### PR TITLE
fix(measurement): GA4 consent default を granted に変更（計測断絶 −78.8% 修復）

### DIFF
--- a/apps/web/src/lib/analytics/GoogleAnalytics.tsx
+++ b/apps/web/src/lib/analytics/GoogleAnalytics.tsx
@@ -46,20 +46,25 @@ export function GoogleAnalytics(): React.ReactElement | null {
         {`
           window.dataLayer = window.dataLayer || [];
           function gtag(){dataLayer.push(arguments);}
+          // 国内向けサイトとして analytics_storage は granted デフォルト
+          // ad_storage のみ denied で広告領域は同意 opt-in。Issue #37
           gtag('consent', 'default', {
-            analytics_storage: 'denied',
+            analytics_storage: 'granted',
             ad_storage: 'denied',
           });
           gtag('js', new Date());
           gtag('config', '${GA_MEASUREMENT_ID}', {
             send_page_view: false,
           });
-          // localStorage から同意状態を復元
+          // localStorage の同意状態が denied なら analytics も off に降格
           try {
             var consent = localStorage.getItem('stats47_cookie_consent');
-            if (consent === 'granted') {
+            if (consent === 'denied') {
               gtag('consent', 'update', {
-                analytics_storage: 'granted',
+                analytics_storage: 'denied',
+              });
+            } else if (consent === 'granted') {
+              gtag('consent', 'update', {
                 ad_storage: 'granted',
               });
             }

--- a/apps/web/src/lib/analytics/components/CookieConsentBanner.tsx
+++ b/apps/web/src/lib/analytics/components/CookieConsentBanner.tsx
@@ -18,18 +18,21 @@ export function CookieConsentBanner() {
   useEffect(() => {
     const stored = localStorage.getItem(CONSENT_KEY);
     if (!stored) {
-      // 未回答：デフォルト denied で初期化
-      window.gtag?.("consent", "default", {
-        analytics_storage: "denied",
-        ad_storage: "denied",
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any -- gtag consent API types not available
-      } as any);
-      // eslint-disable-next-line react-hooks/set-state-in-effect -- sync consent state from localStorage
+      // 未回答: GoogleAnalytics.tsx 側で analytics_storage=granted がデフォルト適用済。
+      // バナーは表示するが消極的 opt-out として運用（Issue #37）。
+      // eslint-disable-next-line react-hooks/set-state-in-effect -- show banner
       setVisible(true);
     } else if (stored === "granted") {
+      // 広告領域も同意済の場合のみ ad_storage を granted へ
       window.gtag?.("consent", "update", {
-        analytics_storage: "granted",
         ad_storage: "granted",
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any -- gtag consent API types not available
+      } as any);
+    } else if (stored === "denied") {
+      // ユーザー明示拒否: analytics / ad 両方 denied に降格
+      window.gtag?.("consent", "update", {
+        analytics_storage: "denied",
+        ad_storage: "denied",
         // eslint-disable-next-line @typescript-eslint/no-explicit-any -- gtag consent API types not available
       } as any);
     }
@@ -47,6 +50,12 @@ export function CookieConsentBanner() {
 
   const handleDecline = () => {
     localStorage.setItem(CONSENT_KEY, "denied");
+    // 拒否時は明示的に analytics / ad 両方を denied に降格（Issue #37 残課題）
+    window.gtag?.("consent", "update", {
+      analytics_storage: "denied",
+      ad_storage: "denied",
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- gtag consent API types not available
+    } as any);
     setVisible(false);
   };
 


### PR DESCRIPTION
## Summary
GA4 Users -78.8% 継続の真因は consent default = denied であることが Issue #37 残課題と W17 review (#107) で確定。analytics_storage デフォルトを granted に変更。

## 変更
- `GoogleAnalytics.tsx` consent default を granted（ad_storage は引き続き denied opt-in）
- `CookieConsentBanner.tsx` handleDecline で明示的 denied 発火（既存漏れ修正）

## プライバシー設計判断
- 国内向けサイト、GDPR 適用外、個人情報保護法では cookie 同意必須でなく「分かりやすい説明」で足りる
- ad_storage は opt-in 維持、広告領域は保守的に
- 拒否ボタンの意思は尊重（明示 denied 発火）

## 期待効果
- GA4 Users / Sessions / PV が GSC clicks に対応する水準（200-300 PV/日推定）に回復
- 来週の weekly-review で乖離解消確認

## Test plan
- [x] tsc pass
- [ ] デプロイ後 24h で GA4 リアルタイム上昇確認
- [ ] 14 日後 (#37 MID 観測) で正常水準確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)