### PR TITLE
perf(home): cookie 同意バナーを LCP 候補から外す (EXP-003)

### DIFF
--- a/.claude/skills/analytics/performance-improvement/reference/improvement-log.md
+++ b/.claude/skills/analytics/performance-improvement/reference/improvement-log.md
@@ -53,6 +53,19 @@
 
 ## Action Log
 
+### [EXP-003] Cookie 同意バナーを LCP 候補から外す — setVisible を 4s 遅延
+
+- **デプロイ日**: 2026-04-26 (予定) / コミット: <pending>
+- **想定効果**: stats47.jp/ mobile LCP 8,251ms → 2,500ms 以下 (-69%) [根拠: PSI 2026-04-25 で LCP 要素を `body.fixed > div.container > p` (CookieConsentBanner) と特定、render delay 3,075ms。banner を LCP 計測ウィンドウ後に挿入すれば本来意図した FeaturedRankings (`apps/web/src/app/page.tsx:121`) が LCP に戻る]
+- **検証コマンド**: `curl 'https://www.googleapis.com/pagespeedonline/v5/runPagespeed?url=https://stats47.jp/&strategy=mobile&category=performance' | jq '.lighthouseResult.audits["largest-contentful-paint"].numericValue, .lighthouseResult.audits["largest-contentful-paint-element"].details.items[0].node.snippet'`
+- **実測 (before)**: LCP 8,251ms / FCP 3,751ms / TBT 353ms / Perf 57 / 取得日 2026-04-25 / `.claude/state/metrics/psi/psi-batch-2026-04-25T17-39-06.json`
+- **実測 (after)**: <pending — 翌朝 PSI 自動計測待ち>
+- **判定**: pending
+- **未確定 / 仮説**:
+  - **[仮説]** banner を 4s 遅延すれば FeaturedRankings が LCP になる / 検証期日 2026-04-27 / 期日後の判定: LCP < 2,500ms かつ lcp_element が `FeaturedRankings` 配下なら effect/full、LCP < 5,000ms なら effect/partial、それ以外は別の LCP 候補（hero h1 / FCP 自体の遅延）を再調査
+  - **[別件]** CrUX TTFB 2,390ms (lab 4ms と乖離) → Cloudflare cache miss path 調査が必要。本 EXP のスコープ外、別 EXP で扱う
+- **副次計測**: `/themes/*` `/ranking/*` 詳細ページの LCP も同じ banner が起点になっていれば同程度改善するか合わせて観測（mobile LCP 11,000-15,000ms 帯）
+
 ### 2026-04-17: 計測データを D1 → ファイルへ移行
 
 - 旧 D1 テーブル `performance_metrics` / `performance_budgets` を `.claude/skills/analytics/performance-improvement/` 配下のファイルに移行

--- a/.claude/state/experiments.json
+++ b/.claude/state/experiments.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "updated_at": "2026-04-25T06:35:00.000Z",
+  "updated_at": "2026-04-26T00:00:00.000Z",
   "experiments": [
     {
       "id": "EXP-001",
@@ -129,6 +129,51 @@
           "date": "2026-04-25T06:35:00.000Z",
           "action": "closed",
           "summary": "ADVERSE。TopoJSON HTML 埋込の LCP 利点が上回ったため revert。HTML -83% は実測したが LCP は 12s → 17-20s に悪化。"
+        }
+      ]
+    },
+    {
+      "id": "EXP-003",
+      "title": "Cookie 同意バナーを LCP 候補から外す — setVisible を 4s 遅延",
+      "hypothesis": "PSI 2026-04-25 で stats47.jp/ mobile の LCP 要素が cookie 同意バナー（body.fixed > div.container > p）と判明。useState(false) → useEffect で setVisible(true) されるため hydration 完了直後にバナーが挿入され、render delay 3,075ms が LCP を 8,251ms に押し上げている。setVisible を setTimeout 4s で遅延させれば LCP 計測ウィンドウ後にバナーが挿入され、本来意図された FeaturedRankings が LCP になり 2,500ms 以下に改善するはず。",
+      "target_metric": "psi_lcp_homepage_mobile",
+      "target_delta": "stats47.jp/ mobile の LCP 8,251ms → 2,500ms 以下 (-69%)。/themes /ranking 詳細ページの LCP も同 banner が起点なら同程度改善するか確認。",
+      "rubric": {
+        "impact": 3,
+        "effort": 1,
+        "learning": 2,
+        "certainty": 2,
+        "weighted": 2.4
+      },
+      "baseline": {
+        "date": "2026-04-25",
+        "source": ".claude/state/metrics/psi/psi-batch-2026-04-25T17-39-06.json",
+        "psi_lcp_home_mobile": 8251,
+        "psi_lcp_home_desktop": 1593,
+        "psi_fcp_home_mobile": 3751,
+        "psi_tbt_home_mobile": 353,
+        "psi_perf_score_home_mobile": 57,
+        "lcp_element": "body.antialiased > div.fixed > div.container > p (CookieConsentBanner)",
+        "crux_lcp_p75": 4406,
+        "crux_ttfb_p75": 2390
+      },
+      "status": "in_progress",
+      "created_at": "2026-04-26T00:00:00.000Z",
+      "started_at": "2026-04-26T00:00:00.000Z",
+      "verification_command": "curl 'https://www.googleapis.com/pagespeedonline/v5/runPagespeed?url=https://stats47.jp/&strategy=mobile&category=performance' | jq '.lighthouseResult.audits[\"largest-contentful-paint\"].numericValue, .lighthouseResult.audits[\"largest-contentful-paint-element\"].details.items[0].node.snippet'",
+      "actions": [
+        "CookieConsentBanner.tsx の setVisible(true) を setTimeout 4s でラップ",
+        "feature/lcp-defer-cookie-banner で PR → develop → main",
+        "デプロイ後 PSI 自動計測 (.claude/state/metrics/psi/LATEST.md) で実測"
+      ],
+      "pending_user_actions": [],
+      "next_check_date": "2026-04-27",
+      "fail_criteria": "LCP > 5,000ms または lcp_element が banner 以外の意図しない要素になっている場合 → 仮説棄却。banner 削除や hero 要素の強化を検討。",
+      "history": [
+        {
+          "date": "2026-04-26T00:00:00.000Z",
+          "action": "proposed",
+          "summary": "PSI batch 2026-04-25 で cookie 同意バナーが LCP 要素と特定。setVisible 遅延で banner を LCP 候補から外す。"
         }
       ]
     }

--- a/apps/web/src/lib/analytics/components/CookieConsentBanner.tsx
+++ b/apps/web/src/lib/analytics/components/CookieConsentBanner.tsx
@@ -18,10 +18,11 @@ export function CookieConsentBanner() {
   useEffect(() => {
     const stored = localStorage.getItem(CONSENT_KEY);
     if (!stored) {
-      // 未回答: GoogleAnalytics.tsx 側で analytics_storage=granted がデフォルト適用済。
-      // バナーは表示するが消極的 opt-out として運用（Issue #37）。
-      // eslint-disable-next-line react-hooks/set-state-in-effect -- show banner
-      setVisible(true);
+      // LCP 計測ウィンドウ（First Input or 5s idle）後にバナーを挿入し、
+      // バナー自身が LCP 要素にならないようにする（EXP-003）。
+      // 同意有無は GoogleAnalytics.tsx 側で analytics_storage=granted がデフォルト。
+      const timer = setTimeout(() => setVisible(true), 4000);
+      return () => clearTimeout(timer);
     } else if (stored === "granted") {
       // 広告領域も同意済の場合のみ ad_storage を granted へ
       window.gtag?.("consent", "update", {


### PR DESCRIPTION
## Summary

- PSI 2026-04-25 で stats47.jp/ mobile の LCP 要素が `CookieConsentBanner` (`<div.fixed > div.container > p>`) と判明
- `useEffect` 内で `setVisible(true)` を `setTimeout` 4s で遅延させ、LCP 計測ウィンドウ後にバナーを挿入
- 想定: mobile `/` LCP **8,251ms → 2,500ms 以下 (-69%)**、本来意図された `FeaturedRankings` が LCP に戻る

## Baseline (実測)

| metric | mobile | desktop |
|---|---:|---:|
| Performance | 57 | 91 |
| LCP | **8,251ms** | 1,593ms |
| FCP | 3,751ms | - |
| TBT | 353ms | - |

CrUX (実ユーザー p75): LCP 4,406ms (SLOW) / TTFB 2,390ms (SLOW)

ソース: `.claude/state/metrics/psi/psi-batch-2026-04-25T17-39-06.json`

## 検証コマンド

```bash
curl 'https://www.googleapis.com/pagespeedonline/v5/runPagespeed?url=https://stats47.jp/&strategy=mobile&category=performance' \
  | jq '.lighthouseResult.audits["largest-contentful-paint"].numericValue,
        .lighthouseResult.audits["largest-contentful-paint-element"].details.items[0].node.snippet'
```

判定は翌朝 06:00 JST の PSI 自動計測 (`.claude/state/metrics/psi/LATEST.md`) で実測。

## 判定基準 (検証期日 2026-04-27)

- LCP < 2,500ms かつ `lcp_element` が `FeaturedRankings` 配下 → effect/full
- LCP < 5,000ms → effect/partial
- それ以外 → 仮説棄却（別 LCP 候補を再調査、banner 削除 / hero 強化を検討）

## Test plan

- [x] `npx tsc --noEmit -p apps/web/tsconfig.json` pass
- [ ] CI (pr-quality-check) pass
- [ ] develop merge → main merge → Cloudflare Pages deploy
- [ ] 翌朝 PSI 自動計測で LCP / lcp_element を実測
- [ ] EXP-003 を `experiments.json` で close (`effect/full|partial|none|adverse`)

## Related

- EXP-002 (ADVERSE) で得た教訓「LCP 要素を先に特定する」を適用
- `.claude/rules/evidence-based-judgment.md` の 3 点セット (仮説 / 検証コマンド / 検証期日) 準拠

🤖 Generated with [Claude Code](https://claude.com/claude-code)