### PR TITLE
fix(ci): sync-known-keys を remote D1 直接クエリに変更

### DIFF
--- a/.github/workflows/sync-known-keys.yml
+++ b/.github/workflows/sync-known-keys.yml
@@ -47,19 +47,13 @@ jobs:
       - name: 📦 Install dependencies
         run: npm ci
 
-      - name: 📥 Pull remote D1 (ranking/tag のみ最小同期)
+      - name: 🔧 Regenerate KNOWN_*_KEYS from remote D1
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
         run: |
-          npm run pull:d1 --workspace=packages/database -- --table ranking_items
-          npm run pull:d1 --workspace=packages/database -- --table article_tags
-
-      - name: 🔧 Regenerate KNOWN_*_KEYS
-        run: |
           cd apps/web
-          npx tsx scripts/generate-known-ranking-keys.ts
-          npx tsx scripts/generate-known-tag-keys.ts
+          npx tsx scripts/sync-known-keys-from-remote.ts
 
       - name: 📅 Resolve date
         id: date

--- a/apps/web/scripts/sync-known-keys-from-remote.ts
+++ b/apps/web/scripts/sync-known-keys-from-remote.ts
@@ -1,0 +1,108 @@
+/**
+ * known-{ranking,tag}-keys.ts を remote D1 から直接生成する CI 用スクリプト。
+ *
+ * 既存の generate-known-*-keys.ts はローカル D1 (better-sqlite3) を読むため、
+ * CI 環境では `.local/d1/...` ディレクトリが存在せず動かない。本スクリプトは
+ * `wrangler d1 execute --remote --json` で直接 remote D1 を叩くため、CI でも動作する。
+ *
+ * 使い方:
+ *   cd apps/web && npx tsx scripts/sync-known-keys-from-remote.ts
+ *
+ * 環境変数:
+ *   CLOUDFLARE_API_TOKEN  — D1 Read 権限の token
+ *   CLOUDFLARE_ACCOUNT_ID — stats47 アカウント
+ *
+ * 出力:
+ *   apps/web/src/config/known-ranking-keys.ts
+ *   apps/web/src/config/known-tag-keys.ts
+ */
+
+import { execFileSync } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+
+const RANKING_QUERY =
+  "SELECT DISTINCT ranking_key FROM ranking_items WHERE is_active = 1 AND area_type = 'prefecture' ORDER BY ranking_key";
+const TAG_QUERY = "SELECT tag_key FROM tags ORDER BY tag_key";
+
+const RANKING_OUT = path.resolve(
+  __dirname,
+  "../src/config/known-ranking-keys.ts",
+);
+const TAG_OUT = path.resolve(__dirname, "../src/config/known-tag-keys.ts");
+
+function queryRemote<T>(sql: string): T[] {
+  const out = execFileSync(
+    "npx",
+    [
+      "wrangler",
+      "d1",
+      "execute",
+      "stats47_static",
+      "--remote",
+      "--env",
+      "production",
+      "--json",
+      "--command",
+      sql,
+    ],
+    { encoding: "utf-8", maxBuffer: 64 * 1024 * 1024 },
+  );
+
+  // wrangler --json 出力形式: [{ results: [...], success: true, ... }]
+  const parsed = JSON.parse(out);
+  const result = Array.isArray(parsed) ? parsed[0] : parsed;
+  if (!result?.results) {
+    throw new Error(`Unexpected wrangler output: ${out.slice(0, 500)}`);
+  }
+  return result.results as T[];
+}
+
+function writeKnownKeys(
+  outPath: string,
+  exportName: string,
+  description: string,
+  keys: string[],
+): void {
+  const today = new Date().toISOString().slice(0, 10);
+  const header = `/**
+ * ${description}
+ *
+ * **このファイルは自動生成されます。手動編集しないこと。**
+ *
+ * 更新方法:
+ *   - 手動: \`cd apps/web && npx tsx scripts/sync-known-keys-from-remote.ts\`
+ *   - 自動: GitHub Actions \`.github/workflows/sync-known-keys.yml\` (毎日 JST 07:00)
+ *
+ * 最終生成日: ${today}
+ * 件数: ${keys.length}
+ */
+export const ${exportName}: ReadonlySet<string> = new Set([
+`;
+  const body = keys.map((k) => `  ${JSON.stringify(k)},`).join("\n");
+  const footer = `\n]);\n`;
+  fs.writeFileSync(outPath, header + body + footer, "utf-8");
+  console.log(`[sync-known-keys] wrote ${keys.length} keys to ${outPath}`);
+}
+
+function main(): void {
+  console.log("[sync-known-keys] querying remote D1 (ranking)...");
+  const rankingRows = queryRemote<{ ranking_key: string }>(RANKING_QUERY);
+  writeKnownKeys(
+    RANKING_OUT,
+    "KNOWN_RANKING_KEYS",
+    "有効な ranking キー一覧（prefecture, is_active = 1）",
+    rankingRows.map((r) => r.ranking_key),
+  );
+
+  console.log("[sync-known-keys] querying remote D1 (tag)...");
+  const tagRows = queryRemote<{ tag_key: string }>(TAG_QUERY);
+  writeKnownKeys(
+    TAG_OUT,
+    "KNOWN_TAG_KEYS",
+    "有効な tag キー一覧（tags テーブル全件）",
+    tagRows.map((r) => r.tag_key),
+  );
+}
+
+main();


### PR DESCRIPTION
Phase 9 P2-A workflow 第 2 弾 hotfix。

**問題**: pull:d1 が CI で動かない
- `pull-remote-d1.ts` は better-sqlite3 でローカル `.local/d1/v3/d1/miniflare-D1DatabaseObject/<hash>.sqlite` を開く
- CI 環境にはこのディレクトリが存在しない → \`TypeError: Cannot open database because the directory does not exist\`
- ディレクトリを mkdir しても schema が無いので空 DB に INSERT できず破綻

**修正**: remote D1 を直接クエリ
- `apps/web/scripts/sync-known-keys-from-remote.ts` 新設
- `wrangler d1 execute --remote --json` で remote から直接 SELECT
- ローカル D1 を介さないため CI で動作

**要件**:
- `CLOUDFLARE_API_TOKEN` secret に D1 Read 権限が必要
- 現状の secret（.env.local 由来）は account-level ログイン可能だが D1 query で 7403
- CI 用に新規最小権限 token 発行必要

🤖 Generated with [Claude Code](https://claude.com/claude-code)