### PR TITLE
fix(test): smoke-test を Phase 9 後の area category 410 仕様に追従

### DIFF
--- a/apps/web/scripts/smoke-test.ts
+++ b/apps/web/scripts/smoke-test.ts
@@ -45,8 +45,8 @@ const testCases: SmokeTestCase[] = [
     expectedTexts: ["北海道"],
   },
   {
-    name: "都道府県ダッシュボード（北海道・気象）",
-    path: "/areas/01000/landweather",
+    name: "都道府県ダッシュボード（北海道・人口）",
+    path: "/areas/01000/population",
     expectedStatus: 200,
     expectedTexts: ["北海道"],
   },
@@ -55,6 +55,13 @@ const testCases: SmokeTestCase[] = [
     path: "/areas/01000/economy",
     expectedStatus: 200,
     expectedTexts: ["北海道"],
+  },
+  {
+    // Phase 9 (2026-04-26): non-indexable category は middleware で 410 化される
+    // INDEXABLE_AREA_CATEGORIES = ["population", "economy"] 以外は意図的に 410
+    name: "都道府県ダッシュボード（北海道・気象）— 410 期待",
+    path: "/areas/01000/landweather",
+    expectedStatus: 410,
   },
   {
     name: "ランキング一覧",


### PR DESCRIPTION
Phase 9 デプロイ後 4 回連続失敗していた Post-Deploy Smoke Test の修正。

**原因**: smoke-test が `/areas/01000/landweather` を 200 期待していたが、Phase 9 で `INDEXABLE_AREA_CATEGORIES = [population, economy]` 以外を 410 化したため不一致。

**修正**:
- `landweather` ケースを 410 期待に変更（仕様通り）
- 代わりに `/areas/01000/population` を追加して indexable category の正常系を検証

**ローカル検証**:
```
npx tsx apps/web/scripts/smoke-test.ts --base-url https://stats47.jp
# 10/10 passed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)