### PR TITLE
fix(ci): sync-known-keys.yml の YAML indentation エラー修正

### DIFF
--- a/.github/workflows/sync-known-keys.yml
+++ b/.github/workflows/sync-known-keys.yml
@@ -88,17 +88,21 @@ jobs:
           git add apps/web/src/config/known-ranking-keys.ts apps/web/src/config/known-tag-keys.ts
           git commit -m "chore(seo): sync KNOWN_*_KEYS from remote D1 (${{ steps.date.outputs.date }})"
           git push origin "$BRANCH"
+          PR_BODY=$(cat <<EOF
+          Automated daily sync of \`KNOWN_RANKING_KEYS\` / \`KNOWN_TAG_KEYS\` from remote D1.
+
+          Phase 9 P2-A: prevent middleware Allowlist from going stale (was 28 days old as of 2026-04-26).
+
+          Diff source: \`apps/web/scripts/generate-known-{ranking,tag}-keys.ts\` against remote D1 production state.
+
+          ⚠ Review the diff carefully — accidental removals would cause real pages to 410.
+          EOF
+          )
           gh pr create \
             --base develop \
             --head "$BRANCH" \
             --title "chore(seo): sync KNOWN_*_KEYS (${{ steps.date.outputs.date }})" \
-            --body "Automated daily sync of \`KNOWN_RANKING_KEYS\` / \`KNOWN_TAG_KEYS\` from remote D1.
-
-Phase 9 P2-A: prevent middleware Allowlist from going stale (was 28 days old as of 2026-04-26).
-
-Diff source: \`apps/web/scripts/generate-known-{ranking,tag}-keys.ts\` against remote D1 production state.
-
-⚠ Review the diff carefully — accidental removals would cause real pages to 410."
+            --body "$PR_BODY"
 
       - name: 📄 Step Summary
         if: always()


### PR DESCRIPTION
Phase 9 P2-A workflow が直前のデプロイ後に「This run likely failed because of a workflow file issue」で失敗していた件の hotfix。

PR body の multiline string が column 1 から始まり YAML `run: |` block を破壊していたのが原因。bash heredoc に置き換えて解消。

```bash
python3 -c "import yaml; yaml.safe_load(open('.github/workflows/sync-known-keys.yml')); print('YAML OK')"
# YAML OK
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)