### PR TITLE
perf(d1): correlation snapshot を R2 に出して /correlation の D1 read を 0 化

### DIFF
--- a/apps/web/src/app/correlation/page.tsx
+++ b/apps/web/src/app/correlation/page.tsx
@@ -9,6 +9,7 @@ import { isOk } from "@stats47/types";
 import { CorrelationPageClient } from "@/features/correlation";
 import { fetchCorrelationPairAction } from "@/features/correlation/server";
 
+import { logger } from "@/lib/logger";
 import { generateOGMetadata } from "@/lib/metadata/og-generator";
 
 import type { Metadata } from "next";
@@ -57,8 +58,13 @@ export default async function CorrelationPage({ searchParams }: PageProps) {
         topCorrelations = topCorrs;
         totalPairs = corrCounts.total;
         strongCount = corrCounts.strong;
-    } catch {
-        // R2 fetch / D1 接続エラー等の場合は空データで描画（500 を防ぐ）
+    } catch (error) {
+        // R2 fetch / D1 接続エラー等の場合は空データで描画（500 を防ぐ）。
+        // ただしサイレント failure を避けるため必ずログには残す。
+        logger.error(
+            { error: error instanceof Error ? error.message : String(error) },
+            "CorrelationPage: 初期データ取得に失敗。空表示にフォールバック",
+        );
     }
 
     // URL パラメータ指定 or ランキング1位をデフォルト表示

--- a/apps/web/src/app/correlation/page.tsx
+++ b/apps/web/src/app/correlation/page.tsx
@@ -1,6 +1,6 @@
 import {
-    countCorrelationStats,
-    listTopCorrelations,
+    readCorrelationStatsFromR2,
+    readTopCorrelationsFromR2,
     type TopCorrelation,
 } from "@stats47/correlation/server";
 import { listRankingItemsLite } from "@stats47/ranking/server";
@@ -13,6 +13,9 @@ import { generateOGMetadata } from "@/lib/metadata/og-generator";
 
 import type { Metadata } from "next";
 
+// correlation_analysis (1.5M rows) への full scan を防ぐため、
+// 集計済み snapshot を R2 経由で fetch する。Next.js Data Cache に乗せて二重防御。
+export const revalidate = 86400;
 
 const title = "都道府県統計の相関分析 | Stats47";
 const description =
@@ -47,15 +50,15 @@ export default async function CorrelationPage({ searchParams }: PageProps) {
     try {
         const [itemsResult, topCorrs, corrCounts] = await Promise.all([
             listRankingItemsLite({ isActive: true, areaType: "prefecture" }),
-            listTopCorrelations(20),
-            countCorrelationStats(),
+            readTopCorrelationsFromR2(20),
+            readCorrelationStatsFromR2(),
         ]);
         rankingOptions = isOk(itemsResult) ? itemsResult.data : [];
         topCorrelations = topCorrs;
         totalPairs = corrCounts.total;
         strongCount = corrCounts.strong;
     } catch {
-        // D1 接続エラー等の場合は空データで描画（500 を防ぐ）
+        // R2 fetch / D1 接続エラー等の場合は空データで描画（500 を防ぐ）
     }
 
     // URL パラメータ指定 or ランキング1位をデフォルト表示

--- a/apps/web/src/app/fishing-ports/page.tsx
+++ b/apps/web/src/app/fishing-ports/page.tsx
@@ -14,7 +14,8 @@ import { loadFishingPortData } from "@/features/fishing-ports/server";
 
 import type { Metadata } from "next";
 
-export const dynamic = "force-dynamic";
+// 漁港データ（2,896 港）は年次更新で十分。ISR 24h でクローラ毎の D1 全件スキャンを回避。
+export const revalidate = 86400;
 
 export const metadata: Metadata = {
   title: "漁港マップ | 統計で見る都道府県",

--- a/apps/web/src/app/search/page.tsx
+++ b/apps/web/src/app/search/page.tsx
@@ -12,7 +12,8 @@ import { generateOGMetadata } from "@/lib/metadata/og-generator";
 
 import type { Metadata } from "next";
 
-export const dynamic = "force-dynamic";
+// 検索インデックスはビルド時に static JSON として bundle 済み（D1 read なし）。
+// searchParams が異なれば Next.js が per-request render に切替えるので force-dynamic は不要。
 
 const searchTitle = "検索 | stats47";
 const searchDescription =

--- a/packages/correlation/package.json
+++ b/packages/correlation/package.json
@@ -18,6 +18,7 @@
   },
   "scripts": {
     "batch": "tsx -r ../ranking/src/scripts/setup-cli.js src/scripts/run-batch.ts",
+    "export-snapshot": "tsx -r ../ranking/src/scripts/setup-cli.js src/scripts/export-snapshot.ts",
     "test": "vitest",
     "test:run": "vitest run",
     "test:coverage": "vitest run --coverage",
@@ -26,6 +27,7 @@
   "dependencies": {
     "@stats47/database": "*",
     "@stats47/logger": "*",
+    "@stats47/r2-storage": "*",
     "@stats47/ranking": "*",
     "@stats47/types": "*",
     "drizzle-orm": "^0.45.1",

--- a/packages/correlation/src/exporters/__tests__/correlation-snapshot.test.ts
+++ b/packages/correlation/src/exporters/__tests__/correlation-snapshot.test.ts
@@ -1,0 +1,134 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+vi.mock("@stats47/database/server", () => ({
+  getDrizzle: vi.fn(),
+  correlationAnalysis: { pearsonR: { name: "pearson_r" } },
+}));
+
+vi.mock("@stats47/logger/server", () => ({
+  logger: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  },
+}));
+
+const { saveToR2Mock, listTopCorrelationsMock } = vi.hoisted(() => ({
+  saveToR2Mock: vi.fn(),
+  listTopCorrelationsMock: vi.fn(),
+}));
+
+vi.mock("@stats47/r2-storage/server", () => ({
+  saveToR2: saveToR2Mock,
+  fetchFromR2AsJson: vi.fn(),
+}));
+
+vi.mock("../../repositories/list-top-correlations", () => ({
+  listTopCorrelations: listTopCorrelationsMock,
+}));
+
+import { getDrizzle } from "@stats47/database/server";
+
+import { exportCorrelationSnapshot } from "../correlation-snapshot";
+import {
+  CORRELATION_STATS_KEY,
+  CORRELATION_TOP_PAIRS_KEY,
+  type CorrelationStatsSnapshot,
+  type CorrelationTopPairsSnapshot,
+} from "../../types/snapshot";
+
+function makeDrizzleStub(countResult: { total: number; strong: number }) {
+  return {
+    select: vi.fn().mockReturnValue({
+      from: vi.fn().mockResolvedValue([countResult]),
+    }),
+  };
+}
+
+function makePair(rankingKeyX: string, rankingKeyY: string, pearsonR: number) {
+  return {
+    rankingKeyX,
+    rankingKeyY,
+    titleX: rankingKeyX,
+    titleY: rankingKeyY,
+    normalizationBasisX: null,
+    normalizationBasisY: null,
+    pearsonR,
+    effectiveR: pearsonR,
+    partialRPopulation: null,
+    partialRArea: null,
+    partialRAging: null,
+    partialRDensity: null,
+  };
+}
+
+describe("exportCorrelationSnapshot", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    saveToR2Mock.mockResolvedValue({
+      key: "ignored",
+      size: 0,
+    });
+  });
+
+  it("R2 に top-pairs と stats の 2 ファイルを保存する", async () => {
+    const pairs = [
+      makePair("a", "b", 0.92),
+      makePair("a", "c", 0.85),
+      makePair("b", "c", 0.71),
+    ];
+    listTopCorrelationsMock.mockResolvedValue(pairs);
+    vi.mocked(getDrizzle).mockReturnValue(
+      makeDrizzleStub({ total: 1234, strong: 56 }) as never,
+    );
+
+    const result = await exportCorrelationSnapshot();
+
+    expect(saveToR2Mock).toHaveBeenCalledTimes(2);
+
+    const calls = saveToR2Mock.mock.calls;
+    const topPairsCall = calls.find((c) => c[0] === CORRELATION_TOP_PAIRS_KEY);
+    const statsCall = calls.find((c) => c[0] === CORRELATION_STATS_KEY);
+
+    expect(topPairsCall).toBeDefined();
+    expect(statsCall).toBeDefined();
+
+    const topPairsSnapshot = JSON.parse(
+      topPairsCall![1] as string,
+    ) as CorrelationTopPairsSnapshot;
+    expect(topPairsSnapshot.pairs).toHaveLength(3);
+    expect(topPairsSnapshot.pairs[0].rankingKeyX).toBe("a");
+    expect(topPairsSnapshot.generatedAt).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+
+    const statsSnapshot = JSON.parse(
+      statsCall![1] as string,
+    ) as CorrelationStatsSnapshot;
+    expect(statsSnapshot.total).toBe(1234);
+    expect(statsSnapshot.strong).toBe(56);
+    expect(statsSnapshot.generatedAt).toBe(topPairsSnapshot.generatedAt);
+
+    expect(result.topPairs.pairCount).toBe(3);
+    expect(result.durationMs).toBeGreaterThanOrEqual(0);
+  });
+
+  it("stats 行の strong が文字列でも数値に変換される", async () => {
+    listTopCorrelationsMock.mockResolvedValue([]);
+    vi.mocked(getDrizzle).mockReturnValue(
+      makeDrizzleStub({ total: 100, strong: "42" as unknown as number }) as never,
+    );
+
+    await exportCorrelationSnapshot();
+
+    const statsCall = saveToR2Mock.mock.calls.find(
+      (c) => c[0] === CORRELATION_STATS_KEY,
+    );
+    const statsSnapshot = JSON.parse(
+      statsCall![1] as string,
+    ) as CorrelationStatsSnapshot;
+    expect(statsSnapshot.strong).toBe(42);
+    expect(typeof statsSnapshot.strong).toBe("number");
+  });
+});

--- a/packages/correlation/src/exporters/correlation-snapshot.ts
+++ b/packages/correlation/src/exporters/correlation-snapshot.ts
@@ -1,0 +1,95 @@
+import "server-only";
+
+import { correlationAnalysis, getDrizzle } from "@stats47/database/server";
+import { logger } from "@stats47/logger/server";
+import { saveToR2 } from "@stats47/r2-storage/server";
+import { count, sql } from "drizzle-orm";
+
+import { listTopCorrelations } from "../repositories/list-top-correlations";
+import {
+  CORRELATION_STATS_KEY,
+  CORRELATION_TOP_PAIRS_KEY,
+  CORRELATION_TOP_PAIRS_SNAPSHOT_LIMIT,
+  type CorrelationStatsSnapshot,
+  type CorrelationTopPairsSnapshot,
+} from "../types/snapshot";
+
+export interface ExportCorrelationSnapshotResult {
+  topPairs: { key: string; sizeBytes: number; pairCount: number };
+  stats: { key: string; sizeBytes: number };
+  durationMs: number;
+}
+
+/**
+ * correlation_analysis の集計を 1 回だけクエリし、
+ * 上位ペアと統計値を R2 に snapshot として保存する。
+ *
+ * Web の /correlation ページはこの snapshot を fetch するだけになり、
+ * D1 への full scan は走らなくなる。
+ */
+export async function exportCorrelationSnapshot(
+  db?: ReturnType<typeof getDrizzle>,
+): Promise<ExportCorrelationSnapshotResult> {
+  const startedAt = Date.now();
+  const drizzleDb = db ?? getDrizzle();
+
+  const [pairs, statsRows] = await Promise.all([
+    listTopCorrelations(CORRELATION_TOP_PAIRS_SNAPSHOT_LIMIT, drizzleDb),
+    drizzleDb
+      .select({
+        total: count(),
+        strong: sql<number>`SUM(CASE WHEN ABS(${correlationAnalysis.pearsonR}) >= 0.7 THEN 1 ELSE 0 END)`,
+      })
+      .from(correlationAnalysis),
+  ]);
+
+  const generatedAt = new Date().toISOString();
+
+  const topPairsSnapshot: CorrelationTopPairsSnapshot = {
+    generatedAt,
+    pairs,
+  };
+  const statsSnapshot: CorrelationStatsSnapshot = {
+    generatedAt,
+    total: statsRows[0]?.total ?? 0,
+    strong: Number(statsRows[0]?.strong ?? 0),
+  };
+
+  const topPairsBody = JSON.stringify(topPairsSnapshot);
+  const statsBody = JSON.stringify(statsSnapshot);
+
+  const [topPairsResult, statsResult] = await Promise.all([
+    saveToR2(CORRELATION_TOP_PAIRS_KEY, topPairsBody, {
+      contentType: "application/json; charset=utf-8",
+    }),
+    saveToR2(CORRELATION_STATS_KEY, statsBody, {
+      contentType: "application/json; charset=utf-8",
+    }),
+  ]);
+
+  const durationMs = Date.now() - startedAt;
+  logger.info(
+    {
+      pairCount: pairs.length,
+      total: statsSnapshot.total,
+      strong: statsSnapshot.strong,
+      topPairsBytes: topPairsResult.size,
+      statsBytes: statsResult.size,
+      durationMs,
+    },
+    "correlation snapshot を R2 に保存しました",
+  );
+
+  return {
+    topPairs: {
+      key: topPairsResult.key,
+      sizeBytes: topPairsResult.size,
+      pairCount: pairs.length,
+    },
+    stats: {
+      key: statsResult.key,
+      sizeBytes: statsResult.size,
+    },
+    durationMs,
+  };
+}

--- a/packages/correlation/src/exporters/index.ts
+++ b/packages/correlation/src/exporters/index.ts
@@ -1,0 +1,4 @@
+export {
+  type ExportCorrelationSnapshotResult,
+  exportCorrelationSnapshot,
+} from "./correlation-snapshot";

--- a/packages/correlation/src/repositories/__tests__/read-correlation-snapshot.test.ts
+++ b/packages/correlation/src/repositories/__tests__/read-correlation-snapshot.test.ts
@@ -1,0 +1,103 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+vi.mock("@stats47/logger/server", () => ({
+  logger: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  },
+}));
+
+const { fetchFromR2AsJsonMock } = vi.hoisted(() => ({
+  fetchFromR2AsJsonMock: vi.fn(),
+}));
+
+vi.mock("@stats47/r2-storage/server", () => ({
+  fetchFromR2AsJson: fetchFromR2AsJsonMock,
+  saveToR2: vi.fn(),
+}));
+
+import {
+  readCorrelationStatsFromR2,
+  readTopCorrelationsFromR2,
+} from "../read-correlation-snapshot";
+import {
+  CORRELATION_STATS_KEY,
+  CORRELATION_TOP_PAIRS_KEY,
+} from "../../types/snapshot";
+
+function makePair(rankingKeyX: string, rankingKeyY: string) {
+  return {
+    rankingKeyX,
+    rankingKeyY,
+    titleX: rankingKeyX,
+    titleY: rankingKeyY,
+    normalizationBasisX: null,
+    normalizationBasisY: null,
+    pearsonR: 0.5,
+    effectiveR: 0.5,
+    partialRPopulation: null,
+    partialRArea: null,
+    partialRAging: null,
+    partialRDensity: null,
+  };
+}
+
+describe("readTopCorrelationsFromR2", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("snapshot 取得 → 上位 N 件を slice して返す", async () => {
+    const pairs = Array.from({ length: 50 }, (_, i) =>
+      makePair(`x${i}`, `y${i}`),
+    );
+    fetchFromR2AsJsonMock.mockResolvedValueOnce({
+      generatedAt: "2026-04-29T00:00:00Z",
+      pairs,
+    });
+
+    const result = await readTopCorrelationsFromR2(20);
+
+    expect(fetchFromR2AsJsonMock).toHaveBeenCalledWith(CORRELATION_TOP_PAIRS_KEY);
+    expect(result).toHaveLength(20);
+    expect(result[0].rankingKeyX).toBe("x0");
+  });
+
+  it("snapshot 不在時は空配列を返す（500 を防ぐ）", async () => {
+    fetchFromR2AsJsonMock.mockResolvedValueOnce(null);
+
+    const result = await readTopCorrelationsFromR2();
+
+    expect(result).toEqual([]);
+  });
+});
+
+describe("readCorrelationStatsFromR2", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("snapshot から total / strong を返す", async () => {
+    fetchFromR2AsJsonMock.mockResolvedValueOnce({
+      generatedAt: "2026-04-29T00:00:00Z",
+      total: 1500,
+      strong: 350,
+    });
+
+    const result = await readCorrelationStatsFromR2();
+
+    expect(fetchFromR2AsJsonMock).toHaveBeenCalledWith(CORRELATION_STATS_KEY);
+    expect(result).toEqual({ total: 1500, strong: 350 });
+  });
+
+  it("snapshot 不在時は { total: 0, strong: 0 } を返す", async () => {
+    fetchFromR2AsJsonMock.mockResolvedValueOnce(null);
+
+    const result = await readCorrelationStatsFromR2();
+
+    expect(result).toEqual({ total: 0, strong: 0 });
+  });
+});

--- a/packages/correlation/src/repositories/index.ts
+++ b/packages/correlation/src/repositories/index.ts
@@ -12,6 +12,10 @@ export {
   listTopCorrelations,
 } from "./list-top-correlations";
 export {
+  readCorrelationStatsFromR2,
+  readTopCorrelationsFromR2,
+} from "./read-correlation-snapshot";
+export {
   type UpsertCorrelationParams,
   upsertCorrelation,
 } from "./upsert-correlation";

--- a/packages/correlation/src/repositories/read-correlation-snapshot.ts
+++ b/packages/correlation/src/repositories/read-correlation-snapshot.ts
@@ -1,0 +1,56 @@
+import "server-only";
+
+import { logger } from "@stats47/logger/server";
+import { fetchFromR2AsJson } from "@stats47/r2-storage/server";
+
+import {
+  CORRELATION_STATS_KEY,
+  CORRELATION_TOP_PAIRS_KEY,
+  type CorrelationStatsSnapshot,
+  type CorrelationTopPairsSnapshot,
+} from "../types/snapshot";
+import type { TopCorrelation } from "./list-top-correlations";
+
+/**
+ * R2 上の correlation snapshot から上位 N 件を読み出す。
+ *
+ * snapshot 不在 / fetch 失敗時は空配列。フォールバック側で空表示すること。
+ * D1 へは一切クエリしない（D1 read 課金回避が目的）。
+ */
+export async function readTopCorrelationsFromR2(
+  limit = 20,
+): Promise<TopCorrelation[]> {
+  const snapshot =
+    await fetchFromR2AsJson<CorrelationTopPairsSnapshot>(CORRELATION_TOP_PAIRS_KEY);
+
+  if (!snapshot) {
+    logger.warn(
+      { key: CORRELATION_TOP_PAIRS_KEY },
+      "correlation top-pairs snapshot が R2 に存在しません。空配列を返します。",
+    );
+    return [];
+  }
+
+  return snapshot.pairs.slice(0, limit);
+}
+
+/**
+ * R2 上の correlation snapshot から統計値（全件・強相関件数）を読み出す。
+ */
+export async function readCorrelationStatsFromR2(): Promise<{
+  total: number;
+  strong: number;
+}> {
+  const snapshot =
+    await fetchFromR2AsJson<CorrelationStatsSnapshot>(CORRELATION_STATS_KEY);
+
+  if (!snapshot) {
+    logger.warn(
+      { key: CORRELATION_STATS_KEY },
+      "correlation stats snapshot が R2 に存在しません。0 を返します。",
+    );
+    return { total: 0, strong: 0 };
+  }
+
+  return { total: snapshot.total, strong: snapshot.strong };
+}

--- a/packages/correlation/src/repositories/read-correlation-snapshot.ts
+++ b/packages/correlation/src/repositories/read-correlation-snapshot.ts
@@ -11,6 +11,21 @@ import {
 } from "../types/snapshot";
 import type { TopCorrelation } from "./list-top-correlations";
 
+// snapshot を最後に更新してから何日経つと「古い」と扱うか。
+// バッチが手動運用なので 1 ヶ月以上の停滞があれば調査トリガにする。
+const STALE_AFTER_DAYS = 30;
+
+function warnIfStale(generatedAt: string, key: string): void {
+  const ageMs = Date.now() - new Date(generatedAt).getTime();
+  const ageDays = ageMs / (1000 * 60 * 60 * 24);
+  if (ageDays > STALE_AFTER_DAYS) {
+    logger.warn(
+      { key, generatedAt, ageDays: Math.round(ageDays) },
+      `correlation snapshot が ${STALE_AFTER_DAYS} 日以上更新されていません。バッチ再実行を検討してください`,
+    );
+  }
+}
+
 /**
  * R2 上の correlation snapshot から上位 N 件を読み出す。
  *
@@ -31,6 +46,7 @@ export async function readTopCorrelationsFromR2(
     return [];
   }
 
+  warnIfStale(snapshot.generatedAt, CORRELATION_TOP_PAIRS_KEY);
   return snapshot.pairs.slice(0, limit);
 }
 
@@ -52,5 +68,6 @@ export async function readCorrelationStatsFromR2(): Promise<{
     return { total: 0, strong: 0 };
   }
 
+  warnIfStale(snapshot.generatedAt, CORRELATION_STATS_KEY);
   return { total: snapshot.total, strong: snapshot.strong };
 }

--- a/packages/correlation/src/scripts/export-snapshot.ts
+++ b/packages/correlation/src/scripts/export-snapshot.ts
@@ -1,0 +1,30 @@
+#!/usr/bin/env tsx
+/**
+ * correlation snapshot を R2 に書き出すだけの軽量 CLI。
+ *
+ * 通常はバッチ完了時に自動で呼ばれるが、
+ * バッチを再実行せずに snapshot だけ最新化したいときに使う。
+ *
+ * Usage:
+ *   npx tsx -r ./packages/ranking/src/scripts/setup-cli.js \
+ *     packages/correlation/src/scripts/export-snapshot.ts
+ */
+
+import { exportCorrelationSnapshot } from "../exporters/correlation-snapshot";
+
+async function main() {
+  console.log("correlation snapshot を R2 に書き出します…");
+  const result = await exportCorrelationSnapshot();
+  console.log(`✅ 完了 (${result.durationMs}ms)`);
+  console.log(
+    `  ${result.topPairs.key} : ${result.topPairs.pairCount} pairs / ${result.topPairs.sizeBytes} bytes`,
+  );
+  console.log(
+    `  ${result.stats.key} : ${result.stats.sizeBytes} bytes`,
+  );
+}
+
+main().catch((err) => {
+  console.error("Fatal:", err);
+  process.exit(1);
+});

--- a/packages/correlation/src/server.ts
+++ b/packages/correlation/src/server.ts
@@ -1,5 +1,7 @@
 import "server-only";
 
+export * from "./exporters";
 export * from "./repositories";
 export * from "./services";
+export * from "./types/snapshot";
 export * from "./utils";

--- a/packages/correlation/src/services/run-batch-correlation.ts
+++ b/packages/correlation/src/services/run-batch-correlation.ts
@@ -2,6 +2,7 @@ import "server-only";
 
 import type { RankingItem } from "@stats47/ranking";
 import { listRankingItems, listRankingValues } from "@stats47/ranking/server";
+import { exportCorrelationSnapshot } from "../exporters/correlation-snapshot";
 import { upsertCorrelation } from "../repositories/upsert-correlation";
 import { isExcludedCorrelationKey, isExcludedCorrelationPair } from "../trivial-pairs";
 import { buildScatterData, calculatePartialR, calculatePearsonR } from "../utils/calculate-pearson";
@@ -442,6 +443,20 @@ export async function runBatchCorrelation(
     }
 
     const wasAborted = observer.isAborted();
+
+    try {
+      const snapshotResult = await exportCorrelationSnapshot();
+      observer.onLog(
+        "info",
+        `R2 snapshot を更新しました（pairs=${snapshotResult.topPairs.pairCount}, ${snapshotResult.durationMs}ms）`,
+      );
+    } catch (snapshotErr) {
+      observer.onLog(
+        "warn",
+        `R2 snapshot 更新に失敗（DB upsert は完了済み）: ${snapshotErr instanceof Error ? snapshotErr.message : String(snapshotErr)}`,
+      );
+    }
+
     observer.onComplete({
       success: true,
       message: wasAborted

--- a/packages/correlation/src/services/run-batch-correlation.ts
+++ b/packages/correlation/src/services/run-batch-correlation.ts
@@ -444,6 +444,8 @@ export async function runBatchCorrelation(
 
     const wasAborted = observer.isAborted();
 
+    let snapshotStatus: "ok" | "failed" = "ok";
+    let snapshotErrorMessage: string | null = null;
     try {
       const snapshotResult = await exportCorrelationSnapshot();
       observer.onLog(
@@ -451,17 +453,26 @@ export async function runBatchCorrelation(
         `R2 snapshot を更新しました（pairs=${snapshotResult.topPairs.pairCount}, ${snapshotResult.durationMs}ms）`,
       );
     } catch (snapshotErr) {
+      snapshotStatus = "failed";
+      snapshotErrorMessage = snapshotErr instanceof Error ? snapshotErr.message : String(snapshotErr);
+      // DB は更新済みだが Web で見えるデータは古い snapshot のまま、というズレが起きるため error 扱い。
       observer.onLog(
-        "warn",
-        `R2 snapshot 更新に失敗（DB upsert は完了済み）: ${snapshotErr instanceof Error ? snapshotErr.message : String(snapshotErr)}`,
+        "error",
+        `R2 snapshot 更新失敗: DB upsert は成功したが Web 反映が古い。要再実行 (npm run export-snapshot --workspace=packages/correlation)。原因: ${snapshotErrorMessage}`,
       );
     }
 
+    const baseMessage = wasAborted
+      ? `中断しました: 完了 ${completed}件, スキップ ${skipped}件, 失敗 ${failed}件`
+      : `完了 ${completed}件, スキップ ${skipped}件, 失敗 ${failed}件`;
+    const fullMessage =
+      snapshotStatus === "ok"
+        ? `${baseMessage} / R2 snapshot 更新済`
+        : `${baseMessage} / ⚠️ R2 snapshot 更新失敗 (Web は旧 snapshot を表示中)`;
+
     observer.onComplete({
       success: true,
-      message: wasAborted
-        ? `中断しました: 完了 ${completed}件, スキップ ${skipped}件, 失敗 ${failed}件`
-        : `完了 ${completed}件, スキップ ${skipped}件, 失敗 ${failed}件`,
+      message: fullMessage,
     });
   } catch (e) {
     observer.onLog(

--- a/packages/correlation/src/types/snapshot.ts
+++ b/packages/correlation/src/types/snapshot.ts
@@ -4,6 +4,10 @@ export const CORRELATION_SNAPSHOT_PREFIX = "snapshots/correlation";
 export const CORRELATION_TOP_PAIRS_KEY = `${CORRELATION_SNAPSHOT_PREFIX}/top-pairs.json`;
 export const CORRELATION_STATS_KEY = `${CORRELATION_SNAPSHOT_PREFIX}/stats.json`;
 
+// listTopCorrelations 内部で `.limit(N * 10)` してから除外フィルタを通すため、
+// 200 件 snapshot を作るには内部 SQL 上限 2,000 件で十分（既存実装と同じ前提）。
+// 200 = Web 想定 limit (20) × 10 倍バッファ。除外フィルタが想定外に厳しくても
+// 上位 200 ペアまでなら十分埋まる経験則。
 export const CORRELATION_TOP_PAIRS_SNAPSHOT_LIMIT = 200;
 
 export interface CorrelationTopPairsSnapshot {

--- a/packages/correlation/src/types/snapshot.ts
+++ b/packages/correlation/src/types/snapshot.ts
@@ -1,0 +1,18 @@
+import type { TopCorrelation } from "../repositories/list-top-correlations";
+
+export const CORRELATION_SNAPSHOT_PREFIX = "snapshots/correlation";
+export const CORRELATION_TOP_PAIRS_KEY = `${CORRELATION_SNAPSHOT_PREFIX}/top-pairs.json`;
+export const CORRELATION_STATS_KEY = `${CORRELATION_SNAPSHOT_PREFIX}/stats.json`;
+
+export const CORRELATION_TOP_PAIRS_SNAPSHOT_LIMIT = 200;
+
+export interface CorrelationTopPairsSnapshot {
+  generatedAt: string;
+  pairs: TopCorrelation[];
+}
+
+export interface CorrelationStatsSnapshot {
+  generatedAt: string;
+  total: number;
+  strong: number;
+}

--- a/packages/r2-storage/src/lib/clients/create-s3-client.ts
+++ b/packages/r2-storage/src/lib/clients/create-s3-client.ts
@@ -1,6 +1,19 @@
 import { S3Client } from "@aws-sdk/client-s3";
 import { logger } from "@stats47/logger";
-import { HttpsProxyAgent } from "https-proxy-agent";
+
+// https-proxy-agent は ESM-only で `"exports": { "import": ... }` のみ。
+// tsx + setup-cli.js の CJS 経路で静的 import すると ERR_PACKAGE_PATH_NOT_EXPORTED
+// で失敗するため、プロキシが必要なときのみ require する遅延ロードに切替。
+type HttpsProxyAgentCtor = new (proxy: string) => unknown;
+function loadHttpsProxyAgent(): HttpsProxyAgentCtor | null {
+  try {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const mod = require("https-proxy-agent") as { HttpsProxyAgent: HttpsProxyAgentCtor };
+    return mod.HttpsProxyAgent;
+  } catch {
+    return null;
+  }
+}
 
 /**
  * R2エンドポイントがNO_PROXYに含まれているか確認
@@ -58,20 +71,28 @@ export function createS3Client(): S3Client {
   const bypassProxy = shouldBypassProxy(r2Endpoint, noProxy);
 
   // プロキシエージェントの設定
-  let httpAgent: HttpsProxyAgent<string> | undefined;
-  let httpsAgent: HttpsProxyAgent<string> | undefined;
+  let httpAgent: unknown | undefined;
+  let httpsAgent: unknown | undefined;
 
   if (httpsProxy && !bypassProxy) {
-    try {
-      const proxyAgent = new HttpsProxyAgent<string>(httpsProxy);
-      httpAgent = proxyAgent;
-      httpsAgent = proxyAgent;
-    } catch (error) {
+    const HttpsProxyAgentClass = loadHttpsProxyAgent();
+    if (HttpsProxyAgentClass) {
+      try {
+        const proxyAgent = new HttpsProxyAgentClass(httpsProxy);
+        httpAgent = proxyAgent;
+        httpsAgent = proxyAgent;
+      } catch (error) {
+        logger.warn(
+          {
+            error: error instanceof Error ? error.message : String(error),
+          },
+          "S3クライアント: プロキシエージェントの作成に失敗、プロキシなしで続行"
+        );
+      }
+    } else {
       logger.warn(
-        {
-          error: error instanceof Error ? error.message : String(error),
-        },
-        "S3クライアント: プロキシエージェントの作成に失敗、プロキシなしで続行"
+        { httpsProxy },
+        "https-proxy-agent を遅延ロードできませんでした。プロキシなしで続行します",
       );
     }
   }

--- a/packages/r2-storage/src/lib/operations/save.ts
+++ b/packages/r2-storage/src/lib/operations/save.ts
@@ -15,6 +15,61 @@ import { convertBodyForR2 } from "../utils/convert-body-for-r2"; // This file wa
 import { detectEnvironment } from "../utils/detect-environment";
 
 /**
+ * Cloudflare REST API 経由でオブジェクトを保存
+ * S3 API がプロキシ / 認証エラーで失敗するときの汎用フォールバック
+ * （fetchFromCloudflareApi の write 版。AWS SDK / https-proxy-agent を経由しない）
+ */
+async function saveToCloudflareApi(
+  key: string,
+  body: string | ArrayBuffer | Buffer | Uint8Array,
+  options?: { contentType?: string },
+): Promise<void> {
+  const accountId = process.env.CLOUDFLARE_ACCOUNT_ID;
+  const apiToken = process.env.CLOUDFLARE_API_TOKEN;
+  const bucketName = process.env.CLOUDFLARE_R2_BUCKET_NAME || "stats47";
+
+  if (!accountId || !apiToken) {
+    throw new Error(
+      "Cloudflare REST API 経由の保存に必要な環境変数が未設定です: CLOUDFLARE_ACCOUNT_ID, CLOUDFLARE_API_TOKEN",
+    );
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const { ProxyAgent, fetch: undiciFetch } = require("undici");
+  const proxy = process.env.HTTPS_PROXY || process.env.HTTP_PROXY;
+  const dispatcher = proxy ? new ProxyAgent(proxy) : undefined;
+
+  let payload: Buffer | Uint8Array | string;
+  if (Buffer.isBuffer(body)) {
+    payload = body;
+  } else if (body instanceof ArrayBuffer) {
+    payload = Buffer.from(body);
+  } else if (body instanceof Uint8Array) {
+    payload = body;
+  } else {
+    payload = String(body);
+  }
+
+  const url = `https://api.cloudflare.com/client/v4/accounts/${accountId}/r2/buckets/${bucketName}/objects/${encodeURIComponent(key)}`;
+  const response = await undiciFetch(url, {
+    method: "PUT",
+    dispatcher,
+    headers: {
+      Authorization: `Bearer ${apiToken}`,
+      "Content-Type": options?.contentType || "application/json",
+    },
+    body: payload,
+  });
+
+  if (!response.ok) {
+    const text = await response.text().catch(() => "");
+    throw new Error(
+      `Cloudflare REST API での保存に失敗: ${response.status} ${text} for key=${key}`,
+    );
+  }
+}
+
+/**
  * オブジェクトを R2 に保存
  *
  * @param key - オブジェクトキー
@@ -61,12 +116,22 @@ export async function saveToR2(
       };
 
       await s3Client.send(new PutObjectCommand(input));
-      
+
       logger.info({ key, size }, "S3クライアント経由でオブジェクト保存完了");
       return { key, size };
     } catch (error) {
-      logger.error({ key, error }, "S3クライアント経由でのオブジェクト保存に失敗しました");
-      throw error;
+      logger.warn(
+        { key, error: error instanceof Error ? error.message : String(error) },
+        "S3クライアント経由での保存に失敗、Cloudflare REST API にフォールバックします",
+      );
+      try {
+        await saveToCloudflareApi(key, body, options);
+        logger.info({ key, size }, "Cloudflare REST API 経由でオブジェクト保存完了");
+        return { key, size };
+      } catch (cfError) {
+        logger.error({ key, s3Error: error, cfError }, "S3・Cloudflare REST API 両方で保存に失敗しました");
+        throw cfError;
+      }
     }
   }
 

--- a/packages/r2-storage/src/lib/operations/save.ts
+++ b/packages/r2-storage/src/lib/operations/save.ts
@@ -5,13 +5,7 @@ import { createS3Client } from "../clients/create-s3-client";
 import { getR2Client } from "../clients/get-r2-client";
 import { handleR2Error } from "../errors/handle-r2-error";
 import { calculateBodySize } from "../utils/calculate-body-size";
-import { convertBodyForR2 } from "../utils/convert-body-for-r2"; // This file was marked for deletion, checking if I need to inline it or keep it. Plan said delete, but save logic uses it. I should inline or keep. Plan said delete convert-body.ts, but valid code uses convertBodyForR2. Ah, convert-body.ts was separate from convert-body-for-r2.ts. Checking if convert-body-for-r2.ts exists.
-
-// Checking imports in save-to-r2.ts: import { convertBodyForR2 } from "../utils/convert-body-for-r2";
-// My plan deleted `packages/r2-storage/src/lib/utils/convert-body.ts`.
-// I should check if `convert-body-for-r2.ts` exists.
-// Assuming it does based on import.
-
+import { convertBodyForR2 } from "../utils/convert-body-for-r2";
 import { detectEnvironment } from "../utils/detect-environment";
 
 /**


### PR DESCRIPTION
## Context

2026-04 月次 invoice **\$26.62** の根本原因は `correlation_analysis` テーブル (~1.5M 行) への full-scan 2 クエリ。

実証データ (`cloudflare-graphql` の `d1QueriesAdaptiveGroups` を `query` ディメンションでグルーピング、計測期間 2026-04-22〜04-28、Ray ID 9f38e7e2b766d341 等):

| クエリ概要 | 7 日間 rows read | call 数 | 1 call あたり |
|---|---|---|---|
| `listTopCorrelations` の `MIN(COALESCE(ABS(partial_r_*)…))` ORDER BY | 11.36B | 1,873 | ~6.07M 行 |
| `countCorrelationStats` の `count(*) + SUM(CASE WHEN ABS(pearson_r) >= 0.7 ...)` | 3.21B | 2,103 | ~1.53M 行 |
| **計** | **14.57B** | — | — |

これらは `apps/web/src/app/correlation/page.tsx:50-51` から呼ばれる。同 page は ISR 未設定で毎リクエスト 2 つの全件スキャンを叩いていた。漁業テーマ追加 (2026-04-25 commit `55b596dd`) で `correlation_analysis` が ~1.5M 行に拡大したのが引き金。

このペースが続けば次回請求 (2026-05-15) は **約 \$54**（前月の 2 倍）と推定。

## 設計方針

**集計済み・低更新頻度の JSON は R2 に snapshot として書き出し、Web は R2 → CDN → ブラウザの一方向で読む。D1 はバッチ実行時とユーザー固有の動的クエリでのみ使う。**

R2 名前空間規約 `snapshots/<domain>/<name>.json` を新設。

## 変更内容

### Phase B: correlation の根本対策

新規:
- `packages/correlation/src/types/snapshot.ts` — snapshot の型と R2 パス定数
- `packages/correlation/src/exporters/correlation-snapshot.ts` — `exportCorrelationSnapshot()` で D1 → R2 に top-pairs (上位 200) + stats (total/strong) を書き出し
- `packages/correlation/src/repositories/read-correlation-snapshot.ts` — Web 用 `readTopCorrelationsFromR2(limit)` / `readCorrelationStatsFromR2()` + 30 日以上古ければ warn する staleness 監視
- `packages/correlation/src/scripts/export-snapshot.ts` — バッチを再実行せずに snapshot だけ更新する軽量 CLI
- 単体テスト 6 件 (vi.hoisted パターン)

修正:
- `services/run-batch-correlation.ts` — バッチ成功時に exportCorrelationSnapshot() を呼出。snapshot 失敗は **error レベル** + onComplete message に「⚠️ R2 snapshot 更新失敗」を含める（DB 更新済 / Web 反映古い のズレを運用者が見落とさないため）
- `apps/web/src/app/correlation/page.tsx` — D1 経由 → R2 reader 経由 + `revalidate = 86400` + 失敗時 catch で logger.error を残す

### Phase D: force-dynamic 撤去

- `apps/web/src/app/search/page.tsx` — 検索 index は build 時 static JSON のため D1 不要、force-dynamic 削除
- `apps/web/src/app/fishing-ports/page.tsx` — `dynamic = "force-dynamic"` → `revalidate = 86400` に置換 (漁港データ 2,896 港、年次更新)

### 共通基盤の修正

- `packages/r2-storage/src/lib/operations/save.ts` — `saveToR2` が S3 で失敗したとき `undici` 直接で Cloudflare REST API に PUT する fallback を追加 (`fetchFromCloudflareApi` の write 版)
- `packages/r2-storage/src/lib/clients/create-s3-client.ts` — `https-proxy-agent` の静的 import を遅延 `require` に変更 (ESM-only な exports なので tsx + setup-cli.js (CJS) 経路で `ERR_PACKAGE_PATH_NOT_EXPORTED` が出るため)

## 検証

- [x] `npm run test:run --workspace=packages/correlation` — 全 63 テスト pass (新規 6 件含む)
- [x] `npx tsc --noEmit -p apps/web/tsconfig.json` — clean
- [x] 本番 R2 に export-snapshot 実行 (S3 401 → CF REST API fallback で成功)
  - `snapshots/correlation/top-pairs.json` : **200 pairs / 84,518 bytes**
  - `snapshots/correlation/stats.json` : **73 bytes** (`total=1,674,544 / strong=48,157`)
- [x] ローカル dev で /correlation /search /fishing-ports すべて HTTP 200
- [x] /correlation rendered HTML に `1,674,544` `48,157` `flood-casualties` 等の R2 由来データが正しく出力されることを確認
- [x] code-reviewer による批判的レビュー実施。指摘事項を反映 (commit `dbb93ead`)

## 想定削減（実証ベース）

- /correlation 経路の D1 read:
  - **Before**: 14.57B / 7 日 (= 月 ~64.5B、無料枠 25B 超過分のみ課金 ~\$39.5)
  - **After**: ~10M / 月（initial render 時の `findCorrelationPair` 単一行 read + `listRankingItemsLite` ~1500 行 read。いずれもインデックス効く軽量クエリ。ISR キャッシュエントリ数 × 数行レベル）
  - **削減率: 99.93%**
- 月次 D1 read 全体は ~50% 残存（`ranking_items` / `ranking_data` のクエリ群、Issue #150 で対応予定）
- 本 PR 単独での月次請求予測: **\$54 → \$15-20**（D1 read 課金大半消失。残存は ranking 系）

## effect 判定基準

参照: `.claude/rules/evidence-based-judgment.md`

- デプロイ翌日: `cloudflare-graphql` の `d1QueriesAdaptiveGroups` で `correlation_analysis` クエリが top 5 から消えていることを確認
- MID (デプロイ + 14 日): D1 read 7 日平均が pre-deploy ベースライン (561M/日) 以下
- FINAL (請求 2026-05-15): `[Cost Snapshot] 2026-05` Issue で前月比 ≥ 60% 減なら effect/full

## 残タスク（別 issue で対応予定）

- **Issue #150** — `ranking_items` / `ranking_data` の R2 snapshot 化 (PR #149 後の主要残存源、月次 D1 read の ~50% を占める)
- code-reviewer 指摘の C3 / m3 (convertBodyForR2 重複)、M3 (実 SQL 統合テスト)、M4 (manual cache invalidation 経路) は本 PR 範囲外

## Test plan

- [ ] CI (`pr-quality-check.yml`) が pass する
- [ ] develop → main にマージ後、`/deploy` で本番反映
- [ ] 翌日の cloudflare-graphql 実測で `correlation_analysis` クエリが top に出ないこと
- [ ] `/correlation` がブラウザで正常表示 (上位 20 ペアと total/strong)
- [ ] `/search` `/fishing-ports` の挙動退行なし
- [ ] Cloudflare Pages の Edge cache size を 1 週間モニタ (M1 懸念: /search の searchParams 組合せでキャッシュ膨張がないか)

🤖 Generated with [Claude Code](https://claude.com/claude-code)