### PR TITLE
feat(theme): 漁業（水産業）テーマダッシュボード追加 + 関連記事導線 (#112)

### DIFF
--- a/apps/web/src/app/themes/fishery-marine/page.tsx
+++ b/apps/web/src/app/themes/fishery-marine/page.tsx
@@ -1,0 +1,32 @@
+
+import { ThemePageLayout, loadThemeData, FISHERY_MARINE_THEME } from "@/features/theme-dashboard/server";
+
+import { generateOGMetadata } from "@/lib/metadata/og-generator";
+
+import type { Metadata } from "next";
+
+
+const theme = FISHERY_MARINE_THEME;
+
+export function generateMetadata(): Metadata {
+  const title = `${theme.title} | 統計で見る都道府県`;
+  return {
+    title,
+    description: theme.description,
+    keywords: theme.keywords,
+    alternates: { canonical: `/themes/${theme.themeKey}` },
+    ...generateOGMetadata({ title, description: theme.description, imageUrl: `/themes/${theme.themeKey}/opengraph-image` }),
+  };
+}
+
+export default async function FisheryMarineThemePage() {
+  const data = await loadThemeData(theme);
+  if (!data) {
+    return (
+      <div className="container mx-auto px-4 py-6">
+        <p className="text-muted-foreground">データの取得に失敗しました。</p>
+      </div>
+    );
+  }
+  return <ThemePageLayout theme={theme} data={data} />;
+}

--- a/apps/web/src/config/known-ranking-keys.ts
+++ b/apps/web/src/config/known-ranking-keys.ts
@@ -10,8 +10,8 @@
  *           `cd apps/web && npx tsx scripts/generate-known-ranking-keys.ts`
  * 更新タイミング: /register-ranking 実行後。必ず git commit してからデプロイ。
  *
- * 最終生成日: 2026-04-17
- * 件数: 1901
+ * 最終生成日: 2026-04-25
+ * 件数: 1920
  */
 export const KNOWN_RANKING_KEYS: ReadonlySet<string> = new Set([
   "abandoned-cultivated-land-area",
@@ -60,6 +60,7 @@ export const KNOWN_RANKING_KEYS: ReadonlySet<string> = new Set([
   "apparel-retail-store-count-per-1000",
   "apple-consumption-expenditure",
   "apple-consumption-quantity",
+  "aquaculture-harvest",
   "aquarium-count",
   "architect-annual-income",
   "art-museum-count",
@@ -531,6 +532,18 @@ export const KNOWN_RANKING_KEYS: ReadonlySet<string> = new Set([
   "fish-pickled-consumption-expenditure",
   "fish-tsukudani-type2-consumption-expenditure",
   "fishery-output-value",
+  "fishery-species-catch-bonito",
+  "fishery-species-catch-japanese-squid",
+  "fishery-species-catch-kelp",
+  "fishery-species-catch-mackerel",
+  "fishery-species-catch-pacific-saury",
+  "fishery-species-catch-pollock",
+  "fishery-species-catch-sardine",
+  "fishery-species-catch-scallop",
+  "fishery-species-catch-sea-bream",
+  "fishery-species-catch-snow-crab",
+  "fishery-species-catch-tuna",
+  "fishery-species-catch-yellowtail",
   "fishery-workers",
   "fishing-port-count-ksj",
   "flavor-seasoning-consumption-expenditure",
@@ -764,6 +777,8 @@ export const KNOWN_RANKING_KEYS: ReadonlySet<string> = new Set([
   "infant-deaths",
   "infant-mortality-rate-per-1000-births",
   "inflow-population-ratio",
+  "inland-aquaculture-harvest",
+  "inland-fishery-catch",
   "inpatient-rate-per-100k",
   "inpatients-per-fulltime-physician-per-day",
   "inpatients-per-nurse-per-day",
@@ -921,6 +936,10 @@ export const KNOWN_RANKING_KEYS: ReadonlySet<string> = new Set([
   "manufacturing-shipment-amount-per-establishment",
   "margarine-consumption-expenditure",
   "margarine-consumption-quantity",
+  "marine-aquaculture-harvest",
+  "marine-fishery-aquaculture-output-value",
+  "marine-fishery-catch",
+  "marine-fishery-output-value",
   "maritime-import-export-cargo",
   "marriages",
   "marriages-per-total-population",

--- a/apps/web/src/config/known-tag-keys.ts
+++ b/apps/web/src/config/known-tag-keys.ts
@@ -9,8 +9,8 @@
  * 更新方法: `cd apps/web && npx tsx scripts/generate-known-tag-keys.ts`
  * 更新タイミング: tags テーブルに新規 tag を追加した後。必ず git commit してからデプロイ。
  *
- * 最終生成日: 2026-04-21
- * 件数: 322
+ * 最終生成日: 2026-04-25
+ * 件数: 327
  */
 export const KNOWN_TAG_KEYS: ReadonlySet<string> = new Set([
   "2024-problem",
@@ -111,6 +111,7 @@ export const KNOWN_TAG_KEYS: ReadonlySet<string> = new Set([
   "fish-catch",
   "fisheries-industry",
   "fishery",
+  "fishery-species-catch",
   "food-culture",
   "food-expenditure",
   "food-products",
@@ -212,6 +213,7 @@ export const KNOWN_TAG_KEYS: ReadonlySet<string> = new Set([
   "outing-disparity",
   "overseas-travel",
   "overtourism",
+  "pacific-saury",
   "park-area",
   "parks",
   "per-capita",
@@ -219,6 +221,7 @@ export const KNOWN_TAG_KEYS: ReadonlySet<string> = new Set([
   "pharmaceuticals",
   "physique",
   "polarization",
+  "pollock-fishing",
   "pollution",
   "population",
   "population-decline",
@@ -257,8 +260,10 @@ export const KNOWN_TAG_KEYS: ReadonlySet<string> = new Set([
   "ryokan",
   "sales-volume",
   "salmon-farming",
+  "sardine-fishing",
   "savings",
   "savings-rate",
+  "scallop-fishing",
   "school-education",
   "school-health-statistics",
   "school-refusal",

--- a/apps/web/src/features/theme-dashboard/components/ThemePageLayout.tsx
+++ b/apps/web/src/features/theme-dashboard/components/ThemePageLayout.tsx
@@ -18,6 +18,7 @@ import {
 } from "../utils";
 
 import { ThemeDashboardClient } from "./ThemeDashboardClient";
+import { ThemeRelatedArticles } from "./ThemeRelatedArticles";
 
 import type { ThemePageData } from "../lib/load-theme-data";
 import type { ThemeConfig } from "../types";
@@ -74,6 +75,10 @@ export async function ThemePageLayout({ theme, data }: Props) {
         pageCharts={pageCharts}
         kpiDataByArea={kpiDataByArea}
       />
+
+      {theme.relatedArticleTagKeys && theme.relatedArticleTagKeys.length > 0 && (
+        <ThemeRelatedArticles tagKeys={theme.relatedArticleTagKeys} />
+      )}
     </div>
   );
 }

--- a/apps/web/src/features/theme-dashboard/components/ThemeRelatedArticles.tsx
+++ b/apps/web/src/features/theme-dashboard/components/ThemeRelatedArticles.tsx
@@ -1,0 +1,98 @@
+import "server-only";
+
+import Link from "next/link";
+
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+} from "@stats47/components/atoms/ui/card";
+import { Newspaper } from "lucide-react";
+
+import { listArticleSummariesByTagKey } from "@/features/blog/server";
+
+interface ThemeRelatedArticlesProps {
+  /** 関連記事を引くタグキー一覧 */
+  tagKeys: string[];
+  /** 表示する最大件数（デフォルト 6） */
+  limit?: number;
+}
+
+interface ArticleSummary {
+  slug: string;
+  title: string;
+  description: string | null;
+}
+
+/**
+ * テーマダッシュボード用「関連記事」セクション。
+ *
+ * `tagKeys` で指定された複数タグの記事を並列取得し、
+ * 重複を除去して最大 `limit` 件表示する。
+ *
+ * - 各タグごとの結果は DB 側で `published_at DESC` ソート済みのため、
+ *   ここでは単純に重複除去 + 上限カットのみ行う
+ * - tagKeys が空 or マッチ記事ゼロのときは何も描画しない（return null）
+ * - 既存の `article_tags` テーブルをそのまま利用するため DB スキーマ変更不要
+ */
+export async function ThemeRelatedArticles({
+  tagKeys,
+  limit = 6,
+}: ThemeRelatedArticlesProps) {
+  if (tagKeys.length === 0) return null;
+
+  // 各タグで記事を並列取得（各タグから最大 limit 件取得し、後で重複除去）
+  const allResults = await Promise.all(
+    tagKeys.map((tagKey) => listArticleSummariesByTagKey(tagKey, limit))
+  );
+
+  const seen = new Set<string>();
+  const articles: ArticleSummary[] = [];
+  for (const tagArticles of allResults) {
+    for (const a of tagArticles) {
+      if (seen.has(a.slug)) continue;
+      if (articles.length >= limit) break;
+      seen.add(a.slug);
+      articles.push({
+        slug: a.slug,
+        title: a.title,
+        description: a.description,
+      });
+    }
+    if (articles.length >= limit) break;
+  }
+
+  if (articles.length === 0) return null;
+
+  const visible = articles;
+
+  return (
+    <Card className="mt-8">
+      <CardHeader className="py-4 px-4 flex-row items-center gap-2 space-y-0">
+        <Newspaper className="h-4 w-4 text-muted-foreground" />
+        <CardTitle className="text-base">関連記事</CardTitle>
+      </CardHeader>
+      <CardContent className="p-4 pt-0">
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3">
+          {visible.map((article) => (
+            <Link
+              key={article.slug}
+              href={`/blog/${article.slug}`}
+              className="block rounded-md border border-border p-3 transition-colors hover:border-primary hover:bg-accent/50"
+            >
+              <p className="text-sm font-medium line-clamp-2 leading-snug">
+                {article.title}
+              </p>
+              {article.description && (
+                <p className="mt-1.5 text-xs text-muted-foreground line-clamp-2">
+                  {article.description}
+                </p>
+              )}
+            </Link>
+          ))}
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/apps/web/src/features/theme-dashboard/config/all-themes.ts
+++ b/apps/web/src/features/theme-dashboard/config/all-themes.ts
@@ -15,6 +15,7 @@ import {
   REAL_INCOME_SET,
   LABOR_MOBILITY_SET,
   LOCAL_FINANCE_SET,
+  FISHERY_MARINE_SET,
 } from "@stats47/types";
 
 import { toThemeConfig } from "../lib/to-theme-config";
@@ -39,4 +40,5 @@ export const ALL_THEMES: ThemeConfig[] = [
   toThemeConfig(REAL_INCOME_SET),
   toThemeConfig(LABOR_MOBILITY_SET),
   toThemeConfig(LOCAL_FINANCE_SET),
+  toThemeConfig(FISHERY_MARINE_SET),
 ];

--- a/apps/web/src/features/theme-dashboard/lib/to-theme-config.ts
+++ b/apps/web/src/features/theme-dashboard/lib/to-theme-config.ts
@@ -36,5 +36,6 @@ export function toThemeConfig(set: IndicatorSet): ThemeConfig {
     keywords: set.keywords ?? [],
     tabIndicators,
     panelTabs: set.panelTabs as PanelTabGroup[] | undefined,
+    relatedArticleTagKeys: set.relatedArticleTagKeys,
   };
 }

--- a/apps/web/src/features/theme-dashboard/server.ts
+++ b/apps/web/src/features/theme-dashboard/server.ts
@@ -17,6 +17,7 @@ import {
   REAL_INCOME_SET,
   LABOR_MOBILITY_SET,
   LOCAL_FINANCE_SET,
+  FISHERY_MARINE_SET,
 } from "@stats47/types";
 
 import { toThemeConfig } from "./lib/to-theme-config";
@@ -39,6 +40,7 @@ export const OCCUPATION_SALARY_THEME = toThemeConfig(OCCUPATION_SALARY_SET);
 export const REAL_INCOME_THEME = toThemeConfig(REAL_INCOME_SET);
 export const LABOR_MOBILITY_THEME = toThemeConfig(LABOR_MOBILITY_SET);
 export const LOCAL_FINANCE_THEME = toThemeConfig(LOCAL_FINANCE_SET);
+export const FISHERY_MARINE_THEME = toThemeConfig(FISHERY_MARINE_SET);
 
 // Server Component
 export { ThemePageLayout } from "./components/ThemePageLayout";

--- a/apps/web/src/features/theme-dashboard/types.ts
+++ b/apps/web/src/features/theme-dashboard/types.ts
@@ -41,6 +41,11 @@ export interface ThemeConfig {
   // チャートは chart_definitions テーブルで管理（Single Source of Truth）
   /** 統計パネルの KPI をタブでグルーピング（未指定時はフラット表示） */
   panelTabs?: PanelTabGroup[];
+  /**
+   * テーマに紐付く関連記事を取得するタグキー一覧。
+   * 未指定 or 空配列の場合、ThemePageLayout は関連記事セクションを描画しない。
+   */
+  relatedArticleTagKeys?: string[];
 }
 
 /** 指標ごとのプリロード済みデータ */

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -93,4 +93,5 @@ export {
   REAL_INCOME_SET,
   LABOR_MOBILITY_SET,
   LOCAL_FINANCE_SET,
+  FISHERY_MARINE_SET,
 } from "./indicator-sets/registry";

--- a/packages/types/src/indicator-set.ts
+++ b/packages/types/src/indicator-set.ts
@@ -125,4 +125,10 @@ export interface IndicatorSet {
   panelTabs?: IndicatorPanelTab[];
   /** SEO キーワード */
   keywords?: string[];
+  /**
+   * テーマに紐付く関連記事を取得するタグキー一覧。
+   * theme-dashboard ページの末尾に「関連記事」セクションとして表示される。
+   * `article_tags.tag_key` で記事を検索し、重複を除いて最大件数まで表示。
+   */
+  relatedArticleTagKeys?: string[];
 }

--- a/packages/types/src/indicator-sets/fishery-marine.ts
+++ b/packages/types/src/indicator-sets/fishery-marine.ts
@@ -1,0 +1,143 @@
+import type { IndicatorSet } from "../indicator-set";
+
+/**
+ * 漁業（水産業）テーマ
+ *
+ * ストーリー軸:
+ *  - 北海道 1 県で全国漁獲量の約 2 割を占める「漁業大国」
+ *  - 半世紀で漁業就業者は約 7 割減、漁獲量はピーク比でほぼ半減
+ *  - 「捕る漁業」から「育てる漁業（養殖）」へのシフト
+ *
+ * シリーズ構成:
+ *  - 漁獲量（C3121 / 1975-2023）+ 内訳（海面 C312101 / 内水面 C312102）
+ *  - 養殖収獲量（C3122 / 2000-2023）+ 内訳（海面 C312201 / 内水面 C312202）
+ *  - 漁業産出額: 旧シリーズ（C3120, 〜2016）と
+ *    新シリーズ「海面漁業・養殖業産出額」（C31201, 2017-）が併存
+ *  - 漁業就業者数（C3125 / 1975-2023）
+ *  - 漁港数（国土数値情報 / Tier B 既登録）
+ */
+export const FISHERY_MARINE_SET: IndicatorSet = {
+  key: "fishery-marine",
+  title: "漁業（水産業）",
+  description:
+    "都道府県別の漁獲量・養殖収獲量・漁業就業者数・漁業産出額・漁港数を地図とランキングで比較。北海道が全国漁獲量の約2割を占める一方、半世紀で就業者は7割減・漁獲量はほぼ半減。「捕る漁業」から「育てる漁業」へのシフトを47都道府県のデータで確認できます。",
+  category: "industry",
+  usage: "theme",
+  indicators: [
+    // 漁獲（捕る漁業）
+    { rankingKey: "fish-catch", shortLabel: "漁獲量", role: "primary" },
+    { rankingKey: "marine-fishery-catch", shortLabel: "海面漁獲量", role: "secondary" },
+    { rankingKey: "inland-fishery-catch", shortLabel: "内水面漁獲量", role: "secondary" },
+    { rankingKey: "fishing-port-count-ksj", shortLabel: "漁港数", role: "context" },
+    // 養殖（育てる漁業）
+    { rankingKey: "aquaculture-harvest", shortLabel: "養殖収獲量", role: "secondary" },
+    { rankingKey: "marine-aquaculture-harvest", shortLabel: "海面養殖", role: "secondary" },
+    { rankingKey: "inland-aquaculture-harvest", shortLabel: "内水面養殖", role: "secondary" },
+    // 経済（産出額）
+    {
+      rankingKey: "marine-fishery-aquaculture-output-value",
+      shortLabel: "産出額（新）",
+      role: "primary",
+    },
+    {
+      rankingKey: "marine-fishery-output-value",
+      shortLabel: "海面漁業産出額",
+      role: "secondary",
+    },
+    { rankingKey: "fishery-output-value", shortLabel: "産出額（旧）", role: "context" },
+    // 雇用
+    { rankingKey: "fishery-workers", shortLabel: "漁業就業者", role: "primary" },
+    // 魚種別漁獲量（海面漁業生産統計調査 0003238633、1956-2015、40都道府県）
+    { rankingKey: "fishery-species-catch-scallop", shortLabel: "ホタテガイ", role: "secondary" },
+    {
+      rankingKey: "fishery-species-catch-japanese-squid",
+      shortLabel: "スルメイカ",
+      role: "secondary",
+    },
+    { rankingKey: "fishery-species-catch-tuna", shortLabel: "マグロ類", role: "secondary" },
+    { rankingKey: "fishery-species-catch-bonito", shortLabel: "カツオ", role: "secondary" },
+    { rankingKey: "fishery-species-catch-mackerel", shortLabel: "サバ類", role: "context" },
+    {
+      rankingKey: "fishery-species-catch-pacific-saury",
+      shortLabel: "サンマ",
+      role: "context",
+    },
+    { rankingKey: "fishery-species-catch-yellowtail", shortLabel: "ブリ類", role: "context" },
+    { rankingKey: "fishery-species-catch-sardine", shortLabel: "イワシ類", role: "context" },
+    { rankingKey: "fishery-species-catch-pollock", shortLabel: "スケトウダラ", role: "context" },
+    { rankingKey: "fishery-species-catch-kelp", shortLabel: "コンブ類", role: "context" },
+    { rankingKey: "fishery-species-catch-snow-crab", shortLabel: "ズワイガニ", role: "context" },
+    { rankingKey: "fishery-species-catch-sea-bream", shortLabel: "タイ類", role: "context" },
+  ],
+  panelTabs: [
+    {
+      label: "漁獲",
+      rankingKeys: [
+        "fish-catch",
+        "marine-fishery-catch",
+        "inland-fishery-catch",
+        "fishing-port-count-ksj",
+      ],
+    },
+    {
+      label: "養殖",
+      rankingKeys: [
+        "aquaculture-harvest",
+        "marine-aquaculture-harvest",
+        "inland-aquaculture-harvest",
+      ],
+    },
+    {
+      label: "経済",
+      rankingKeys: [
+        "marine-fishery-aquaculture-output-value",
+        "marine-fishery-output-value",
+        "fishery-output-value",
+      ],
+    },
+    {
+      label: "雇用",
+      rankingKeys: ["fishery-workers"],
+    },
+    {
+      label: "推移",
+      rankingKeys: ["fish-catch", "fishery-workers"],
+    },
+    {
+      label: "魚種別",
+      rankingKeys: [
+        "fishery-species-catch-scallop",
+        "fishery-species-catch-japanese-squid",
+        "fishery-species-catch-tuna",
+        "fishery-species-catch-bonito",
+        "fishery-species-catch-mackerel",
+        "fishery-species-catch-pacific-saury",
+        "fishery-species-catch-yellowtail",
+        "fishery-species-catch-sardine",
+        "fishery-species-catch-pollock",
+        "fishery-species-catch-kelp",
+        "fishery-species-catch-snow-crab",
+        "fishery-species-catch-sea-bream",
+      ],
+    },
+  ],
+  keywords: [
+    "漁業",
+    "水産業",
+    "漁獲量",
+    "養殖",
+    "漁業就業者",
+    "漁業産出額",
+    "漁港",
+    "海面漁業",
+    "内水面漁業",
+    "都道府県",
+    "ランキング",
+  ],
+  relatedArticleTagKeys: [
+    "fishery",
+    "fish-catch",
+    "aquaculture",
+    "fisheries-industry",
+  ],
+};

--- a/packages/types/src/indicator-sets/registry.ts
+++ b/packages/types/src/indicator-sets/registry.ts
@@ -22,6 +22,7 @@ import { COMPARE_PRIVATE_WAGE_SET } from "./compare-private-wage";
 import { REAL_INCOME_SET } from "./real-income";
 import { LABOR_MOBILITY_SET } from "./labor-mobility";
 import { LOCAL_FINANCE_SET } from "./local-finance";
+import { FISHERY_MARINE_SET } from "./fishery-marine";
 
 // ============================================================================
 // 個別 export（直接参照用）
@@ -44,6 +45,7 @@ export {
   REAL_INCOME_SET,
   LABOR_MOBILITY_SET,
   LOCAL_FINANCE_SET,
+  FISHERY_MARINE_SET,
   COMPARE_FISCAL_SET,
   COMPARE_SALARY_SET,
   COMPARE_SPENDING_SET,
@@ -73,6 +75,7 @@ export const THEME_INDICATOR_SETS: IndicatorSet[] = [
   REAL_INCOME_SET,
   LABOR_MOBILITY_SET,
   LOCAL_FINANCE_SET,
+  FISHERY_MARINE_SET,
 ];
 
 // ============================================================================


### PR DESCRIPTION
## Summary

Issue #112 漁業テーマダッシュボードを Phase 1〜4 で構築完了したものを 3 commit に分けてマージ。

- **Phase 3** [9db6fc72] テーマページから関連記事への導線インフラ実装（既存タグベース再利用、DB 変更なし、optional 設計で他テーマ無影響）
- **Phase 1+2+4** [55b596dd] 漁業（水産業）テーマダッシュボード追加（社人統 11 指標 + 海面漁業魚種別 12 指標、計 23 ranking、6 panelTabs）
- **Phase 4 config** [42526b64] 漁業 23 ranking_keys + 5 tag_keys 反映（自動生成 config）

## ストーリー軸

- 北海道 1 県で全国漁獲量の約 2 割
- 半世紀で漁業就業者 7 割減・漁獲量半減
- 「捕る漁業から育てる漁業」シフト
- 都道府県の特産魚種（青森ホタテ、広島カキ、佐賀ノリ等）

## ローカル D1 / R2 の状態（リモート未反映）

このコードに紐付くデータ（マージ後に sync 必要）:

- ranking_items: 11 主要 + 12 魚種 = 23 件
- ranking_data: 17,892 + 28,008 行
- page_components / assignments: 6 件
- articles: \`fishery-species-prefecture-specialty\`「魚種でわかる都道府県の海」+ 5 chart SVG

マージ後に **/sync-remote-d1** + **/push-r2 blog** でリモート反映。

## Test plan

- [x] \`npx tsc --noEmit -p apps/web/tsconfig.json\` エラー 0
- [x] dev server で /themes/fishery-marine 表示確認（h1 / 6 panel / 12 魚種 KPI / 関連記事 2 件）
- [x] /blog/fishery-species-prefecture-specialty（新記事）表示確認
- [x] /blog/fishery-catch-aquaculture-shift（既存記事）が壊れていないことを確認
- [ ] CI quality check
- [ ] develop マージ後に /sync-remote-d1 + /push-r2 blog でリモート反映

Closes #112

🤖 Generated with [Claude Code](https://claude.com/claude-code)