### PR TITLE
chore(seo): sync KNOWN_*_KEYS (2026-04-26)

### DIFF
--- a/apps/web/src/config/known-ranking-keys.ts
+++ b/apps/web/src/config/known-ranking-keys.ts
@@ -3,14 +3,11 @@
  *
  * **このファイルは自動生成されます。手動編集しないこと。**
  *
- * middleware.ts の Fix 6 が参照する。CI ビルド環境では D1 binding が使えないため、
- * 静的ファイルとして git commit する。page.tsx は触らない（SSG は従来どおり）。
+ * 更新方法:
+ *   - 手動: `cd apps/web && npx tsx scripts/sync-known-keys-from-remote.ts`
+ *   - 自動: GitHub Actions `.github/workflows/sync-known-keys.yml` (毎日 JST 07:00)
  *
- * 更新方法: `/generate-known-ranking-keys` スキル or
- *           `cd apps/web && npx tsx scripts/generate-known-ranking-keys.ts`
- * 更新タイミング: /register-ranking 実行後。必ず git commit してからデプロイ。
- *
- * 最終生成日: 2026-04-25
+ * 最終生成日: 2026-04-26
  * 件数: 1920
  */
 export const KNOWN_RANKING_KEYS: ReadonlySet<string> = new Set([

--- a/apps/web/src/config/known-tag-keys.ts
+++ b/apps/web/src/config/known-tag-keys.ts
@@ -3,13 +3,11 @@
  *
  * **このファイルは自動生成されます。手動編集しないこと。**
  *
- * middleware.ts の Fix 9 が参照する。CI ビルド環境では D1 binding が使えないため、
- * 静的ファイルとして git commit する。page.tsx は触らない（SSG は従来どおり）。
+ * 更新方法:
+ *   - 手動: `cd apps/web && npx tsx scripts/sync-known-keys-from-remote.ts`
+ *   - 自動: GitHub Actions `.github/workflows/sync-known-keys.yml` (毎日 JST 07:00)
  *
- * 更新方法: `cd apps/web && npx tsx scripts/generate-known-tag-keys.ts`
- * 更新タイミング: tags テーブルに新規 tag を追加した後。必ず git commit してからデプロイ。
- *
- * 最終生成日: 2026-04-25
+ * 最終生成日: 2026-04-26
  * 件数: 327
  */
 export const KNOWN_TAG_KEYS: ReadonlySet<string> = new Set([


### PR DESCRIPTION
Phase 9 P2-A workflow 初回成功による自動 sync。

**diff 内容**: 
- 件数変化なし（ranking 1920 / tag 同数）
- ヘッダ文言のみ更新: 旧 Fix 6 / Fix 9 への参照削除、新 sync-known-keys-from-remote.ts への参照追加

**検証フロー**:
1. workflow が remote D1 から query 成功 ✅
2. diff 検出 ✅
3. 自動 PR 作成（permission 設定後の手動投入）

🤖 Generated by GitHub Actions sync-known-keys workflow