### PR TITLE
fix(ranking): regional_analysis を UI に配線 (#129)

### DIFF
--- a/apps/web/src/app/ranking/[rankingKey]/page.tsx
+++ b/apps/web/src/app/ranking/[rankingKey]/page.tsx
@@ -315,6 +315,12 @@ export default async function RankingKeyPage({
             ? <AiContentAccordion title="データの考察"><AiMarkdownContent content={aiContent.insights} /></AiContentAccordion>
             : null
         }
+        // AI生成コンテンツ: 地域別の傾向（折りたたみ）
+        regionalAnalysisSection={
+          aiContent?.regionalAnalysis
+            ? <AiContentAccordion title="地域別の傾向"><AiMarkdownContent content={aiContent.regionalAnalysis} /></AiContentAccordion>
+            : null
+        }
         // AI生成コンテンツ: FAQ JSON-LD（非表示 script）
         faqSection={
           aiContent?.faq


### PR DESCRIPTION
## Summary

- `apps/web/src/app/ranking/[rankingKey]/page.tsx` に `regionalAnalysisSection` prop を追加し、`aiContent.regionalAnalysis` を `AiContentAccordion` で「地域別の傾向」として描画
- v1.0 から運用されているのに UI スロットが未配線で **DB に保存された `regional_analysis` の内容が読者に届いていなかった** 問題を解消
- v3.0 pilot 8 件で「## 相関構造：…」セクションが localhost に描画されることを確認

## 検証

- [x] `npx tsc --noEmit -p apps/web/tsconfig.json` PASS
- [x] dev server で `http://localhost:3000/ranking/konbu-consumption-quantity` を curl
- [x] 「地域別の傾向」アコーディオン (2 occurrences = aria + visible)
- [x] 3 番目のセクション「相関構造：北日本食文化クラスター + 都市化との負相関」描画確認

## Closes

- Closes #129

🤖 Generated with [Claude Code](https://claude.com/claude-code)