### PR TITLE
refactor(seo): GSC ゼロベース再構築 — middleware + sitemap クリーンアップ (Phase 9)

### DIFF
--- a/.github/workflows/sync-known-keys.yml
+++ b/.github/workflows/sync-known-keys.yml
@@ -1,0 +1,111 @@
+name: 🔑 Sync KNOWN_*_KEYS from remote D1 (daily)
+
+# Phase 9 P2-A (2026-04-26): KNOWN_RANKING_KEYS / KNOWN_TAG_KEYS の同期を自動化。
+# middleware の Allowlist が古いと「実在するページが 410 化される」逆事故が発生するため、
+# remote D1 から定期的に再生成して PR を作る。
+#
+# 必要な GitHub secrets:
+# - CLOUDFLARE_API_TOKEN: D1 Read 権限を持つ token（pull:d1 用）
+# - CLOUDFLARE_ACCOUNT_ID: stats47 アカウント ID
+#
+# 動作:
+# 1. develop branch を checkout
+# 2. wrangler 経由で remote D1 → local SQLite に pull
+# 3. apps/web/scripts/generate-known-{ranking,tag}-keys.ts を実行
+# 4. diff があれば feature/sync-known-keys-YYYY-MM-DD ブランチで PR を自動起票
+
+on:
+  schedule:
+    - cron: "0 22 * * *" # JST 07:00 (UTC 22:00 前日)
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: sync-known-keys
+  cancel-in-progress: false
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: 🧰 Checkout develop
+        uses: actions/checkout@v4
+        with:
+          ref: develop
+          fetch-depth: 1
+
+      - name: 🟢 Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "npm"
+
+      - name: 📦 Install dependencies
+        run: npm ci
+
+      - name: 📥 Pull remote D1 (ranking/tag のみ最小同期)
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: |
+          npm run pull:d1 --workspace=packages/database -- --table ranking_items
+          npm run pull:d1 --workspace=packages/database -- --table article_tags
+
+      - name: 🔧 Regenerate KNOWN_*_KEYS
+        run: |
+          cd apps/web
+          npx tsx scripts/generate-known-ranking-keys.ts
+          npx tsx scripts/generate-known-tag-keys.ts
+
+      - name: 📅 Resolve date
+        id: date
+        run: echo "date=$(date -u +%Y-%m-%d)" >> $GITHUB_OUTPUT
+
+      - name: 🔍 Detect diff
+        id: diff
+        run: |
+          if git diff --quiet apps/web/src/config/known-ranking-keys.ts apps/web/src/config/known-tag-keys.ts; then
+            echo "changed=false" >> $GITHUB_OUTPUT
+            echo "No changes detected"
+          else
+            echo "changed=true" >> $GITHUB_OUTPUT
+            git diff --stat apps/web/src/config/known-ranking-keys.ts apps/web/src/config/known-tag-keys.ts
+          fi
+
+      - name: 🌿 Create PR with diffs
+        if: steps.diff.outputs.changed == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          BRANCH="feature/sync-known-keys-${{ steps.date.outputs.date }}"
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git checkout -b "$BRANCH"
+          git add apps/web/src/config/known-ranking-keys.ts apps/web/src/config/known-tag-keys.ts
+          git commit -m "chore(seo): sync KNOWN_*_KEYS from remote D1 (${{ steps.date.outputs.date }})"
+          git push origin "$BRANCH"
+          gh pr create \
+            --base develop \
+            --head "$BRANCH" \
+            --title "chore(seo): sync KNOWN_*_KEYS (${{ steps.date.outputs.date }})" \
+            --body "Automated daily sync of \`KNOWN_RANKING_KEYS\` / \`KNOWN_TAG_KEYS\` from remote D1.
+
+Phase 9 P2-A: prevent middleware Allowlist from going stale (was 28 days old as of 2026-04-26).
+
+Diff source: \`apps/web/scripts/generate-known-{ranking,tag}-keys.ts\` against remote D1 production state.
+
+⚠ Review the diff carefully — accidental removals would cause real pages to 410."
+
+      - name: 📄 Step Summary
+        if: always()
+        run: |
+          echo "# Sync KNOWN_*_KEYS — ${{ steps.date.outputs.date }}" >> $GITHUB_STEP_SUMMARY
+          if [ "${{ steps.diff.outputs.changed }}" = "true" ]; then
+            echo "✅ Diff detected, PR created on branch \`feature/sync-known-keys-${{ steps.date.outputs.date }}\`" >> $GITHUB_STEP_SUMMARY
+          else
+            echo "✅ No diff — KNOWN_*_KEYS already in sync." >> $GITHUB_STEP_SUMMARY
+          fi

--- a/apps/web/src/app/areas/[areaCode]/[categoryKey]/page.tsx
+++ b/apps/web/src/app/areas/[areaCode]/[categoryKey]/page.tsx
@@ -31,7 +31,7 @@ import {
 import { getAreaProfileAction, AreaDashboardSection } from "@/features/area-profile/server";
 import { listCategories } from "@/features/category/server";
 
-import { INDEXABLE_AREA_CATEGORIES_SET } from "@/lib/indexable-area-categories";
+import { UrlPolicy } from "@/lib/url-policy";
 
 import type { Metadata } from "next";
 
@@ -39,9 +39,6 @@ import type { Metadata } from "next";
 
 
 
-
-/** インデックス対象カテゴリ（共通定数） */
-const INDEXABLE_CATEGORIES = INDEXABLE_AREA_CATEGORIES_SET;
 
 interface PageProps {
     params: Promise<{ areaCode: string; categoryKey: string }>;
@@ -69,7 +66,7 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
     // 追加して GSC の duplicate canonical を回避。
     const title = `${profile.areaName}の${category.categoryName}データ｜47都道府県ランキング比較`;
     const description = `${profile.areaName}の${category.categoryName}分野の統計データ一覧。全国 47 都道府県で${profile.areaName}は何位か、グラフと地図で比較できます。`;
-    const indexable = INDEXABLE_CATEGORIES.has(categoryKey);
+    const indexable = UrlPolicy.area.isIndexableCategory(categoryKey);
 
     const baseUrl = process.env.NEXT_PUBLIC_BASE_URL || "https://stats47.jp";
     const imageUrl = `${baseUrl}/areas/${areaCode}/opengraph-image`;

--- a/apps/web/src/app/sitemap.ts
+++ b/apps/web/src/app/sitemap.ts
@@ -1,3 +1,14 @@
+/**
+ * Phase 9 P2-C (2026-04-26): sitemap index 化
+ *
+ * Next.js 15 の `generateSitemaps()` API を使い 1 つの sitemap.xml を 8 segment に分割。
+ * - 出力 URL: /sitemap.xml (index) + /sitemap/0.xml, /sitemap/1.xml, ...
+ * - 各 segment ごとに ISR キャッシュが独立し、巨大な ranking 取得が他に波及しない
+ * - GSC で各 segment を個別に submit すれば「どこが詰まっているか」が見える
+ *
+ * SEGMENTS の順序を変えると URL（数字 id）が変わるため、追加時は末尾に追記すること。
+ */
+
 import {
   getDrizzle,
   rankingItems,
@@ -16,32 +27,46 @@ import { BLOG_SLUG_REDIRECTS } from "@/config/blog-redirects";
 
 import type { MetadataRoute } from "next";
 
-// ISR 24h キャッシュ: Googlebot の sitemap.xml 取得のたびに D1 全テーブルスキャンが走るのを防ぐ
+// ISR 24h: Googlebot が sitemap を取得するたびの D1 全テーブルスキャンを防ぐ
 export const revalidate = 86400;
 
 const BASE_URL = process.env.NEXT_PUBLIC_BASE_URL || "https://stats47.jp";
 
-const PREFECTURE_CODES = Array.from({ length: 47 }, (_, i) =>
-  String(i + 1).padStart(2, "0") + "000",
+const PREFECTURE_CODES = Array.from(
+  { length: 47 },
+  (_, i) => String(i + 1).padStart(2, "0") + "000",
 );
 
-/**
- * Phase 9 (2026-04-26) lastmod 戦略:
- * - 静的ページ / 集約ページ（ranking, areas, themes, surveys 等）は lastmod 省略
- *   → bulk timestamp が「全件 100% 同一」状態を作り、Google が lastmod 信号を
- *     完全無視する事象を回避（公式推奨「不正確な lastmod を出すぐらいなら省略」）
- * - blog のみ published_at を固定使用（記事公開日として安定）
- * - tag は含有記事の最新 published_at を集計
- *
- * 参考: https://developers.google.com/search/docs/crawling-indexing/sitemaps/build-sitemap
- */
+// ----------------------------------------------------------------------------
+// Sitemap Index 定義
+// ----------------------------------------------------------------------------
+
+const SEGMENTS = [
+  "static",
+  "themes",
+  "areas",
+  "ranking",
+  "blog",
+  "categories",
+  "surveys",
+  "tags",
+] as const;
+
+type Segment = (typeof SEGMENTS)[number];
+
+export async function generateSitemaps(): Promise<{ id: number }[]> {
+  return SEGMENTS.map((_, id) => ({ id }));
+}
+
+// ----------------------------------------------------------------------------
+// Segment 別生成ロジック
+// ----------------------------------------------------------------------------
+
 const STATIC_PAGES: MetadataRoute.Sitemap = [
   { url: BASE_URL, changeFrequency: "daily", priority: 1.0 },
   { url: `${BASE_URL}/ranking`, changeFrequency: "daily", priority: 0.9 },
   { url: `${BASE_URL}/areas`, changeFrequency: "weekly", priority: 0.8 },
   { url: `${BASE_URL}/themes`, changeFrequency: "weekly", priority: 0.8 },
-  // /compare は除外: インタラクティブツールで searchParams 膨張。/compare/* は noindex, follow 戦略
-  // correlation は除外: インタラクティブツールで検索流入なし（71表示/0クリック）、25秒の応答時間で5xx原因
   { url: `${BASE_URL}/search`, changeFrequency: "weekly", priority: 0.4 },
   { url: `${BASE_URL}/about`, changeFrequency: "monthly", priority: 0.5 },
   { url: `${BASE_URL}/privacy`, changeFrequency: "yearly", priority: 0.2 },
@@ -54,140 +79,151 @@ const THEME_PAGES: MetadataRoute.Sitemap = ALL_THEMES.map((theme) => ({
   priority: 0.8,
 }));
 
-const AREA_PAGES: MetadataRoute.Sitemap = PREFECTURE_CODES.map((code) => ({
-  url: `${BASE_URL}/areas/${code}`,
-  changeFrequency: "weekly",
-  priority: 0.8,
-}));
-
-// Phase 9 (2026-04-26): UrlPolicy 経由で indexable category を引く（middleware と完全一致）。
-// 過去事故（2026-04-26 批判レビュー）: middleware は [population, economy] 両方を 200 で返すが
-// sitemap は population のみという乖離があり /areas/{prefCode}/economy が orphan page 化していた。
-const AREA_CATEGORY_PAGES: MetadataRoute.Sitemap = PREFECTURE_CODES.flatMap(
-  (code) =>
+const AREA_PAGES: MetadataRoute.Sitemap = [
+  ...PREFECTURE_CODES.map((code) => ({
+    url: `${BASE_URL}/areas/${code}`,
+    changeFrequency: "weekly" as const,
+    priority: 0.8,
+  })),
+  // UrlPolicy.area.indexableCategories と middleware を完全一致（economy orphan page 解消）
+  ...PREFECTURE_CODES.flatMap((code) =>
     UrlPolicy.area.indexableCategories.map((cat) => ({
       url: `${BASE_URL}/areas/${code}/${cat}`,
       changeFrequency: "weekly" as const,
       priority: 0.7,
     })),
-);
+  ),
+];
 
-export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
-  try {
-    const db = getDrizzle();
+async function getRankingPages(): Promise<MetadataRoute.Sitemap> {
+  const db = getDrizzle();
+  const rows = await db
+    .select({ rankingKey: rankingItems.rankingKey })
+    .from(rankingItems)
+    .where(eq(rankingItems.isActive, true));
 
-    // ランキング詳細ページ
-    // Phase 9: lastmod は省略。ranking_items.updated_at は bulk update で同一 timestamp が
-    // 大量発生するため、Google が信号として使えない。「無いほうが良い」という公式推奨に従う。
-    const rankingRows = await db
-      .select({ rankingKey: rankingItems.rankingKey })
-      .from(rankingItems)
-      .where(eq(rankingItems.isActive, true));
+  // ranking_items は (ranking_key, area_type) 複合主キーのため重複排除必須
+  const seen = new Set<string>();
+  return rows
+    .filter((row) => UrlPolicy.ranking.shouldIncludeInSitemap(row.rankingKey))
+    .filter((row) => {
+      if (seen.has(row.rankingKey)) return false;
+      seen.add(row.rankingKey);
+      return true;
+    })
+    .map((row) => ({
+      url: `${BASE_URL}/ranking/${row.rankingKey}`,
+      changeFrequency: "monthly" as const,
+      priority: 0.9,
+    }));
+}
 
-    // ranking_items は (ranking_key, area_type) 複合主キーのため重複排除必須
-    const seenRankingKeys = new Set<string>();
-    const rankingPages: MetadataRoute.Sitemap = rankingRows
-      .filter((row) => UrlPolicy.ranking.shouldIncludeInSitemap(row.rankingKey))
-      .filter((row) => {
-        if (seenRankingKeys.has(row.rankingKey)) return false;
-        seenRankingKeys.add(row.rankingKey);
-        return true;
-      })
+async function getBlogPages(): Promise<MetadataRoute.Sitemap> {
+  const db = getDrizzle();
+  const rows = await db
+    .select({ slug: articles.slug, publishedAt: articles.publishedAt })
+    .from(articles)
+    .where(and(eq(articles.published, true), isNotNull(articles.publishedAt)));
+
+  const redirected = new Set(Object.keys(BLOG_SLUG_REDIRECTS));
+  return [
+    { url: `${BASE_URL}/blog`, changeFrequency: "daily", priority: 0.8 },
+    ...rows
+      .filter((row) => !redirected.has(row.slug))
       .map((row) => ({
-        url: `${BASE_URL}/ranking/${row.rankingKey}`,
+        url: `${BASE_URL}/blog/${row.slug}`,
+        lastModified: row.publishedAt ? new Date(row.publishedAt) : undefined,
         changeFrequency: "monthly" as const,
-        priority: 0.9,
-      }));
-
-    // カテゴリページ — lastmod 省略（集約ページのため updated_at の信頼性低い）
-    const categoryRows = await db
-      .select({ categoryKey: categories.categoryKey })
-      .from(categories);
-
-    const categoryPages: MetadataRoute.Sitemap = categoryRows.map((row) => ({
-      url: `${BASE_URL}/category/${row.categoryKey}`,
-      changeFrequency: "weekly",
-      priority: 0.5,
-    }));
-
-    // /compare/* は noindex, follow 戦略。sitemap には含めない。
-
-    // ブログ記事 — published_at を固定使用（updated_at は安易な編集で動くため信頼性低い）
-    const articleRows = await db
-      .select({
-        slug: articles.slug,
-        publishedAt: articles.publishedAt,
-      })
-      .from(articles)
-      .where(and(eq(articles.published, true), isNotNull(articles.publishedAt)));
-
-    const redirectedSlugs = new Set(Object.keys(BLOG_SLUG_REDIRECTS));
-    const blogPages: MetadataRoute.Sitemap = [
-      { url: `${BASE_URL}/blog`, changeFrequency: "daily", priority: 0.8 },
-      ...articleRows
-        .filter((row) => !redirectedSlugs.has(row.slug))
-        .map((row) => ({
-          url: `${BASE_URL}/blog/${row.slug}`,
-          lastModified: row.publishedAt ? new Date(row.publishedAt) : undefined,
-          changeFrequency: "monthly" as const,
-          priority: 0.7,
-        })),
-    ];
-
-    // 調査ページ — lastmod 省略
-    const surveyRows = await db.select({ id: surveys.id }).from(surveys);
-
-    const surveyPages: MetadataRoute.Sitemap = [
-      { url: `${BASE_URL}/survey`, changeFrequency: "weekly", priority: 0.6 },
-      ...surveyRows.map((row) => ({
-        url: `${BASE_URL}/survey/${row.id}`,
-        changeFrequency: "monthly" as const,
-        priority: 0.5,
+        priority: 0.7,
       })),
-    ];
+  ];
+}
 
-    // タグページ（公開記事が 5 本以上あるタグのみ）
-    // lastmod は含有記事の最新 published_at（aggregate page として正しい挙動）
-    const tagRows = await db
-      .select({
-        tagKey: articleTags.tagKey,
-        latestPublishedAt: sql<string | null>`max(${articles.publishedAt})`.as(
-          "latestPublishedAt",
-        ),
-      })
-      .from(articleTags)
-      .innerJoin(articles, eq(articleTags.slug, articles.slug))
-      .where(eq(articles.published, true))
-      .groupBy(articleTags.tagKey)
-      .having(sql`count(*) >= 5`);
+async function getCategoryPages(): Promise<MetadataRoute.Sitemap> {
+  const db = getDrizzle();
+  const rows = await db
+    .select({ categoryKey: categories.categoryKey })
+    .from(categories);
+  return rows.map((row) => ({
+    url: `${BASE_URL}/category/${row.categoryKey}`,
+    changeFrequency: "weekly",
+    priority: 0.5,
+  }));
+}
 
-    const tagPages: MetadataRoute.Sitemap = tagRows.map((row) => ({
-      url: `${BASE_URL}/tag/${row.tagKey}`,
-      lastModified: row.latestPublishedAt
-        ? new Date(row.latestPublishedAt)
-        : undefined,
-      changeFrequency: "weekly" as const,
-      priority: 0.4,
-    }));
+async function getSurveyPages(): Promise<MetadataRoute.Sitemap> {
+  const db = getDrizzle();
+  const rows = await db.select({ id: surveys.id }).from(surveys);
+  return [
+    { url: `${BASE_URL}/survey`, changeFrequency: "weekly", priority: 0.6 },
+    ...rows.map((row) => ({
+      url: `${BASE_URL}/survey/${row.id}`,
+      changeFrequency: "monthly" as const,
+      priority: 0.5,
+    })),
+  ];
+}
 
-    return [
-      ...STATIC_PAGES,
-      ...THEME_PAGES,
-      ...AREA_PAGES,
-      ...AREA_CATEGORY_PAGES,
-      ...rankingPages,
-      ...categoryPages,
-      ...blogPages,
-      ...surveyPages,
-      ...tagPages,
-    ];
+async function getTagPages(): Promise<MetadataRoute.Sitemap> {
+  const db = getDrizzle();
+  const rows = await db
+    .select({
+      tagKey: articleTags.tagKey,
+      latestPublishedAt: sql<string | null>`max(${articles.publishedAt})`.as(
+        "latestPublishedAt",
+      ),
+    })
+    .from(articleTags)
+    .innerJoin(articles, eq(articleTags.slug, articles.slug))
+    .where(eq(articles.published, true))
+    .groupBy(articleTags.tagKey)
+    .having(sql`count(*) >= 5`);
+
+  return rows.map((row) => ({
+    url: `${BASE_URL}/tag/${row.tagKey}`,
+    lastModified: row.latestPublishedAt
+      ? new Date(row.latestPublishedAt)
+      : undefined,
+    changeFrequency: "weekly" as const,
+    priority: 0.4,
+  }));
+}
+
+// ----------------------------------------------------------------------------
+// Dispatcher
+// ----------------------------------------------------------------------------
+
+export default async function sitemap({
+  id,
+}: {
+  id: number;
+}): Promise<MetadataRoute.Sitemap> {
+  const segment: Segment | undefined = SEGMENTS[id];
+  if (!segment) {
+    return [];
+  }
+
+  try {
+    switch (segment) {
+      case "static":
+        return STATIC_PAGES;
+      case "themes":
+        return THEME_PAGES;
+      case "areas":
+        return AREA_PAGES;
+      case "ranking":
+        return await getRankingPages();
+      case "blog":
+        return await getBlogPages();
+      case "categories":
+        return await getCategoryPages();
+      case "surveys":
+        return await getSurveyPages();
+      case "tags":
+        return await getTagPages();
+    }
   } catch {
-    // ビルド時に D1 が利用できない場合は静的ページのみ返し、ISR で再生成する
-    return [
-      ...STATIC_PAGES,
-      ...THEME_PAGES,
-      ...AREA_PAGES,
-      ...AREA_CATEGORY_PAGES,
-    ];
+    // ビルド時に D1 が利用できない場合は空配列で fallback（ISR で再生成）
+    return [];
   }
 }

--- a/apps/web/src/app/sitemap.ts
+++ b/apps/web/src/app/sitemap.ts
@@ -1,15 +1,18 @@
-
-import { getDrizzle, rankingItems, categories, articles, surveys, articleTags } from "@stats47/database/server";
+import {
+  getDrizzle,
+  rankingItems,
+  categories,
+  articles,
+  surveys,
+  articleTags,
+} from "@stats47/database/server";
 import { eq, and, isNotNull, sql } from "drizzle-orm";
 
 import { ALL_THEMES } from "@/features/theme-dashboard/config/all-themes";
 
-import { INDEXABLE_AREA_CATEGORIES } from "@/lib/indexable-area-categories";
+import { UrlPolicy } from "@/lib/url-policy";
 
 import { BLOG_SLUG_REDIRECTS } from "@/config/blog-redirects";
-import { GONE_RANKING_KEYS } from "@/config/gone-ranking-keys";
-import { INDEXABLE_RANKING_KEYS } from "@/config/indexable-ranking-keys";
-
 
 import type { MetadataRoute } from "next";
 
@@ -19,9 +22,19 @@ export const revalidate = 86400;
 const BASE_URL = process.env.NEXT_PUBLIC_BASE_URL || "https://stats47.jp";
 
 const PREFECTURE_CODES = Array.from({ length: 47 }, (_, i) =>
-  String(i + 1).padStart(2, "0") + "000"
+  String(i + 1).padStart(2, "0") + "000",
 );
 
+/**
+ * Phase 9 (2026-04-26) lastmod 戦略:
+ * - 静的ページ / 集約ページ（ranking, areas, themes, surveys 等）は lastmod 省略
+ *   → bulk timestamp が「全件 100% 同一」状態を作り、Google が lastmod 信号を
+ *     完全無視する事象を回避（公式推奨「不正確な lastmod を出すぐらいなら省略」）
+ * - blog のみ published_at を固定使用（記事公開日として安定）
+ * - tag は含有記事の最新 published_at を集計
+ *
+ * 参考: https://developers.google.com/search/docs/crawling-indexing/sitemaps/build-sitemap
+ */
 const STATIC_PAGES: MetadataRoute.Sitemap = [
   { url: BASE_URL, changeFrequency: "daily", priority: 1.0 },
   { url: `${BASE_URL}/ranking`, changeFrequency: "daily", priority: 0.9 },
@@ -47,20 +60,16 @@ const AREA_PAGES: MetadataRoute.Sitemap = PREFECTURE_CODES.map((code) => ({
   priority: 0.8,
 }));
 
-// 2026-04-25: sitemap に出すサブカテゴリは population のみに絞る（クロール予算節約）。
-// middleware/page.tsx は INDEXABLE_AREA_CATEGORIES_SET をそのまま使い続けるため、
-// /areas/{prefCode}/economy など既存インデックス済みページは引き続き 200 を返す。
-// Google は sitemap で発見しなくなるが既存インデックスは保持される設計。
-const SITEMAP_AREA_CATEGORIES = INDEXABLE_AREA_CATEGORIES.filter(
-  (cat) => cat === "population"
-);
-
-const AREA_CATEGORY_PAGES: MetadataRoute.Sitemap = PREFECTURE_CODES.flatMap((code) =>
-  SITEMAP_AREA_CATEGORIES.map((cat) => ({
-    url: `${BASE_URL}/areas/${code}/${cat}`,
-    changeFrequency: "weekly" as const,
-    priority: 0.7,
-  }))
+// Phase 9 (2026-04-26): UrlPolicy 経由で indexable category を引く（middleware と完全一致）。
+// 過去事故（2026-04-26 批判レビュー）: middleware は [population, economy] 両方を 200 で返すが
+// sitemap は population のみという乖離があり /areas/{prefCode}/economy が orphan page 化していた。
+const AREA_CATEGORY_PAGES: MetadataRoute.Sitemap = PREFECTURE_CODES.flatMap(
+  (code) =>
+    UrlPolicy.area.indexableCategories.map((cat) => ({
+      url: `${BASE_URL}/areas/${code}/${cat}`,
+      changeFrequency: "weekly" as const,
+      priority: 0.7,
+    })),
 );
 
 export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
@@ -68,25 +77,17 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     const db = getDrizzle();
 
     // ランキング詳細ページ
+    // Phase 9: lastmod は省略。ranking_items.updated_at は bulk update で同一 timestamp が
+    // 大量発生するため、Google が信号として使えない。「無いほうが良い」という公式推奨に従う。
     const rankingRows = await db
-      .select({
-        rankingKey: rankingItems.rankingKey,
-        updatedAt: rankingItems.updatedAt,
-      })
+      .select({ rankingKey: rankingItems.rankingKey })
       .from(rankingItems)
       .where(eq(rankingItems.isActive, true));
 
-    // 2026-04-25: sitemap には GSC で実際に Impressions ≥ 1 が出ている ranking のみ載せる。
-    // 残りの ranking は middleware で 200 を返し続けるが sitemap で発見させない。
-    // 元データ生成: node .claude/scripts/gsc/build-indexable-ranking-keys.cjs
-    //
-    // Phase 9 (2026-04-26): ranking_items は (ranking_key, area_type) 複合主キーのため
-    // 同じ ranking_key が複数 area_type で存在しうる。重複排除しないと sitemap.xml
-    // に同 URL が複数回出現し、Google が soft 404 / 重複コンテンツと判定するリスク。
+    // ranking_items は (ranking_key, area_type) 複合主キーのため重複排除必須
     const seenRankingKeys = new Set<string>();
     const rankingPages: MetadataRoute.Sitemap = rankingRows
-      .filter((row) => !GONE_RANKING_KEYS.has(row.rankingKey))
-      .filter((row) => INDEXABLE_RANKING_KEYS.has(row.rankingKey))
+      .filter((row) => UrlPolicy.ranking.shouldIncludeInSitemap(row.rankingKey))
       .filter((row) => {
         if (seenRankingKeys.has(row.rankingKey)) return false;
         seenRankingKeys.add(row.rankingKey);
@@ -94,34 +95,28 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
       })
       .map((row) => ({
         url: `${BASE_URL}/ranking/${row.rankingKey}`,
-        lastModified: row.updatedAt ? new Date(row.updatedAt) : undefined,
-        changeFrequency: "monthly",
+        changeFrequency: "monthly" as const,
         priority: 0.9,
       }));
 
-    // カテゴリページ
+    // カテゴリページ — lastmod 省略（集約ページのため updated_at の信頼性低い）
     const categoryRows = await db
-      .select({
-        categoryKey: categories.categoryKey,
-        updatedAt: categories.updatedAt,
-      })
+      .select({ categoryKey: categories.categoryKey })
       .from(categories);
 
     const categoryPages: MetadataRoute.Sitemap = categoryRows.map((row) => ({
       url: `${BASE_URL}/category/${row.categoryKey}`,
-      lastModified: row.updatedAt ? new Date(row.updatedAt) : undefined,
       changeFrequency: "weekly",
       priority: 0.5,
     }));
 
     // /compare/* は noindex, follow 戦略。sitemap には含めない。
 
-    // ブログ記事
+    // ブログ記事 — published_at を固定使用（updated_at は安易な編集で動くため信頼性低い）
     const articleRows = await db
       .select({
         slug: articles.slug,
         publishedAt: articles.publishedAt,
-        updatedAt: articles.updatedAt,
       })
       .from(articles)
       .where(and(eq(articles.published, true), isNotNull(articles.publishedAt)));
@@ -129,41 +124,36 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     const redirectedSlugs = new Set(Object.keys(BLOG_SLUG_REDIRECTS));
     const blogPages: MetadataRoute.Sitemap = [
       { url: `${BASE_URL}/blog`, changeFrequency: "daily", priority: 0.8 },
-      ...articleRows.filter((row) => !redirectedSlugs.has(row.slug)).map((row) => ({
-        url: `${BASE_URL}/blog/${row.slug}`,
-        lastModified: row.updatedAt
-          ? new Date(row.updatedAt)
-          : row.publishedAt
-            ? new Date(row.publishedAt)
-            : undefined,
-        changeFrequency: "monthly" as const,
-        priority: 0.7,
-      })),
+      ...articleRows
+        .filter((row) => !redirectedSlugs.has(row.slug))
+        .map((row) => ({
+          url: `${BASE_URL}/blog/${row.slug}`,
+          lastModified: row.publishedAt ? new Date(row.publishedAt) : undefined,
+          changeFrequency: "monthly" as const,
+          priority: 0.7,
+        })),
     ];
 
-    // 調査ページ
-    const surveyRows = await db
-      .select({ id: surveys.id, updatedAt: surveys.updatedAt })
-      .from(surveys);
+    // 調査ページ — lastmod 省略
+    const surveyRows = await db.select({ id: surveys.id }).from(surveys);
 
     const surveyPages: MetadataRoute.Sitemap = [
       { url: `${BASE_URL}/survey`, changeFrequency: "weekly", priority: 0.6 },
       ...surveyRows.map((row) => ({
         url: `${BASE_URL}/survey/${row.id}`,
-        lastModified: row.updatedAt ? new Date(row.updatedAt) : undefined,
         changeFrequency: "monthly" as const,
         priority: 0.5,
       })),
     ];
 
     // タグページ（公開記事が 5 本以上あるタグのみ）
-    // 2026-04-25: 閾値 2 → 5 に厳格化（クロール予算節約）。
-    // 1-4 本のタグは thin content と判定されやすいため sitemap から除外。
-    // page.tsx 側でも generateMetadata で noindex, follow を返す。
+    // lastmod は含有記事の最新 published_at（aggregate page として正しい挙動）
     const tagRows = await db
       .select({
         tagKey: articleTags.tagKey,
-        count: sql<number>`count(*)`.as("count"),
+        latestPublishedAt: sql<string | null>`max(${articles.publishedAt})`.as(
+          "latestPublishedAt",
+        ),
       })
       .from(articleTags)
       .innerJoin(articles, eq(articleTags.slug, articles.slug))
@@ -173,13 +163,31 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
 
     const tagPages: MetadataRoute.Sitemap = tagRows.map((row) => ({
       url: `${BASE_URL}/tag/${row.tagKey}`,
+      lastModified: row.latestPublishedAt
+        ? new Date(row.latestPublishedAt)
+        : undefined,
       changeFrequency: "weekly" as const,
       priority: 0.4,
     }));
 
-    return [...STATIC_PAGES, ...THEME_PAGES, ...AREA_PAGES, ...AREA_CATEGORY_PAGES, ...rankingPages, ...categoryPages, ...blogPages, ...surveyPages, ...tagPages];
+    return [
+      ...STATIC_PAGES,
+      ...THEME_PAGES,
+      ...AREA_PAGES,
+      ...AREA_CATEGORY_PAGES,
+      ...rankingPages,
+      ...categoryPages,
+      ...blogPages,
+      ...surveyPages,
+      ...tagPages,
+    ];
   } catch {
     // ビルド時に D1 が利用できない場合は静的ページのみ返し、ISR で再生成する
-    return [...STATIC_PAGES, ...THEME_PAGES, ...AREA_PAGES, ...AREA_CATEGORY_PAGES];
+    return [
+      ...STATIC_PAGES,
+      ...THEME_PAGES,
+      ...AREA_PAGES,
+      ...AREA_CATEGORY_PAGES,
+    ];
   }
 }

--- a/apps/web/src/app/sitemap.ts
+++ b/apps/web/src/app/sitemap.ts
@@ -79,9 +79,19 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     // 2026-04-25: sitemap には GSC で実際に Impressions ≥ 1 が出ている ranking のみ載せる。
     // 残りの ranking は middleware で 200 を返し続けるが sitemap で発見させない。
     // 元データ生成: node .claude/scripts/gsc/build-indexable-ranking-keys.cjs
+    //
+    // Phase 9 (2026-04-26): ranking_items は (ranking_key, area_type) 複合主キーのため
+    // 同じ ranking_key が複数 area_type で存在しうる。重複排除しないと sitemap.xml
+    // に同 URL が複数回出現し、Google が soft 404 / 重複コンテンツと判定するリスク。
+    const seenRankingKeys = new Set<string>();
     const rankingPages: MetadataRoute.Sitemap = rankingRows
       .filter((row) => !GONE_RANKING_KEYS.has(row.rankingKey))
       .filter((row) => INDEXABLE_RANKING_KEYS.has(row.rankingKey))
+      .filter((row) => {
+        if (seenRankingKeys.has(row.rankingKey)) return false;
+        seenRankingKeys.add(row.rankingKey);
+        return true;
+      })
       .map((row) => ({
         url: `${BASE_URL}/ranking/${row.rankingKey}`,
         lastModified: row.updatedAt ? new Date(row.updatedAt) : undefined,

--- a/apps/web/src/app/sitemap.xml/route.ts
+++ b/apps/web/src/app/sitemap.xml/route.ts
@@ -1,0 +1,40 @@
+/**
+ * Sitemap Index (/sitemap.xml)
+ *
+ * Phase 9 P2-C (2026-04-26): app/sitemap.ts が generateSitemaps で
+ * /sitemap/<id>.xml を生成するように変更したため、Google が探す
+ * /sitemap.xml を sitemap index として明示的に提供する route handler。
+ *
+ * SEGMENTS の数・順序は app/sitemap.ts の SEGMENTS と完全一致させる。
+ */
+
+import { NextResponse } from "next/server";
+
+// ISR 24h: index 自体は変わらないため。segment 内容は各 sitemap が個別に ISR 管理。
+export const revalidate = 86400;
+
+const BASE_URL = process.env.NEXT_PUBLIC_BASE_URL || "https://stats47.jp";
+
+// app/sitemap.ts の SEGMENTS と一致（追加時は両方を更新）
+const SEGMENT_COUNT = 8;
+
+export async function GET(): Promise<NextResponse> {
+  const sitemaps = Array.from({ length: SEGMENT_COUNT }, (_, id) => id)
+    .map(
+      (id) => `  <sitemap><loc>${BASE_URL}/sitemap/${id}.xml</loc></sitemap>`,
+    )
+    .join("\n");
+
+  const xml = `<?xml version="1.0" encoding="UTF-8"?>
+<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+${sitemaps}
+</sitemapindex>
+`;
+
+  return new NextResponse(xml, {
+    headers: {
+      "Content-Type": "application/xml; charset=utf-8",
+      "Cache-Control": "public, max-age=0, s-maxage=86400, stale-while-revalidate=604800",
+    },
+  });
+}

--- a/apps/web/src/lib/indexable-area-categories.ts
+++ b/apps/web/src/lib/indexable-area-categories.ts
@@ -1,16 +1,13 @@
 /**
- * インデックス対象のエリア×カテゴリ（コンテンツが十分厚い）
- *
- * sitemap.ts と areas/[areaCode]/[slug]/page.tsx で共用。
- * 新カテゴリ追加時はここを更新すること。
- *
- * **2026-04 更新**: クロール予算枯渇対策のため 13 → 2 に削減。47 × 13 = 611 URL が
- * 類似テンプレートとして Google に「クロール済み - インデックス未登録」扱いされていた
- * ため、最もコンテンツが厚い population / economy のみ残す。2-4 週間 GSC を観測して
- * 効果があれば他カテゴリを段階的に追加する。
+ * @deprecated UrlPolicy へ移行済み（Phase 9, 2026-04-26）。
+ * 新規コードは `@/lib/url-policy` の UrlPolicy.area を直接使用してください。
+ * 本ファイルは互換性のために UrlPolicy から再 export しているのみ。
  */
-export const INDEXABLE_AREA_CATEGORIES = ["population", "economy"] as const;
+
+import { INDEXABLE_AREA_CATEGORIES } from "@/lib/url-policy";
+
+export { INDEXABLE_AREA_CATEGORIES };
 
 export const INDEXABLE_AREA_CATEGORIES_SET = new Set<string>(
-  INDEXABLE_AREA_CATEGORIES
+  INDEXABLE_AREA_CATEGORIES,
 );

--- a/apps/web/src/lib/url-policy.ts
+++ b/apps/web/src/lib/url-policy.ts
@@ -1,0 +1,76 @@
+/**
+ * UrlPolicy — URL の取り扱い方針の Single Source of Truth (Phase 9, 2026-04-26)
+ *
+ * middleware / sitemap.ts / page.tsx の **すべて** が本ファイルを参照する。
+ * 個別の `KNOWN_*_KEYS` / `GONE_*_KEYS` / `INDEXABLE_*` を直接 import せず、
+ * UrlPolicy 経由でアクセスすることで「ある URL の判定が複数箇所で乖離する」事故を防ぐ。
+ *
+ * 過去事故（2026-04-26 批判レビュー）:
+ * - middleware は INDEXABLE_AREA_CATEGORIES = [population, economy] 両方を indexable 扱い
+ * - sitemap は population のみに絞り込み
+ * - → /areas/{prefCode}/economy が orphan page（存在するが sitemap で発見できない）
+ *
+ * ルール:
+ * - 削除シグナルは 410（gone() で統一）
+ * - 旧 URL → 新 URL の 301 はリダイレクト先が known の場合のみ
+ *   リダイレクト先が unknown なら直接 410（301→410 チェーン回避）
+ */
+
+import { GONE_BLOG_SLUGS } from "@/config/gone-blog-slugs";
+import { GONE_RANKING_KEYS } from "@/config/gone-ranking-keys";
+import { GONE_TAG_KEYS } from "@/config/gone-tag-keys";
+import { INDEXABLE_RANKING_KEYS } from "@/config/indexable-ranking-keys";
+import { KNOWN_RANKING_KEYS } from "@/config/known-ranking-keys";
+import { KNOWN_TAG_KEYS } from "@/config/known-tag-keys";
+import { KNOWN_THEME_SLUGS } from "@/config/known-theme-slugs";
+
+/**
+ * インデックス対象のエリア×カテゴリ。
+ * middleware（200 で返す）と sitemap（出力する）で完全一致させる。
+ */
+export const INDEXABLE_AREA_CATEGORIES = ["population", "economy"] as const;
+export type IndexableAreaCategory = (typeof INDEXABLE_AREA_CATEGORIES)[number];
+
+const INDEXABLE_AREA_CATEGORIES_SET = new Set<string>(
+  INDEXABLE_AREA_CATEGORIES,
+);
+
+/**
+ * 都道府県コード（01000〜47000）の妥当性判定。
+ * 5 桁数字かつ prefNum 01〜47、末尾 `000` のみ有効。
+ */
+export function isValidPrefCode(code: string): boolean {
+  if (!/^\d{5}$/.test(code)) return false;
+  const prefNum = parseInt(code.slice(0, 2), 10);
+  const suffix = code.slice(2);
+  return prefNum >= 1 && prefNum <= 47 && suffix === "000";
+}
+
+export const UrlPolicy = {
+  area: {
+    indexableCategories: INDEXABLE_AREA_CATEGORIES,
+    isIndexableCategory: (cat: string): boolean =>
+      INDEXABLE_AREA_CATEGORIES_SET.has(cat),
+    isValidPrefCode,
+  },
+  ranking: {
+    isKnown: (key: string): boolean => KNOWN_RANKING_KEYS.has(key),
+    isGone: (key: string): boolean => GONE_RANKING_KEYS.has(key),
+    isIndexable: (key: string): boolean => INDEXABLE_RANKING_KEYS.has(key),
+    /**
+     * sitemap 出力対象判定: 削除済みでなく、かつ Impressions ≥ 1 がある ranking のみ。
+     */
+    shouldIncludeInSitemap: (key: string): boolean =>
+      !GONE_RANKING_KEYS.has(key) && INDEXABLE_RANKING_KEYS.has(key),
+  },
+  tag: {
+    isKnown: (key: string): boolean => KNOWN_TAG_KEYS.has(key),
+    isGone: (key: string): boolean => GONE_TAG_KEYS.has(key),
+  },
+  theme: {
+    isKnown: (slug: string): boolean => KNOWN_THEME_SLUGS.has(slug),
+  },
+  blog: {
+    isGone: (slug: string): boolean => GONE_BLOG_SLUGS.has(slug),
+  },
+} as const;

--- a/apps/web/src/middleware.ts
+++ b/apps/web/src/middleware.ts
@@ -1,22 +1,17 @@
 import { type NextRequest, NextResponse } from "next/server";
 
-import { INDEXABLE_AREA_CATEGORIES_SET } from "@/lib/indexable-area-categories";
+import { UrlPolicy } from "@/lib/url-policy";
 
 import { BLOG_SLUG_REDIRECTS } from "@/config/blog-redirects";
-import { GONE_BLOG_SLUGS } from "@/config/gone-blog-slugs";
-import { GONE_RANKING_KEYS } from "@/config/gone-ranking-keys";
-import { GONE_TAG_KEYS } from "@/config/gone-tag-keys";
-import { KNOWN_RANKING_KEYS } from "@/config/known-ranking-keys";
-import { KNOWN_TAG_KEYS } from "@/config/known-tag-keys";
-import { KNOWN_THEME_SLUGS } from "@/config/known-theme-slugs";
 
 /**
- * 410 Gone 応答。
+ * 410 Gone 応答（CDN cacheable + noindex 強化）。
  *
- * Phase 9 (2026-04-26): no-store を撤廃して CDN キャッシュ可能化。
- * - 旧: no-store, must-revalidate → Google が毎回 origin に再確認 → クロール予算枯渇
- * - 新: public, max-age=86400, s-maxage=604800 → Google が「永続削除」と認識して再確認頻度低下
- * - X-Robots-Tag: noindex を併用して削除シグナル強化
+ * Phase 9 (2026-04-26) で `no-store, must-revalidate` から変更。
+ * - 旧設定では Google が毎回 origin に再確認し、クロール予算を 410 URL 群に吸収させていた
+ * - CDN キャッシュ可能化により Google の再確認頻度が下がり、新コンテンツへ予算が回る
+ * - X-Robots-Tag: noindex も併用して削除シグナル強化
+ *
  * 公式根拠: https://developers.google.com/search/docs/crawling-indexing/http-caching
  */
 function gone(): Response {
@@ -30,20 +25,8 @@ function gone(): Response {
 }
 
 /**
- * 都道府県コード（01000〜47000）の妥当性判定。
- * 5 桁数字かつ prefNum 01〜47、末尾 `000` のみ有効。
- */
-export function isValidPrefCode(code: string): boolean {
-  if (!/^\d{5}$/.test(code)) return false;
-  const prefNum = parseInt(code.slice(0, 2), 10);
-  const suffix = code.slice(2);
-  return prefNum >= 1 && prefNum <= 47 && suffix === "000";
-}
-
-/**
- * 旧URL構造のカテゴリキー一覧
- * /{categoryKey}/{subcategoryKey}/ranking/{rankingKey} や
- * /{categoryKey}/{subcategoryKey}/dashboard/{prefCode} の判定に使用
+ * 旧URL構造のカテゴリキー一覧。
+ * /{cat}/{sub}/dashboard|ranking/{x} などのレガシーパス判定に使用。
  */
 const OLD_CATEGORY_KEYS = new Set([
   "administrativefinancial",
@@ -66,44 +49,48 @@ const OLD_CATEGORY_KEYS = new Set([
 ]);
 
 /**
- * 旧URL → 新URL の 301 リダイレクトを試行する。
- * マッチしなければ null を返す。
+ * `isValidPrefCode` は UrlPolicy から再 export（既存テスト互換のため）。
  */
+export const isValidPrefCode = UrlPolicy.area.isValidPrefCode;
+
+// ============================================================================
+// Section 1: 旧 URL 構造の 301 リダイレクト / 410 Gone
+// ============================================================================
+// Phase 9 (2026-04-26): リダイレクト先が unknown / gone なら 301 ではなく直接 410
+// （301→410 チェーン解消で Google の「壊れたリダイレクト」判定を回避）。
+
 function tryLegacyRedirect(pathname: string, baseUrl: string): Response | null {
   const segments = pathname.split("/").filter(Boolean);
 
   // /{cat}/{sub}/dashboard/{prefCode} → /areas/{prefCode}
   // /{cat}/{sub}/ranking/{rankingKey} → /ranking/{rankingKey}
-  // 無効 prefCode（例 /administrativefinancial/.../dashboard/00000）は 301→410 チェーンを避け直接 410 を返す。
   if (segments.length >= 4 && OLD_CATEGORY_KEYS.has(segments[0])) {
-    const pageType = segments[2]; // "dashboard" or "ranking"
+    const pageType = segments[2];
     const key = segments[3];
     if (pageType === "dashboard" && /^\d{5}$/.test(key)) {
-      if (!isValidPrefCode(key)) return gone();
+      if (!UrlPolicy.area.isValidPrefCode(key)) return gone();
       return NextResponse.redirect(new URL(`/areas/${key}`, baseUrl), { status: 301 });
     }
     if (pageType === "ranking" && key) {
-      if (GONE_RANKING_KEYS.has(key)) return gone();
+      // 301→410 チェーン解消: KNOWN にない or GONE なら直接 410
+      if (UrlPolicy.ranking.isGone(key) || !UrlPolicy.ranking.isKnown(key)) return gone();
       return NextResponse.redirect(new URL(`/ranking/${key}`, baseUrl), { status: 301 });
     }
   }
 
-  // /area-profile/{prefCode}[/...] → /areas/{prefCode}
+  // /area-profile/{prefCode} → /areas/{prefCode}
   if (segments.length >= 2 && segments[0] === "area-profile" && /^\d{5}$/.test(segments[1])) {
-    if (!isValidPrefCode(segments[1])) return gone();
+    if (!UrlPolicy.area.isValidPrefCode(segments[1])) return gone();
     return NextResponse.redirect(new URL(`/areas/${segments[1]}`, baseUrl), { status: 301 });
   }
 
-  // /dashboard/{prefCode}/{cat}/{sub} → /areas/{prefCode}
-  // 旧URL構造のバリアント（セグメント順序が逆のパターン）
+  // /dashboard/{prefCode}/... → /areas/{prefCode}（旧 URL のセグメント順序違いバリアント）
   if (segments.length >= 2 && segments[0] === "dashboard" && /^\d{5}$/.test(segments[1])) {
-    if (!isValidPrefCode(segments[1])) return gone();
+    if (!UrlPolicy.area.isValidPrefCode(segments[1])) return gone();
     return NextResponse.redirect(new URL(`/areas/${segments[1]}`, baseUrl), { status: 301 });
   }
 
-  // 旧URL で 410 Gone を返すパターン:
-  // - /blog/prefecture-rank/...
-  // - /stats/* （配下のルートは全て削除済。サブドメイン storage.stats47.jp は本 middleware 対象外）
+  // 完全廃止のパスは 410 Gone
   if (
     pathname.startsWith("/blog/prefecture-rank/") ||
     pathname.startsWith("/stats/")
@@ -111,20 +98,17 @@ function tryLegacyRedirect(pathname: string, baseUrl: string): Response | null {
     return gone();
   }
 
+  // /{cat}/{sub}[/dashboard|/ranking] → /category/{cat} に集約 301
   if (segments.length >= 2 && segments.length <= 3 && OLD_CATEGORY_KEYS.has(segments[0])) {
-    // /{cat}/{sub} or /{cat}/{sub}/dashboard or /{cat}/{sub}/ranking
-    // → /category/{cat} カテゴリランキング一覧へ 301 リダイレクト
     return NextResponse.redirect(new URL(`/category/${segments[0]}`, baseUrl), { status: 301 });
   }
 
-  // OLD_CATEGORY_KEYS にマッチしない旧URL構造（サブカテゴリ先頭等）
-  // /econohousehold-economy/... のようなパターンに 410 Gone を返す
+  // OLD_CATEGORY_KEYS にマッチしない旧URL構造（subcategory 先頭等）+ dashboard/ranking + prefCode
   if (
     segments.length >= 3 &&
     (segments.includes("dashboard") || segments.includes("ranking"))
   ) {
-    const hasPrefCode = segments.some((s) => /^\d{5}$/.test(s));
-    if (hasPrefCode) {
+    if (segments.some((s) => /^\d{5}$/.test(s))) {
       return gone();
     }
   }
@@ -132,10 +116,143 @@ function tryLegacyRedirect(pathname: string, baseUrl: string): Response | null {
   return null;
 }
 
+// ============================================================================
+// Section 2: コンテンツタイプ別 Allowlist 判定
+// ============================================================================
+// 各コンテンツタイプの未登録 / 削除済 key を 410 化して Google に削除シグナル送信。
+// Phase 9 で Fix 6 / Fix 7 / Fix 9 / 旧 ranking ロジック等の重複を 1 関数に集約。
+
+function checkContentTypePolicy(pathname: string): Response | null {
+  // /ranking/prefecture/{slug} → /ranking/{slug} へ 301（known なら）/ 直接 410（unknown なら）
+  if (pathname.startsWith("/ranking/prefecture/")) {
+    const slug = pathname.slice("/ranking/prefecture/".length).split("/")[0];
+    if (!slug) return gone();
+    // 301→410 チェーン解消: KNOWN にない or GONE なら直接 410
+    if (UrlPolicy.ranking.isGone(slug) || !UrlPolicy.ranking.isKnown(slug)) return gone();
+    return NextResponse.redirect(new URL(`/ranking/${slug}`, "https://stats47.jp"), { status: 301 });
+  }
+
+  // /ranking/{key}: GONE または unknown は 410（一括判定で重複削除）
+  if (pathname.startsWith("/ranking/")) {
+    const rankingKey = pathname.slice("/ranking/".length).split("/")[0];
+    if (rankingKey) {
+      if (UrlPolicy.ranking.isGone(rankingKey) || !UrlPolicy.ranking.isKnown(rankingKey)) {
+        return gone();
+      }
+    }
+  }
+
+  // /tag/{tagKey}: 日本語 tagKey / GONE / 未登録 すべて 410
+  {
+    const directTagMatch = pathname.match(/^\/tag\/([^/]+)\/?$/);
+    if (directTagMatch) {
+      const tagKey = decodeURIComponent(directTagMatch[1]);
+      if (/[^\x00-\x7F]/.test(tagKey)) return gone();
+      if (UrlPolicy.tag.isGone(tagKey) || !UrlPolicy.tag.isKnown(tagKey)) return gone();
+    }
+  }
+
+  // /blog/tags?/{key}: 旧パス完全廃止 → 410
+  if (/^\/blog\/tags?\/.+/.test(pathname)) {
+    return gone();
+  }
+
+  // /blog/{slug}: redirect → 301、GONE → 410、旧カテゴリ名 → 410
+  if (pathname.startsWith("/blog/")) {
+    const slug = pathname.slice("/blog/".length).split("/")[0];
+    if (slug) {
+      const newSlug = BLOG_SLUG_REDIRECTS[slug];
+      if (newSlug) {
+        return NextResponse.redirect(
+          new URL(`/blog/${newSlug}`, "https://stats47.jp"),
+          { status: 301 },
+        );
+      }
+      if (UrlPolicy.blog.isGone(slug)) return gone();
+      // 旧カテゴリ名が blog slug として解釈されるパターン
+      if (OLD_CATEGORY_KEYS.has(slug)) return gone();
+    }
+  }
+
+  // /correlation/{slug}: 存在しないルート → 410（query 版 /correlation?x=... のみ有効）
+  if (pathname.startsWith("/correlation/")) {
+    return gone();
+  }
+
+  // /dashboard/* (legacy redirect でカバーされない亜種を捕捉)
+  if (pathname.startsWith("/dashboard") || pathname.includes("/dashboard/")) {
+    return gone();
+  }
+
+  // /themes/{unknown-slug} → 410
+  if (pathname.startsWith("/themes/")) {
+    const slug = pathname.slice("/themes/".length).split("/")[0];
+    if (slug && !UrlPolicy.theme.isKnown(slug)) {
+      return gone();
+    }
+  }
+
+  return null;
+}
+
+// ============================================================================
+// Section 3: /areas/* の判定（無効 prefCode / cities / 非 indexable category）
+// ============================================================================
+
+function checkAreasPolicy(pathname: string): Response | null {
+  const seg = pathname.split("/").filter(Boolean);
+  if (seg[0] !== "areas") return null;
+
+  // /areas/{無効5桁コード}: cities セグメント以外は 410
+  if (seg.length >= 2 && seg[1] !== "cities") {
+    if (/^\d{5}$/.test(seg[1]) && !UrlPolicy.area.isValidPrefCode(seg[1])) {
+      return gone();
+    }
+  }
+
+  // /areas/{prefCode}/cities/{cityCode}[/...] → 410（市区町村ページは廃止）
+  if (
+    seg.length >= 4 &&
+    seg[2] === "cities" &&
+    /^\d{5}$/.test(seg[3])
+  ) {
+    return gone();
+  }
+
+  // /areas/{prefCode}/{5桁数字} → 410（cityCode が areaCode 直下にきた異常パターン）
+  if (
+    seg.length >= 3 &&
+    seg[1] !== "cities" &&
+    /^\d{5}$/.test(seg[2]) &&
+    seg[2] !== seg[1]
+  ) {
+    return gone();
+  }
+
+  // /areas/{prefCode}/{non-indexable-category} → 410
+  // INDEXABLE_AREA_CATEGORIES = [population, economy] のみ通す
+  if (
+    seg.length >= 3 &&
+    /^\d{5}$/.test(seg[1]) &&
+    UrlPolicy.area.isValidPrefCode(seg[1]) &&
+    seg[2] !== "cities" &&
+    !/^\d{5}$/.test(seg[2]) &&
+    !UrlPolicy.area.isIndexableCategory(seg[2])
+  ) {
+    return gone();
+  }
+
+  return null;
+}
+
+// ============================================================================
+// Middleware Entry Point
+// ============================================================================
+
 export default function middleware(req: NextRequest) {
   const { pathname } = req.nextUrl;
 
-  // --- www → 非www リダイレクト（301 Permanent） ---
+  // --- ホスト正規化: www → 非 www（301）---
   const host = req.headers.get("host") || "";
   if (host.startsWith("www.")) {
     const url = new URL(pathname, "https://stats47.jp");
@@ -143,228 +260,57 @@ export default function middleware(req: NextRequest) {
     return NextResponse.redirect(url, { status: 301 });
   }
 
-  // --- Trailing slash の正規化（301 Permanent） ---
+  // --- Trailing slash 正規化（301）---
   if (pathname !== "/" && pathname.endsWith("/")) {
     const url = new URL(pathname.slice(0, -1), req.url);
     url.search = req.nextUrl.search;
     return NextResponse.redirect(url, { status: 301 });
   }
 
-  // --- /blog/tags/{tagKey} or /blog/tag/{tagKey} → 410 Gone ---
-  // 旧パスは全て廃止。現行は /tag/{tagKey} のみ。
-  // 301 リダイレクトするとリダイレクト先が 404 のケース（記事0件タグ）で
-  // Google に「壊れたリダイレクト」と判定されるため、全て 410 で統一。
-  {
-    const tagMatch = pathname.match(/^\/blog\/tags?\/(.+)$/);
-    if (tagMatch) {
-      return gone();
-    }
-  }
+  // --- Section 2: コンテンツタイプ別 Allowlist 判定 ---
+  const contentResponse = checkContentTypePolicy(pathname);
+  if (contentResponse) return contentResponse;
 
-  // --- Fix 9: /tag/{tagKey} 直接アクセスのうち廃止済み or 未登録を 410 Gone ---
-  // 判定順:
-  //   1. 日本語 tagKey（現行は英語 slug のみ有効）→ 410
-  //   2. GONE_TAG_KEYS に登録済みの廃止英語 slug → 410
-  //   3. KNOWN_TAG_KEYS に存在しない英語 slug → 410（DB に無いタグは notFound になるため事前に 410 化）
-  // KNOWN_TAG_KEYS は git commit された静的 Set（tags テーブル全件）。Ranking Fix 6 と同じ allowlist 設計。
-  // page.tsx は触らない（SSG は従来どおり）。
-  {
-    const directTagMatch = pathname.match(/^\/tag\/([^/]+)\/?$/);
-    if (directTagMatch) {
-      const tagKey = decodeURIComponent(directTagMatch[1]);
-      if (/[^\x00-\x7F]/.test(tagKey)) return gone();
-      if (GONE_TAG_KEYS.has(tagKey)) return gone();
-      if (!KNOWN_TAG_KEYS.has(tagKey)) return gone();
-    }
-  }
-
-  // --- ブログ slug 変更の 301 リダイレクト / 完全削除 slug の 410 ---
-  if (pathname.startsWith("/blog/")) {
-    const slug = pathname.slice("/blog/".length).split("/")[0];
-    const newSlug = BLOG_SLUG_REDIRECTS[slug];
-    if (newSlug) {
-      return NextResponse.redirect(new URL(`/blog/${newSlug}`, req.url), {
-        status: 301,
-      });
-    }
-    if (GONE_BLOG_SLUGS.has(slug)) {
-      return gone();
-    }
-  }
-
-  // --- /ranking/prefecture/{slug} → /ranking/{slug} リダイレクト or 410 ---
-  // 旧 URL 構造 /ranking/prefecture/xxx は Next.js の /ranking/[rankingKey] 単一セグメントに
-  // 一致せず 404 を返していた。GONE_RANKING_KEYS に該当すれば 410、それ以外は 301 で新 URL へ。
-  if (pathname.startsWith("/ranking/prefecture/")) {
-    const slug = pathname.slice("/ranking/prefecture/".length).split("/")[0];
-    if (!slug) return gone();
-    if (GONE_RANKING_KEYS.has(slug)) return gone();
-    return NextResponse.redirect(new URL(`/ranking/${slug}`, req.url), { status: 301 });
-  }
-
-  // --- 削除済みランキングキーへの直接アクセス → 410 Gone ---
-  if (pathname.startsWith("/ranking/")) {
-    const rankingKey = pathname.slice("/ranking/".length);
-    if (GONE_RANKING_KEYS.has(rankingKey)) {
-      return gone();
-    }
-  }
-
-  // --- Fix 6: 未知の ranking キー → 410 Gone（v3: middleware-only 設計）---
-  // 2026-04 GSC 調査で `/ranking/任意キー` が常に 200 を返す問題を確認（クロール済み未登録 2,415 の主因）。
-  // KNOWN_RANKING_KEYS は git commit された静的 Set（1,899 件）。GONE でも KNOWN でもないキーは
-  // 過去存在したことがない or まだ登録されていないキー → Google に「完全削除」シグナル（410）を送る。
-  //
-  // v1 (d30094c1) と v2 (73b1277b) は page.tsx の dynamicParams=false を併用したが、
-  // CI ビルド環境で D1 binding が無く全ページ SSG が notFound 化してサイト崩壊 (revert 0ba2b163)。
-  // v3 は page.tsx に触らず middleware だけで対応する設計。
-  //
-  // 注意: `/ranking` (index) や `/ranking/{key}/{sub}` サブパスは対象外。
-  //       split("/")[0] で最初のセグメントのみ判定。
-  if (pathname.startsWith("/ranking/")) {
-    const rankingKey = pathname.slice("/ranking/".length).split("/")[0];
-    if (rankingKey && !KNOWN_RANKING_KEYS.has(rankingKey) && !GONE_RANKING_KEYS.has(rankingKey)) {
-      return gone();
-    }
-  }
-
-  // --- Fix 1: /correlation/{slug} → 410 Gone ---
-  // correlation ページは /correlation?x=...&y=... で動作。/correlation/xxx-and-yyy は存在しないルート。
-  // Google がクロールして 5xx（タイムアウト）を返していた。
-  if (pathname.startsWith("/correlation/")) {
-    return gone();
-  }
-
-  // --- Fix 2: /dashboard/* → 410 Gone ---
-  // 旧 URL 構造の亜種。tryLegacyRedirect がカバーしない /dashboard/00000/* 等を捕捉。
-  if (pathname.startsWith("/dashboard") || pathname.includes("/dashboard/")) {
-    return gone();
-  }
-
-  // --- Fix 4: /areas/{無効コード} → 410 Gone ---
-  // /areas/00000, /areas/14100 等の無効な都道府県コードが soft 404 を発生させていた。
-  {
-    const areaSegments = pathname.split("/").filter(Boolean);
-    if (areaSegments[0] === "areas" && areaSegments.length >= 2 && areaSegments[1] !== "cities") {
-      const code = areaSegments[1];
-      if (/^\d{5}$/.test(code) && !isValidPrefCode(code)) {
-        return gone();
-      }
-    }
-  }
-
-  // --- Fix 4.5: /areas/{prefCode}/cities/{cityCode}[/...] → 410 Gone ---
-  // 2026-04 GSC 調査で `/areas/13000/cities/13101` が 500、`/areas/11000/cities/11101` が 200
-  // と挙動不一致を確認。robots.txt ブロック済みだが middleware で明示的に 410 を返して
-  // Google に「完全に削除」シグナルを送る。既存の L231-245 は旧 URL 構造（cities セグメントなし）
-  // 用のため、cities セグメントありのパターンは別途処理が必要だった。
-  {
-    const areaSegments = pathname.split("/").filter(Boolean);
-    if (
-      areaSegments.length >= 4 &&
-      areaSegments[0] === "areas" &&
-      areaSegments[2] === "cities" &&
-      /^\d{5}$/.test(areaSegments[3])
-    ) {
-      return gone();
-    }
-  }
-
-  // --- Fix 5: /blog/{旧カテゴリ名} → 410 Gone ---
-  // /blog/construction, /blog/socialsecurity 等がブログスラッグとして解釈され soft 404。
-  if (pathname.startsWith("/blog/")) {
-    const blogSlug = pathname.slice("/blog/".length).split("/")[0];
-    if (OLD_CATEGORY_KEYS.has(blogSlug)) {
-      return gone();
-    }
-  }
-
-  // --- 旧URL構造の 301 リダイレクト / 410 Gone ---
+  // --- Section 1: 旧 URL 構造の 301/410 ---
   const legacyResponse = tryLegacyRedirect(pathname, req.url);
   if (legacyResponse) return legacyResponse;
 
-  // --- 市区町村 URL → 410 Gone ---
-  // /areas/{areaCode}/{5桁cityCode}[/...] は市区町村ページ。robots.txt でブロック済みのため
-  // 301 リダイレクトではなく 410 Gone を返す（リダイレクト先がブロック済みだと GSC で二重問題になる）
-  {
-    const areaSegments = pathname.split("/").filter(Boolean);
-    if (
-      areaSegments.length >= 3 &&
-      areaSegments[0] === "areas" &&
-      areaSegments[1] !== "cities" &&
-      /^\d{5}$/.test(areaSegments[2]) &&
-      areaSegments[2] !== areaSegments[1] // cityCode !== areaCode（自分自身ではない）
-    ) {
-      return gone();
-    }
-  }
+  // --- Section 3: /areas/* の判定 ---
+  const areasResponse = checkAreasPolicy(pathname);
+  if (areasResponse) return areasResponse;
 
-  // --- Fix 7: /themes/{unknown-slug} → 410 Gone ---
-  // /themes/ 配下は静的に ALL_THEMES で定義された 16 slug のみ。動的ルート [themeSlug]/
-  // は page.tsx を持たず notFound（404）を返すが、middleware で 410 を返して
-  // Google に「完全削除」シグナルを送る。
-  if (pathname.startsWith("/themes/")) {
-    const slug = pathname.slice("/themes/".length).split("/")[0];
-    if (slug && !KNOWN_THEME_SLUGS.has(slug)) {
-      return gone();
-    }
-  }
-
-  // --- Fix 8: /areas/{prefCode}/{non-indexable-category} → 410 Gone ---
-  // 2026-04 に INDEXABLE_AREA_CATEGORIES を 13 → 2（population / economy）に削減した。
-  // 47 × 11 = 517 URL が「クロール済み - インデックス未登録」に残っているため、
-  // /areas/{prefCode}/{削除済みカテゴリ} を明示的に 410 化する。
-  // 既存の city-code 410（seg[2] が 5 桁数字）と cities 410 はそれぞれ先に処理されるので、
-  // ここでは数字 5 桁・cities・indexable カテゴリを除外した残りの sub を対象とする。
-  {
-    const seg = pathname.split("/").filter(Boolean);
-    if (
-      seg.length >= 3 &&
-      seg[0] === "areas" &&
-      /^\d{5}$/.test(seg[1]) &&
-      isValidPrefCode(seg[1]) &&
-      seg[2] !== "cities" &&
-      !/^\d{5}$/.test(seg[2]) &&
-      !INDEXABLE_AREA_CATEGORIES_SET.has(seg[2])
-    ) {
-      return gone();
-    }
-  }
-
-  // --- カテゴリ URL リダイレクト ---
+  // --- 既存ルートへの query → path 正規化 301 ---
   // /{categoryKey} → /category/{categoryKey}
   {
     const segments = pathname.split("/").filter(Boolean);
     if (segments.length === 1 && OLD_CATEGORY_KEYS.has(segments[0])) {
-      return NextResponse.redirect(new URL(`/category/${segments[0]}`, req.url), { status: 301 });
+      return NextResponse.redirect(
+        new URL(`/category/${segments[0]}`, req.url),
+        { status: 301 },
+      );
     }
   }
 
-  // /areas/{areaCode}?category={key} → /areas/{areaCode}/{key} へ 301 リダイレクト
+  // /areas/{areaCode}?category={key} → /areas/{areaCode}/{key}
   if (pathname.startsWith("/areas/") && req.nextUrl.searchParams.has("category")) {
     const pathSegments = pathname.split("/").filter(Boolean);
-    // /areas/{areaCode} or /areas/{areaCode}/{cityCode} のパターンに対応
     if (pathSegments.length >= 2) {
       const categoryKey = req.nextUrl.searchParams.get("category");
       if (categoryKey) {
         const newUrl = new URL(`${pathname}/${categoryKey}`, req.url);
-        // ranking パラメータは維持
         const ranking = req.nextUrl.searchParams.get("ranking");
-        if (ranking) {
-          newUrl.searchParams.set("ranking", ranking);
-        }
+        if (ranking) newUrl.searchParams.set("ranking", ranking);
         return NextResponse.redirect(newUrl, { status: 301 });
       }
     }
   }
 
-  // /ranking?subcategory=xxx → /ranking へ 301 リダイレクト（旧URL互換）
+  // /ranking?subcategory=... → /ranking
   if (pathname === "/ranking" && req.nextUrl.searchParams.has("subcategory")) {
-    const url = new URL("/ranking", req.url);
-    return NextResponse.redirect(url, { status: 301 });
+    return NextResponse.redirect(new URL("/ranking", req.url), { status: 301 });
   }
 
-  // /blog?q=xxx 等 → /search?type=blog&... へ 301 リダイレクト
+  // /blog?q=... → /search?type=blog&...
   if (pathname === "/blog") {
     const sp = req.nextUrl.searchParams;
     const blogParamKeys = ["q", "tags", "year", "month"];
@@ -379,26 +325,22 @@ export default function middleware(req: NextRequest) {
     }
   }
 
-  // パス名ヘッダーの追加
+  // パス名ヘッダーの追加（page.tsx 側で利用）
   const requestHeaders = new Headers(req.headers);
   requestHeaders.set("x-pathname", pathname);
 
   return NextResponse.next({
-    request: {
-      headers: requestHeaders,
-    },
+    request: { headers: requestHeaders },
   });
 }
 
 export const config = {
   matcher: [
     /*
-     * すべてのパスにマッチするが、以下を除外:
-     * - _next/static (静的ファイル)
-     * - _next/image (画像最適化ファイル)
-     * - favicon.ico (ファビコン)
-     * - static assets
+     * すべてのパスにマッチ。除外:
+     * - _next/static / _next/image / favicon / 静的アセット
+     * - api/ ルート（middleware を通す必要なし、Phase 9 で明示）
      */
-    "/((?!_next/static|_next/image|favicon.ico|.*\\.(?:svg|png|jpg|jpeg|gif|webp|ico)).*)",
+    "/((?!_next/static|_next/image|api/|favicon.ico|.*\\.(?:svg|png|jpg|jpeg|gif|webp|ico)).*)",
   ],
 };

--- a/apps/web/src/middleware.ts
+++ b/apps/web/src/middleware.ts
@@ -11,13 +11,21 @@ import { KNOWN_TAG_KEYS } from "@/config/known-tag-keys";
 import { KNOWN_THEME_SLUGS } from "@/config/known-theme-slugs";
 
 /**
- * 410 Gone 応答。Cloudflare エッジやブラウザでキャッシュされないよう no-store を付与する。
- * Cloudflare Cache Rule が 4xx を誤ってキャッシュしても middleware 側で防ぐ defense in depth。
+ * 410 Gone 応答。
+ *
+ * Phase 9 (2026-04-26): no-store を撤廃して CDN キャッシュ可能化。
+ * - 旧: no-store, must-revalidate → Google が毎回 origin に再確認 → クロール予算枯渇
+ * - 新: public, max-age=86400, s-maxage=604800 → Google が「永続削除」と認識して再確認頻度低下
+ * - X-Robots-Tag: noindex を併用して削除シグナル強化
+ * 公式根拠: https://developers.google.com/search/docs/crawling-indexing/http-caching
  */
 function gone(): Response {
   return new Response(null, {
     status: 410,
-    headers: { "Cache-Control": "no-store, must-revalidate" },
+    headers: {
+      "Cache-Control": "public, max-age=86400, s-maxage=604800",
+      "X-Robots-Tag": "noindex",
+    },
   });
 }
 

--- a/apps/web/src/middleware.ts
+++ b/apps/web/src/middleware.ts
@@ -329,9 +329,23 @@ export default function middleware(req: NextRequest) {
   const requestHeaders = new Headers(req.headers);
   requestHeaders.set("x-pathname", pathname);
 
-  return NextResponse.next({
+  const response = NextResponse.next({
     request: { headers: requestHeaders },
   });
+
+  // Phase 9 P2-B (2026-04-26): Vary ヘッダ最小化
+  // Next.js は RSC 用に `Vary: RSC, Next-Router-State-Tree, Next-Router-Prefetch,
+  // Next-Router-Segment-Prefetch` を全レスポンスに付与する。
+  // Google は `Vary: Accept-Encoding` 以外を無視する仕様だが、Cloudflare 等の CDN は
+  // Vary ヘッダごとにキャッシュ variant を保持するため、不要な Vary はキャッシュ効率を悪化させる。
+  // RSC navigation は req に `RSC: 1` ヘッダが付くのでその場合のみ Next.js デフォルトを尊重し、
+  // 通常リクエスト（Googlebot / 初回 HTML 取得）は Accept-Encoding のみに固定する。
+  const isRscRequest = req.headers.get("RSC") === "1";
+  if (!isRscRequest) {
+    response.headers.set("Vary", "Accept-Encoding");
+  }
+
+  return response;
 }
 
 export const config = {


### PR DESCRIPTION
## Summary

GSC 改善が 9 個の Fix 累積で設計の整合性を失い、Google から「設計が定まっていないサイト」と判定されていた問題への対処。批判レビューの指摘を反映し、middleware + sitemap をゼロベースで再構築。

4 commit で段階的 revert 可能に分離（P0 / P1 / P2-A / P2-B+C）。

### Phase 9 P0: 即効施策 (b4b7a31c)
- `gone()` を `no-store, must-revalidate` → `public, max-age=86400, s-maxage=604800` + `X-Robots-Tag: noindex`
- sitemap.xml の重複 URL（manufacturing-net-value-added-private 等 3 件）を `seenRankingKeys` で排除

### Phase 9 P1: 設計整合性回復 (bb4303e9)
- **UrlPolicy データ層を新設** (`apps/web/src/lib/url-policy.ts`) — middleware / sitemap / page.tsx の Single Source of Truth
- middleware を 9 個の Fix 累積から 4 セクション構造へ整理
- **301→410 チェーン解消**: KNOWN にない / GONE な ranking key は 301 を経由せず直接 410
- **lastmod 信頼性回復**: ranking 削除 / blog は published_at 固定 / tag は集計 / その他省略
- middleware matcher に `api/` 除外を明示

### Phase 9 P2-A: KNOWN_*_KEYS 自動同期 (4dec30e5)
- `.github/workflows/sync-known-keys.yml` を新規追加
- 毎日 JST 07:00 に remote D1 から再生成 → 差分があれば PR 自動起票
- 必要 secrets: `CLOUDFLARE_API_TOKEN` / `CLOUDFLARE_ACCOUNT_ID`

### Phase 9 P2-B + P2-C: Vary 最小化 + sitemap index 化 (0ec26659)
- **P2-B**: middleware で RSC 以外のリクエストの Vary を `Accept-Encoding` のみに固定
  - Next.js が並べる `RSC, Next-Router-State-Tree, ...` を Cloudflare キャッシュから排除（Google は Vary: Accept-Encoding 以外を無視）
  - RSC navigation (`req.headers.RSC === '1'`) は Next.js デフォルト維持
- **P2-C**: `/sitemap.xml` を sitemap index 化、8 segment に分割
  - `/sitemap.xml` = sitemapindex (新 route handler)
  - `/sitemap/{0..7}.xml` = static / themes / areas / ranking / blog / categories / surveys / tags
  - 各 segment が独立 ISR、巨大な ranking 取得が他に波及しない
  - GSC で各 segment を個別 submit すれば「どこが詰まっているか」が見える
  - robots.txt は引き続き `/sitemap.xml` を指す（変更不要）

## Test plan

### ビルド・型チェック・テスト
- [x] `npx tsc --noEmit -p apps/web/tsconfig.json` 通過
- [x] `npx vitest run` 全 340 テスト通過（4 commit 後も維持）
- [x] `npx next build` 成功（`/sitemap.xml` (static) + `/sitemap/[__metadata_id__]` (segments) 共存確認）
- [x] sitemap index XML 生成内容確認（8 segment 全て参照）

### デプロイ後の本番検証（develop → main マージ後）
- [ ] `curl -sI https://stats47.jp/dashboard/13000 | grep -i "cache-control\|x-robots"` で `Cache-Control: public, max-age=86400` / `X-Robots-Tag: noindex`
- [ ] `curl -sI https://stats47.jp/ | grep -i "vary"` で `Vary: Accept-Encoding` のみ
- [ ] `curl -s https://stats47.jp/sitemap.xml | head -15` で sitemapindex XML 確認
- [ ] `curl -s https://stats47.jp/sitemap/3.xml | grep -c "<loc>"` で ranking segment 件数確認
- [ ] `curl -s -L -o /dev/null -w "%{http_code} hops:%{num_redirects}\n" https://stats47.jp/ranking/prefecture/non-existent-key` で `410 hops:0`
- [ ] URL Inspection API（既存 daily workflow）の `coverageState` 別件数推移を 1 週間トラッキング

### Rollback 戦略
4 commit が独立しているため段階的 revert 可能:
| 状況 | revert 対象 |
|---|---|
| Cache-Control 変更で逆に問題 | b4b7a31c |
| UrlPolicy 統一で SSR 壊れた | bb4303e9 |
| sync workflow に問題 | 4dec30e5 |
| Vary / sitemap index で問題 | 0ec26659 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)