### PR TITLE
fix(deps): https-proxy-agent v8 → v7.0.6 で tsx 実行を復旧

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
       "dependencies": {
         "d3": "^7.9.0",
         "http-proxy-agent": "^8.0.0",
-        "https-proxy-agent": "^8.0.0",
+        "https-proxy-agent": "^7.0.6",
         "topojson-client": "^3.1.0",
         "topojson-simplify": "^3.0.3"
       },
@@ -414,20 +414,6 @@
       "dependencies": {
         "agent-base": "^7.1.0",
         "debug": "^4.3.4"
-      },
-      "engines": {
-        "node": ">= 14"
-      }
-    },
-    "apps/web/node_modules/https-proxy-agent": {
-      "version": "7.0.6",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
-      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "agent-base": "^7.1.2",
-        "debug": "4"
       },
       "engines": {
         "node": ">= 14"
@@ -17476,20 +17462,6 @@
         "node": ">= 12"
       }
     },
-    "node_modules/gaxios/node_modules/https-proxy-agent": {
-      "version": "7.0.6",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
-      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "agent-base": "^7.1.2",
-        "debug": "4"
-      },
-      "engines": {
-        "node": ">= 14"
-      }
-    },
     "node_modules/gaxios/node_modules/node-fetch": {
       "version": "3.3.2",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
@@ -18326,23 +18298,14 @@
       }
     },
     "node_modules/https-proxy-agent": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-8.0.0.tgz",
-      "integrity": "sha512-YYeW+iCnAS3xhvj2dvVoWgsbca3RfQy/IlaNHHOtDmU0jMqPI9euIq3Y9BJETdxk16h9NHHCKqp/KB9nIMStCQ==",
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
       "license": "MIT",
       "dependencies": {
-        "agent-base": "8.0.0",
-        "debug": "^4.3.4"
+        "agent-base": "^7.1.2",
+        "debug": "4"
       },
-      "engines": {
-        "node": ">= 14"
-      }
-    },
-    "node_modules/https-proxy-agent/node_modules/agent-base": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-8.0.0.tgz",
-      "integrity": "sha512-QT8i0hCz6C/KQ+KTAbSNwCHDGdmUJl2tp2ZpNlGSWCfhUNVbYG2WLE3MdZGBAgXPV4GAvjGMxo+C1hroyxmZEg==",
-      "license": "MIT",
       "engines": {
         "node": ">= 14"
       }
@@ -19317,19 +19280,6 @@
       "dependencies": {
         "agent-base": "^7.1.0",
         "debug": "^4.3.4"
-      },
-      "engines": {
-        "node": ">= 14"
-      }
-    },
-    "node_modules/jsdom/node_modules/https-proxy-agent": {
-      "version": "7.0.6",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
-      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
-      "license": "MIT",
-      "dependencies": {
-        "agent-base": "^7.1.2",
-        "debug": "4"
       },
       "engines": {
         "node": ">= 14"
@@ -30296,20 +30246,6 @@
       "dependencies": {
         "agent-base": "^7.1.0",
         "debug": "^4.3.4"
-      },
-      "engines": {
-        "node": ">= 14"
-      }
-    },
-    "packages/visualization/node_modules/https-proxy-agent": {
-      "version": "7.0.6",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
-      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "agent-base": "^7.1.2",
-        "debug": "4"
       },
       "engines": {
         "node": ">= 14"

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
   "dependencies": {
     "d3": "^7.9.0",
     "http-proxy-agent": "^8.0.0",
-    "https-proxy-agent": "^8.0.0",
+    "https-proxy-agent": "^7.0.6",
     "topojson-client": "^3.1.0",
     "topojson-simplify": "^3.0.3"
   }


### PR DESCRIPTION
## Summary

root の \`https-proxy-agent\` を v8.0.0 (ESM-only) から v7.0.6 (CJS 互換) に downgrade。tsx でのスクリプト実行時に \`ERR_PACKAGE_PATH_NOT_EXPORTED\` で失敗していた問題を解消。

## 問題

v8.0.0 は \`type: \"module\"\` の ESM-only パッケージで \`exports.require\` が定義されていない。tsx が CJS-style resolution で require すると Node.js が失敗。

これにより以下が動作不能だった:
- \`npm run r2:upload\` / \`populate-all-rankings.ts\` 等の tsx スクリプト全般
- Phase 1/4 の e-Stat populate は WebFetch + better-sqlite3 直接投入で代替
- R2 push は wrangler CLI で個別アップロードで代替

## 修正

\`package.json\` で \`\"https-proxy-agent\": \"^7.0.6\"\` に下げる。jsdom / gaxios も既に v7.0.6 を nested install していたため、root と一致して dedup される。

## 検証

- [x] \`npx tsx packages/r2-storage/src/scripts/sync-upload.ts --dry-run --prefix blog/foo\` → エラー無し
- [x] \`npx tsc --noEmit -p apps/web/tsconfig.json\` → エラー 0
- [x] \`npm ls https-proxy-agent\` → 全箇所が \`7.0.6 deduped\`
- [ ] CI quality check
- [ ] develop merge 後、\`/sync-articles\` 等 tsx 系スキルが正常動作することを実環境で確認

## 副作用評価

- v7 ↔ v8 の \`HttpsProxyAgent\` クラス API は互換（コンストラクタ署名同じ）
- \`packages/r2-storage/src/lib/clients/create-s3-client.ts\` は変更不要
- \`apps/web/next.config.ts\` の webpack externals 設定は v7 でも動作（API 互換）
- v7 は LTS 扱いで proxy-agents モノレポによりサポート継続

🤖 Generated with [Claude Code](https://claude.com/claude-code)