### PR TITLE
feat(ai-content): v3.0 プロンプト + 相関データ統合 (#132 準備)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29777,6 +29777,7 @@
       "version": "1.0.0",
       "dependencies": {
         "@stats47/area": "*",
+        "@stats47/correlation": "*",
         "@stats47/database": "*",
         "@stats47/ranking": "*",
         "drizzle-orm": "^0.45.1",

--- a/packages/ai-content/package.json
+++ b/packages/ai-content/package.json
@@ -23,6 +23,7 @@
   },
   "dependencies": {
     "@stats47/area": "*",
+    "@stats47/correlation": "*",
     "@stats47/database": "*",
     "@stats47/ranking": "*",
     "drizzle-orm": "^0.45.1",

--- a/packages/ai-content/src/scripts/build-prompt.ts
+++ b/packages/ai-content/src/scripts/build-prompt.ts
@@ -16,10 +16,16 @@
 
 import "dotenv/config";
 import { listRankingItems, listRankingValues } from "@stats47/ranking/server";
+import { findHighlyCorrelated } from "@stats47/correlation/server";
+import { isExcludedCorrelationKey } from "@stats47/correlation";
 import { buildRankingContentPrompt } from "../services/prompts/ranking-content-prompt";
-import type { RankingContentInput } from "../services/prompts/ranking-content-prompt";
+import type {
+  CorrelationInputItem,
+  RankingContentInput,
+} from "../services/prompts/ranking-content-prompt";
 
 const AREA_TYPE = "prefecture";
+const CORRELATION_TOP_N = 10;
 
 function parseArgs(): { key: string } {
   const argv = process.argv.slice(2);
@@ -84,6 +90,25 @@ async function main() {
     value: v.value ?? 0,
   }));
 
+  // 相関データ取得（v3.0）
+  const isExcluded = isExcludedCorrelationKey(key);
+  let correlations: CorrelationInputItem[] = [];
+  if (!isExcluded) {
+    const corrResult = await findHighlyCorrelated(key, CORRELATION_TOP_N);
+    if (corrResult.success) {
+      correlations = corrResult.data
+        .filter((c) => !isExcludedCorrelationKey(c.rankingKey))
+        .map((c) => ({
+          title: c.subtitle ? `${c.title}（${c.subtitle}）` : c.title,
+          pearsonR: c.pearsonR,
+          partialRPopulation: c.partialRPopulation,
+          partialRArea: c.partialRArea,
+          partialRAging: c.partialRAging,
+          partialRDensity: c.partialRDensity,
+        }));
+    }
+  }
+
   const input: RankingContentInput = {
     rankingName: item.title ?? item.rankingName,
     unit: item.unit,
@@ -95,6 +120,8 @@ async function main() {
     min,
     max,
     totalCount: sorted.length,
+    correlations,
+    isExcludedFromCorrelation: isExcluded,
   };
 
   const prompt = buildRankingContentPrompt(input);

--- a/packages/ai-content/src/scripts/generate-parallel.ts
+++ b/packages/ai-content/src/scripts/generate-parallel.ts
@@ -17,13 +17,17 @@
 import "dotenv/config";
 import { spawn } from "child_process";
 import { listRankingItems, listRankingValues } from "@stats47/ranking/server";
+import { findHighlyCorrelated } from "@stats47/correlation/server";
+import { isExcludedCorrelationKey } from "@stats47/correlation";
 import { buildRankingContentPrompt } from "../services/prompts/ranking-content-prompt";
+import type { CorrelationInputItem } from "../services/prompts/ranking-content-prompt";
 import { upsertRankingAiContent } from "../repositories/upsert-ranking-ai-content";
 import { getDrizzle, rankingAiContent } from "@stats47/database/server";
 import type { FaqContent } from "../types";
 
 const AREA_TYPE = "prefecture";
-const PROMPT_VERSION = "1.0.0";
+const PROMPT_VERSION = "3.0.0";
+const CORRELATION_TOP_N = 10;
 
 // ============================================================
 // 引数パース
@@ -162,6 +166,25 @@ async function processOne(
         ? numericValues.reduce((s, v) => s + v, 0) / numericValues.length
         : 0;
 
+    // 相関データ取得（v3.0）。EXCLUDED キーは空配列で扱い、プロンプト側で除外説明を挿入
+    const isExcluded = isExcludedCorrelationKey(rankingKey);
+    let correlations: CorrelationInputItem[] = [];
+    if (!isExcluded) {
+      const corrResult = await findHighlyCorrelated(rankingKey, CORRELATION_TOP_N);
+      if (corrResult.success) {
+        correlations = corrResult.data
+          .filter((c) => !isExcludedCorrelationKey(c.rankingKey))
+          .map((c) => ({
+            title: c.subtitle ? `${c.title}（${c.subtitle}）` : c.title,
+            pearsonR: c.pearsonR,
+            partialRPopulation: c.partialRPopulation,
+            partialRArea: c.partialRArea,
+            partialRAging: c.partialRAging,
+            partialRDensity: c.partialRDensity,
+          }));
+      }
+    }
+
     const prompt = buildRankingContentPrompt({
       rankingName,
       unit,
@@ -185,6 +208,8 @@ async function processOne(
       min: numericValues.length > 0 ? Math.min(...numericValues) : 0,
       max: numericValues.length > 0 ? Math.max(...numericValues) : 0,
       totalCount: sorted.length,
+      correlations,
+      isExcludedFromCorrelation: isExcluded,
     });
 
     // AI 呼び出し

--- a/packages/ai-content/src/services/prompts/ranking-content-prompt.ts
+++ b/packages/ai-content/src/services/prompts/ranking-content-prompt.ts
@@ -1,6 +1,23 @@
 import "server-only";
 
-import { REGIONS, fetchPrefectures } from "@stats47/area";
+/**
+ * 相関考察に渡す各 counterpart 指標の情報。
+ * findHighlyCorrelated の結果から組み立てる想定。
+ */
+export interface CorrelationInputItem {
+  /** 相手側ランキングのタイトル（人間向け表記） */
+  title: string;
+  /** ピアソン相関係数 */
+  pearsonR: number;
+  /** 人口を統制した偏相関 */
+  partialRPopulation: number | null;
+  /** 面積を統制した偏相関 */
+  partialRArea: number | null;
+  /** 高齢化率を統制した偏相関 */
+  partialRAging: number | null;
+  /** 人口密度を統制した偏相関 */
+  partialRDensity: number | null;
+}
 
 export interface RankingContentInput {
   rankingName: string;
@@ -13,38 +30,97 @@ export interface RankingContentInput {
   min: number;
   max: number;
   totalCount: number;
+  /**
+   * 相関分析の上位 counterpart（v3.0 から）。
+   * 空配列 / undefined の場合は相関考察を含めず「特異な変化」軸で記述する。
+   */
+  correlations?: CorrelationInputItem[];
+  /**
+   * EXCLUDED_CORRELATION_KEYS に該当するか（v3.0 から）。
+   * true の場合、相関考察を書かず除外理由を insights / faq に記す。
+   */
+  isExcludedFromCorrelation?: boolean;
+}
+
+function formatPartial(label: string, r: number | null): string | null {
+  if (r === null || !Number.isFinite(r)) return null;
+  return `${label}偏相関 ${r.toFixed(2)}`;
+}
+
+function formatCorrelationLine(item: CorrelationInputItem): string {
+  const partials = [
+    formatPartial("人口", item.partialRPopulation),
+    formatPartial("面積", item.partialRArea),
+    formatPartial("高齢化", item.partialRAging),
+    formatPartial("密度", item.partialRDensity),
+  ].filter((p): p is string => p !== null);
+  const partialText = partials.length > 0 ? `（${partials.join(" / ")}）` : "";
+  return `- ${item.title}: r=${item.pearsonR.toFixed(2)}${partialText}`;
 }
 
 /**
- * 7地方区分テキストを生成する（プロンプト埋め込み用）
- */
-function buildRegionMapText(): string {
-  const prefectures = fetchPrefectures();
-  const codeToName = new Map(prefectures.map((p) => [p.prefCode, p.prefName]));
-  return REGIONS.map((region) => {
-    const names = region.prefectures.map((code) => codeToName.get(code) ?? code);
-    return `- ${region.regionName}: ${names.join(", ")}`;
-  }).join("\n");
-}
-
-/**
- * ランキングページ向けAIコンテンツ生成プロンプトを構築する。
+ * ランキングページ向けAIコンテンツ生成プロンプトを構築する（v3.0）。
  * 出力: JSON（FaqContent, regionalAnalysis Markdown, insights Markdown）
+ *
+ * v3.0 の主な変更:
+ *   - regional_analysis を 7 地方区分 → 3 セクション分析（上位帯 / 下位帯 / 相関構造 or 特異な変化）に変更
+ *   - 相関データ（correlations）を入力に追加し、相関構造セクションで活用
+ *   - EXCLUDED_CORRELATION_KEYS（人口・絶対数指標）は相関考察を省略し除外理由を明記
  */
 export function buildRankingContentPrompt(input: RankingContentInput): string {
   const allPrefText = input.allPrefectures
     .map((r) => `${r.rank}位 ${r.areaName}: ${r.value.toLocaleString()}${input.unit}`)
     .join("\n");
 
-  const regionMapText = buildRegionMapText();
+  const hasCorrelations = !input.isExcludedFromCorrelation && (input.correlations?.length ?? 0) > 0;
+  const correlationsBlock = hasCorrelations
+    ? `## 相関データ（上位 ${input.correlations!.length} 件、ピアソン r 絶対値順）
+
+${input.correlations!.map(formatCorrelationLine).join("\n")}
+
+注意: 偏相関は当該変数を統制した後に残る相関。低下幅が大きい変数は「その交絡変数で説明される部分が大きい」ことを意味する。`
+    : "";
+
+  const excludedNote = input.isExcludedFromCorrelation
+    ? `## 相関データ取り扱い
+
+本指標は人口規模・絶対数指標のため相関分析対象外（他の絶対数指標と自明に正相関するため、人口・面積・密度などとの相関を集計しても示唆が得られない）。
+相関考察は書かず、insights 末尾に「相関データの取扱い」見出しでこの旨を明記すること。`
+    : "";
+
+  const thirdSectionRule = input.isExcludedFromCorrelation
+    ? "「## 特異な変化」または「## 構造的特徴」見出しで、本指標固有の時系列変化・順位逆転・地理的偏りなどを 250〜350 字で考察する。相関には触れない。"
+    : hasCorrelations
+      ? "「## 相関構造」見出しで、上記の相関データを引用し『何と相関するか / 偏相関でどう変化するか / 何が主因と読めるか』を 250〜400 字で考察する。具体的な r の数値を 3〜5 個引用すること。"
+      : "「## 特異な変化」または「## 構造的特徴」見出しで、本指標固有の時系列変化や地理的偏りを 200〜300 字で考察する。";
+
+  const insightsThirdRule = input.isExcludedFromCorrelation
+    ? `第 4 項目は **「## 相関データの取扱い」** 見出しで、本指標が人口規模指標のため相関分析対象外である旨を 100〜180 字で説明する（学校数・産出額など多くの指標が人口に比例して動くため、人口を相関軸に置くと自明な結果しか得られない、という主旨）。`
+    : hasCorrelations
+      ? `第 3 項目は **「## 〜（相関を象徴する短い見出し）」** とし、相関データから読み取れる『人口を統制しても残る関係』『面積を統制しても残る関係』を 200〜350 字で考察する。具体的な r の数値を引用してよいが、テーブルではなく流れる文章で記述する。`
+      : `第 3 項目は通常通り集計・比較からの示唆を 150〜250 字で記述する。`;
+
+  const faqExtraItem = input.isExcludedFromCorrelation
+    ? `      ,{
+        "question": "（この指標が他の指標と何と相関するか？という趣旨の質問）",
+        "answer": "（本指標は人口規模指標のため相関分析対象外。他の絶対数指標と自明に正相関する旨を簡潔に説明）",
+        "type": "custom"
+      }`
+    : hasCorrelations
+      ? `      ,{
+        "question": "（${input.rankingName}は何と相関しますか？という趣旨の質問）",
+        "answer": "（提供された相関データから、強い正相関 1〜2 件と偏相関での変化を 1〜2 文で要約）",
+        "type": "custom"
+      }`
+      : "";
 
   return `あなたは日本の公的統計データを正確に読み解く統計アナリストです。
 以下の「${input.rankingName}」の都道府県別ランキングデータ（${input.yearCode}年度）を分析し、Webページに掲載するコンテンツを生成してください。
 
 ## 絶対ルール（違反は不可）
 
-1. **提供データのみ使用**: 以下に記載された数値・順位のみを使うこと。プロンプトに含まれないデータ、外部統計、他指標への言及は一切禁止
-2. **因果関係の推測禁止**: 「〜が原因」「〜のおかげ」等の因果推論は書かない。「〜と相関がある可能性がある」「〜が背景にあると考えられる」程度の示唆に留める
+1. **提供データのみ使用**: 以下に記載された数値・順位・相関データのみを使うこと。プロンプトに含まれないデータ、外部統計、未記載の指標への言及は一切禁止
+2. **因果関係の推測禁止**: 「〜が原因」「〜のおかげ」等の因果推論は書かない。「〜と相関がある」「〜が背景にあると考えられる」程度の示唆に留める
 3. **煽り表現禁止**: 「衝撃」「危機」「非常事態」「跳ね上がる」等の感情的表現は使わない。客観的・中立的なトーンを維持する
 4. **データ外の知識を混ぜない**: 特定の施設名、政策名、制度名、企業名への言及は禁止（提供データに含まれていない限り）
 
@@ -59,8 +135,7 @@ export function buildRankingContentPrompt(input: RankingContentInput): string {
 
 ${allPrefText}
 
-## 7地方区分
-${regionMapText}
+${correlationsBlock}${excludedNote}
 
 ## 出力形式
 
@@ -95,6 +170,7 @@ ${regionMapText}
         "answer": "（具体的な倍率や差を含む回答）",
         "type": "custom"
       }
+${faqExtraItem}
     ]
   },
   "regionalAnalysis": "（Markdown形式。後述のルール参照）",
@@ -102,43 +178,49 @@ ${regionMapText}
 }
 \`\`\`
 
-### regionalAnalysis のルール
+### regionalAnalysis のルール（v3.0 = 3 セクション構成）
 
-- 7地方区分ごとに \`## 北海道・東北\`, \`## 関東\`, \`## 中部\`, \`## 近畿\`, \`## 中国\`, \`## 四国\`, \`## 九州・沖縄\` の見出しで始める
-- **個別の都道府県名・数値・順位を網羅的に列挙しない**。数値はチャートやテーブルで確認できるため、テキストでは地方ごとの「傾向」「パターン」「特徴」を述べる
-- 具体的な数値を引用するのは、傾向を裏付ける代表例として1地方あたり最大1県に留める。2県以上の数値を並べない
-- 地方内での上位・下位の偏り、全国平均との乖離、隣接地方との対比など「分析的な視点」を提供する
-- 都道府県を列挙する箇条書き風の文体にしない。地方全体の傾向→代表例1県という流れで書く
-- 各地方100〜150字。全体で700〜1000字程度
+3 つの \`## 見出し\` セクションで構成する。各セクション 200〜350 字、全体で 700〜1,000 字程度。
 
-### insights のルール
+1. **第 1 セクション**: \`## 上位帯：（上位帯を象徴する短いラベル）\` 見出し。上位 5 県の傾向を分析する。地理的クラスタリング（東北・首都圏・西日本など）、産業特性、共通する地理的条件などを述べる。1 位の数値、上位 5 県のシェア（合計 / 全国 = X%）、1〜3 位の県名と数値を本文に自然に組み込む。
+2. **第 2 セクション**: \`## 下位帯：（下位帯を象徴する短いラベル）\` 見出し。下位 5 県の傾向を分析する。最下位の数値、最下位〜下位 3 位の県名、上位との倍率（X 倍格差）を含める。
+3. **第 3 セクション**: ${thirdSectionRule}
 
-- \`## 見出し\` で3〜4項目に分けて記述する
-- 各項目100〜200字。全体で400〜700字程度
-- **個別都道府県の数値列挙は禁止**。数値はチャート・テーブルで確認できるため、テキストでは集計・比較から導かれるパターンや傾向のみ記述する
-- 書くべき内容の例:
-  - 上位5県の値の合計が全体の何%を占めるか（集中度）
-  - 1位と47位の倍率（格差の大きさ）
-  - 地方ブロック間の平均値比較
-  - 上位県・下位県に共通する地理的特徴（太平洋側/日本海側、都市部/地方部 等）
-- 「なぜそうなるか」の因果は書かない。「〜という傾向が見られる」で止める
+文体ルール:
+- 都道府県名を箇条書きや羅列で並べない。1 文に複数県を数値付きで列挙しない
+- 数値引用は本文の流れに自然に組み込む（括弧連打 NG）
+- セクション 1, 2 では具体的な県名 5〜7 個を引用してよい（ただし価値ある分析と組み合わせること）
+
+### insights のルール（v3.0 = 3〜4 項目）
+
+\`## 見出し\` で項目を分ける。${input.isExcludedFromCorrelation ? "4 項目" : "3 項目"}構成。各項目 150〜350 字、全体で 600〜900 字程度。
+
+1. **第 1 項目**: 集中度（上位 N 県のシェア）または 1 位のシェアを軸に分析。CV（変動係数 ≒ 標準偏差/平均）の概念に触れてよいが、数値計算は提供データから推定可能な範囲に留める。
+2. **第 2 項目**: X 倍格差（最大値 / 最小値）と他の格差（人口格差 26.7 倍など）との比較。義務的最低水準・地理的下限など格差を制限する要因に触れてよい。
+3. ${insightsThirdRule}
+
+文体ルール:
+- **個別都道府県の数値羅列は禁止**: チャート・テーブルで確認できるため、テキストでは集計・比較から導かれるパターン・傾向のみ記述
+- 「なぜそうなるか」の因果は断定せず、「〜という傾向が見られる」「〜が背景にあると考えられる」で止める
+- 数値を出す場合は提供データから直接読める / 計算できるものに限る
 
 ### FAQ のルール
 
 - question は検索ユーザーが実際に検索窓に入力しそうな自然な日本語にする
 - answer は提供データの数値のみで回答する。「〜と考えられます」等の推測は含めない
-- 各 answer は1〜3文で簡潔に
+- 各 answer は 1〜3 文で簡潔に
+- ${input.isExcludedFromCorrelation ? "6 番目に「相関分析の対象外である理由」を必ず含める" : hasCorrelations ? "6 番目に「相関する指標」項目を必ず含める" : "FAQ は 5 項目"}
 
 ### 文体ルール（全セクション共通）
 
-- **数値の羅列・列挙は禁止**: 同じページにチャートとテーブルがあるため、テキストの役割は「データを読み解いた分析」を提供すること。都道府県名と数値を並べるだけの文章は価値がない
-- **括弧による数値挿入を全面禁止**: 都道府県名の直後に括弧で値・順位を入れてはならない。
+- **数値の羅列・列挙は禁止**: 同じページにチャートとテーブルがあるため、テキストの役割は「データを読み解いた分析」を提供すること
+- **括弧による数値挿入を全面禁止**: 都道府県名の直後に括弧で値・順位を入れてはならない
   - NG:「愛知県（746.0万人）が4位」「石川県（2.5人、31位）」「鹿児島県（2.6人）が25位」
   - NG:「福井県（73.9万人）や山梨県（79.1万人）は〜」← 括弧付き都道府県を連続させるのも禁止
   - OK:「愛知県は4位で、中部地方の中核を担っている」「石川県は31位で全国平均をやや下回る」
   - OK:「中部地方では愛知県が4位と突出しているが、県ごとの差が大きい」
-- **1文に複数の都道府県を数値付きで並べない**: 個別県のデータ紹介が続くと箇条書きと変わらなくなる。代わりに地方単位やグループ単位の傾向を述べ、代表例として1県だけ引用する
-- 数値を引用する場合は、傾向を裏付ける代表例として最小限（1地方あたり1県）に留め、文章の流れの中に自然に組み込む
+- **1 文に複数の都道府県を数値付きで並べない**
+- 数値を引用する場合は、傾向を裏付ける代表例として最小限に留め、文章の流れの中に自然に組み込む
 - 年度を参照する場合は「${input.yearCode}年度」と表記する
 - 「ワースト」「ベスト」「激減」「急増」は使わない。「上位」「下位」「最も多い」「最も少ない」を使う`;
 }


### PR DESCRIPTION
## Summary

Issue #132 の自動展開準備として `ranking-content-prompt.ts` を v3.0 へ更新し、相関データ + EXCLUDED 判定をプロンプト入力に統合。

## 主な変更

- `RankingContentInput` に `correlations: CorrelationInputItem[]` と `isExcludedFromCorrelation: boolean` を追加
- regional_analysis を **7 地方区分 → 3 セクション**（上位帯 / 下位帯 / 相関構造 or 特異な変化）に再構成
- insights は 3 項目（相関あり）/ 4 項目（EXCLUDED）構成。EXCLUDED の最終項目は「相関データの取扱い」を明記
- FAQ は 6 項目（通常 = 相関 Q、EXCLUDED = 除外理由 Q）
- `generate-parallel.ts` / `build-prompt.ts` を `findHighlyCorrelated` + `isExcludedCorrelationKey` 経由で相関データ取得するよう更新
- `PROMPT_VERSION` を `1.0.0` → `3.0.0` に変更
- `@stats47/correlation` を `@stats47/ai-content` の依存に追加

## 検証

- [x] `npx tsc --noEmit -p packages/ai-content` PASS
- [x] `npx tsc --noEmit -p apps/web/tsconfig.json` PASS（型互換性確認）
- [x] `konbu-consumption-quantity` (相関 10 件) で Haiku 生成: 6 FAQ + 3 regional + 3 insights、相関構造セクションが r 値付きで描画される構造
- [x] `total-population` (EXCLUDED) で Haiku 生成: 6 FAQ + 3 regional + 4 insights、最終項目が「相関データの取扱い」になる

## 次の作業

- 残 ~1,864 件の batch 生成（別 PR / Issue #132 でスクリプト追加 + ロールアウト実施）

🤖 Generated with [Claude Code](https://claude.com/claude-code)