### PR TITLE
docs(records): W18 SNS 準備の学びを knowledge に記録

### DIFF
--- a/.claude/skills/management/knowledge/SKILL.md
+++ b/.claude/skills/management/knowledge/SKILL.md
@@ -440,3 +440,62 @@ export async function GET() {
 - `apps/web/src/app/sitemap.ts` (generateSitemaps)
 - `apps/web/src/app/sitemap.xml/route.ts` (index)
 - PR #121 (Phase 9 P2-C)
+
+
+---
+
+## Instagram 投稿パイプラインのギャップ — caption 事前準備が必須（2026-04-26）
+
+**問題**: 「IG にメディア投稿しよう」と思っても、`/post-instagram <key>` が即座に動くケースは少ない。実行直前に caption / 動画 / 静止画のいずれかが欠けていてエラー停止することが多い。
+
+**原因**: ranking と bar-chart-race で IG メディア生成パイプラインが**分離**しており、それぞれ別スキルでの事前生成が必要:
+- **bar-chart-race**: `/post-bar-chart-race-captions <key>` でキャプション生成（Claude prompt-based、CLI バッチ不可なので 1 件ずつ起動）→ `/render-bar-chart-race --key <key> --platform instagram` で reel.mp4 生成
+- **ranking**: `instagram/caption.json` を別スキルで事前作成 → `apps/remotion/scripts/pipeline/render-sns-all.ts --key <key> --stills-only` で stills 生成
+- **両方とも**: 完成後に `/push-r2` で R2 にアップロードしないと `post-instagram.ts` が public URL を引けず container 作成に失敗
+
+**対策**:
+1. IG 投稿前に必ずファイル存在チェックを走らせる:
+   ```bash
+   # bar-chart-race の場合
+   for key in <keys>; do
+     [ -f .local/r2/sns/bar-chart-race/$key/instagram/reel.mp4 ] && \
+     [ -f .local/r2/sns/bar-chart-race/$key/instagram/caption.txt ] && \
+     echo "✅ $key" || echo "❌ $key"
+   done
+   ```
+2. R2 にあれば `curl -o` でローカルに pull する（render より速い）:
+   ```bash
+   curl "https://storage.stats47.jp/sns/bar-chart-race/<key>/instagram/caption.txt" -o .local/r2/sns/bar-chart-race/<key>/instagram/caption.txt
+   ```
+3. 「7 件投稿したい」が「実は 3 件しか ready」というギャップは設計レベルで起きうる。事前に rendering catalog (`render-bar-chart-race --dry-run`) と caption の R2 存在を両方チェックする運用にする
+
+**関連**:
+- `.claude/skills/sns/post-bar-chart-race-captions/SKILL.md`
+- `apps/remotion/scripts/pipeline/render-bar-chart-race.ts`
+- `apps/remotion/scripts/pipeline/render-sns-all.ts`
+- W18 Plan #127 のコメント (実例)
+
+
+---
+
+## Instagram 予約投稿の API 制約と代替手段の ROI（2026-04-26）
+
+**問題**: 「IG に N 件予約投稿したい」と言われたとき、Instagram Graph API には `scheduled_publish_time` パラメータが**存在しない**ため、API だけでは予約不可。代替実装は重い割に、少量の投稿には ROI が合わない。
+
+**原因**: Meta は IG Content Publishing API を**即時投稿のみ**に制限している。Facebook Page 用 Graph API には `published=false` + `scheduled_publish_time` があるが、IG 用には実装されていない（2026-04 時点）。予約 UI は Meta Business Suite UI のみが提供。
+
+**対策（代替手段の選定基準）**:
+| 代替手段 | 実装コスト | 信頼性 | 適切な投稿頻度 |
+|---|---|---|---|
+| **手動 trigger**（毎朝 `/post-instagram <key>` 実行） | ゼロ | 高（API 即時投稿） | **週 7 件以下** |
+| **launchd plist**（mac のみ、PC 起動必須） | 30-60 分 | Mac 起動依存 | 週 7 件以上、固定 mac 使用時 |
+| **GitHub Actions cron**（クラウド） | 60-90 分 + post-instagram の CI 対応 | 高 | 週 14 件以上 |
+| **Meta Business Suite UI** (browser-use) | 2-3 時間 (UI 解析) | 中（MBS UI 不安定） | あまり推奨しない |
+
+**推奨**: **週 7 件以下なら手動 trigger 一択**。30 秒/日 × 7 日 = 3.5 分/週で済むし、API の安定性を享受できる。
+
+**ROI が破綻する典型例**: 「全自動で予約投稿したい」要望に対して GitHub Actions を組むと、post-instagram の CI 対応 (caption / media を R2 から fetch する改修) で +1-2 時間追加発生。1-2 時間の自動化投資が回収できるのは**月 30 投稿以上**運用するケースのみ。
+
+**関連**:
+- memory: `project_instagram_graph_api_setup.md` (API 仕様詳細)
+- W18 Plan #127 のコメント (実際にスコープ縮小した事例)

--- a/.claude/skills/management/nsm-experiment/reference/weekly-snapshots/2026-W17.json
+++ b/.claude/skills/management/nsm-experiment/reference/weekly-snapshots/2026-W17.json
@@ -2,26 +2,26 @@
   "week_id": "2026-W17",
   "year": 2026,
   "week": 17,
-  "generated_at": "2026-04-19T22:20:59.006Z",
+  "generated_at": "2026-04-26T02:18:04.835Z",
   "ranges": {
     "ga4": {
       "this": {
-        "start": "2026-04-12",
-        "end": "2026-04-18"
+        "start": "2026-04-19",
+        "end": "2026-04-25"
       },
       "prev": {
-        "start": "2026-04-05",
-        "end": "2026-04-11"
+        "start": "2026-04-12",
+        "end": "2026-04-18"
       }
     },
     "gsc": {
       "this": {
-        "start": "2026-04-10",
-        "end": "2026-04-16"
+        "start": "2026-04-17",
+        "end": "2026-04-23"
       },
       "prev": {
-        "start": "2026-04-03",
-        "end": "2026-04-09"
+        "start": "2026-04-10",
+        "end": "2026-04-16"
       }
     }
   },
@@ -29,185 +29,184 @@
     "channels": [
       {
         "channel": "Referral",
-        "thisUsers": 10,
-        "prevUsers": 12,
-        "userDelta": -2,
-        "userDeltaPct": -16.666666666666664,
-        "thisSessions": 16,
+        "thisUsers": 35,
+        "prevUsers": 10,
+        "userDelta": 25,
+        "userDeltaPct": 250,
+        "thisSessions": 36,
         "prevSessions": 16,
-        "thisEngagedSessions": 11,
-        "prevEngagedSessions": 12,
-        "thisEngagementRate": 0.6875
-      },
-      {
-        "channel": "Direct",
-        "thisUsers": 3,
-        "prevUsers": 4,
-        "userDelta": -1,
-        "userDeltaPct": -25,
-        "thisSessions": 4,
-        "prevSessions": 7,
-        "thisEngagedSessions": 3,
-        "prevEngagedSessions": 5,
+        "thisEngagedSessions": 27,
+        "prevEngagedSessions": 11,
         "thisEngagementRate": 0.75
       },
       {
         "channel": "Organic Search",
-        "thisUsers": 3,
-        "prevUsers": 9,
-        "userDelta": -6,
-        "userDeltaPct": -66.66666666666666,
-        "thisSessions": 3,
-        "prevSessions": 10,
+        "thisUsers": 21,
+        "prevUsers": 3,
+        "userDelta": 18,
+        "userDeltaPct": 600,
+        "thisSessions": 22,
+        "prevSessions": 3,
+        "thisEngagedSessions": 2,
+        "prevEngagedSessions": 3,
+        "thisEngagementRate": 0.09090909090909091
+      },
+      {
+        "channel": "Unassigned",
+        "thisUsers": 18,
+        "prevUsers": 0,
+        "userDelta": 18,
+        "userDeltaPct": null,
+        "thisSessions": 19,
+        "prevSessions": 0,
+        "thisEngagedSessions": 0,
+        "prevEngagedSessions": 0,
+        "thisEngagementRate": 0
+      },
+      {
+        "channel": "Direct",
+        "thisUsers": 8,
+        "prevUsers": 3,
+        "userDelta": 5,
+        "userDeltaPct": 166.66666666666669,
+        "thisSessions": 8,
+        "prevSessions": 4,
         "thisEngagedSessions": 3,
-        "prevEngagedSessions": 7,
-        "thisEngagementRate": 1
+        "prevEngagedSessions": 3,
+        "thisEngagementRate": 0.375
       },
       {
         "channel": "Organic Social",
-        "thisUsers": 1,
+        "thisUsers": 0,
         "prevUsers": 1,
-        "userDelta": 0,
-        "userDeltaPct": 0,
-        "thisSessions": 1,
+        "userDelta": -1,
+        "userDeltaPct": -100,
+        "thisSessions": 0,
         "prevSessions": 1,
-        "thisEngagedSessions": 1,
+        "thisEngagedSessions": 0,
         "prevEngagedSessions": 1,
-        "thisEngagementRate": 1
+        "thisEngagementRate": 0
       }
     ],
     "total": {
-      "thisUsers": 17,
-      "prevUsers": 26,
-      "thisSessions": 24,
-      "prevSessions": 34,
-      "thisEngagedSessions": 18,
-      "prevEngagedSessions": 25,
-      "userDelta": -9,
-      "userDeltaPct": -34.61538461538461,
-      "engagedSessionDelta": -7,
-      "engagedSessionDeltaPct": -28.000000000000004
+      "thisUsers": 82,
+      "prevUsers": 17,
+      "thisSessions": 85,
+      "prevSessions": 24,
+      "thisEngagedSessions": 32,
+      "prevEngagedSessions": 18,
+      "userDelta": 65,
+      "userDeltaPct": 382.3529411764706,
+      "engagedSessionDelta": 14,
+      "engagedSessionDeltaPct": 77.77777777777779
     },
     "organic": {
       "channel": "Organic Search",
-      "thisUsers": 3,
-      "prevUsers": 9,
-      "userDelta": -6,
-      "userDeltaPct": -66.66666666666666,
-      "thisSessions": 3,
-      "prevSessions": 10,
-      "thisEngagedSessions": 3,
-      "prevEngagedSessions": 7,
-      "thisEngagementRate": 1
+      "thisUsers": 21,
+      "prevUsers": 3,
+      "userDelta": 18,
+      "userDeltaPct": 600,
+      "thisSessions": 22,
+      "prevSessions": 3,
+      "thisEngagedSessions": 2,
+      "prevEngagedSessions": 3,
+      "thisEngagementRate": 0.09090909090909091
     }
   },
   "gsc": {
     "total": {
-      "thisClicks": 86,
-      "prevClicks": 164,
-      "clickDelta": -78,
-      "clickDeltaPct": -47.5609756097561,
-      "thisImpressions": 3730,
-      "prevImpressions": 3023,
-      "impressionDelta": 707,
-      "thisCtr": 0.023056300268096516,
-      "prevCtr": 0.05425074429374793,
-      "thisPosition": 9.672117962466489,
-      "prevPosition": 8.595765795567317
+      "thisClicks": 106,
+      "prevClicks": 86,
+      "clickDelta": 20,
+      "clickDeltaPct": 23.25581395348837,
+      "thisImpressions": 3912,
+      "prevImpressions": 3730,
+      "impressionDelta": 182,
+      "thisCtr": 0.0270961145194274,
+      "prevCtr": 0.023056300268096516,
+      "thisPosition": 9.098670756646216,
+      "prevPosition": 9.672117962466489
     },
     "topQueries": [
       {
-        "query": "昆布 消費量 ランキング",
-        "clicks": 2,
-        "impressions": 10,
-        "ctr": 0.2,
-        "position": 7.4
-      },
-      {
-        "query": "エンゲル係数 都道府県",
+        "query": "家計調査 品目別ランキング",
         "clicks": 1,
-        "impressions": 2,
-        "ctr": 0.5,
-        "position": 6.5
-      },
-      {
-        "query": "公園が多い県",
-        "clicks": 1,
-        "impressions": 7,
-        "ctr": 0.14285714285714285,
-        "position": 7.142857142857143
-      },
-      {
-        "query": "地方債残高 ランキング",
-        "clicks": 1,
-        "impressions": 8,
-        "ctr": 0.125,
-        "position": 5
-      },
-      {
-        "query": "大学進学率 都道府県",
-        "clicks": 1,
-        "impressions": 2,
-        "ctr": 0.5,
-        "position": 10
+        "impressions": 9,
+        "ctr": 0.1111111111111111,
+        "position": 11
       },
       {
         "query": "昆布消費量ランキング",
         "clicks": 1,
-        "impressions": 4,
-        "ctr": 0.25,
-        "position": 7.25
+        "impressions": 8,
+        "ctr": 0.125,
+        "position": 8.5
       },
       {
-        "query": "猛暑日日数 都 道府県",
+        "query": "経常収支比率 自治体 ランキング",
         "clicks": 1,
-        "impressions": 2,
-        "ctr": 0.5,
-        "position": 11
-      },
-      {
-        "query": "\"出生数 全都道府県で減少\"",
-        "clicks": 0,
         "impressions": 1,
-        "ctr": 0,
-        "position": 10
+        "ctr": 1,
+        "position": 18
       },
       {
-        "query": "2040年 介護人材 不足 69万人",
-        "clicks": 0,
-        "impressions": 3,
-        "ctr": 0,
-        "position": 5.333333333333333
-      },
-      {
-        "query": "お酒消費量 都道府県",
-        "clicks": 0,
+        "query": "都道府県 財政 ランキング",
+        "clicks": 1,
         "impressions": 1,
-        "ctr": 0,
+        "ctr": 1,
+        "position": 39
+      },
+      {
+        "query": "都道府県出生率ランキング",
+        "clicks": 1,
+        "impressions": 1,
+        "ctr": 1,
         "position": 16
+      },
+      {
+        "query": "47 都 道府県",
+        "clicks": 0,
+        "impressions": 1,
+        "ctr": 0,
+        "position": 73
+      },
+      {
+        "query": "47 都 道府県 一覧",
+        "clicks": 0,
+        "impressions": 1,
+        "ctr": 0,
+        "position": 48
+      },
+      {
+        "query": "47 都道府県",
+        "clicks": 0,
+        "impressions": 1,
+        "ctr": 0,
+        "position": 71
+      },
+      {
+        "query": "47都道府県",
+        "clicks": 0,
+        "impressions": 1,
+        "ctr": 0,
+        "position": 20
+      },
+      {
+        "query": "じゃがいも 消費量",
+        "clicks": 0,
+        "impressions": 1,
+        "ctr": 0,
+        "position": 12
       }
     ]
   },
   "psi": {
-    "url": "https://stats47.jp/",
-    "strategy": "mobile",
-    "scores": {
-      "performance": 55,
-      "accessibility": 100,
-      "best_practices": 100,
-      "seo": 100
-    },
-    "lab_data": {
-      "LCP_ms": 9453.652191576162,
-      "TBT_ms": 632,
-      "CLS": 0.000185,
-      "FCP_ms": 1351.3043498530028,
-      "TTI_ms": 14861.623317207457
-    }
+    "skipped": true,
+    "reason": "PSI_API_KEY 未設定"
   },
   "notes": [
-    "GSC データは 3 日遅延のため、直近期間は 2026-04-10 〜 2026-04-16 を採用",
+    "GSC データは 3 日遅延のため、直近期間は 2026-04-17 〜 2026-04-23 を採用",
     "NSM = 週間エンゲージドセッション数 (GA4 engagedSessions 全チャネル合計)",
-    "NSM 定義: docs/03_レビュー/critical/north-star-metric.md"
+    "NSM 定義: [Critical Review] North Star Metric Issue (gh issue list --label critical-review)"
   ]
 }

--- a/.claude/skills/management/nsm-experiment/reference/weekly-snapshots/index.json
+++ b/.claude/skills/management/nsm-experiment/reference/weekly-snapshots/index.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "generated_at": "2026-04-19T22:20:59.016Z",
+  "generated_at": "2026-04-26T02:18:04.864Z",
   "weeks": [
     {
       "week_id": "2026-W16",
@@ -10,7 +10,7 @@
     {
       "week_id": "2026-W17",
       "path": ".claude/skills/management/nsm-experiment/reference/weekly-snapshots/2026-W17.json",
-      "generated_at": "2026-04-19T22:20:59.008Z"
+      "generated_at": "2026-04-26T02:18:04.837Z"
     }
   ]
 }


### PR DESCRIPTION
Phase 9 セッション同様、SNS 投稿セットアップで得た知見を knowledge に固定化。

- IG メディア生成パイプラインのギャップ（caption 事前準備、ranking と BCR で別系統）
- IG 予約投稿の API 制約 + 代替手段の ROI 表

W18 plan #127 のコメントに実例リンク済。

🤖 Generated with [Claude Code](https://claude.com/claude-code)