### PR TITLE
fix(db): build 時の D1 binding 不在で noop adapter にフォールバック

### DIFF
--- a/packages/database/src/adapters/noop-adapter.ts
+++ b/packages/database/src/adapters/noop-adapter.ts
@@ -1,0 +1,49 @@
+import type { D1Database } from "@cloudflare/workers-types";
+import { logger } from "@stats47/logger";
+
+import {
+  type D1Adapter,
+  type D1PreparedStatementAdapter,
+  type D1Result,
+  asD1Database,
+} from "../types";
+
+/**
+ * 全クエリを空結果で返す noop アダプタ。
+ *
+ * Cloudflare Workers ビルド時 (NEXT_PHASE=phase-production-build) に D1 binding が
+ * 利用できない場合、`getStaticDatabase()` が throw すると `next build` の RSC 静的生成が
+ * 中断する (build worker exits 1)。本アダプタを返すことで「クエリは success だが空配列」
+ * という形にし、ビルドを通過させる。
+ *
+ * 実リクエスト時は Cloudflare Workers の D1 binding が context 経由で注入されるので
+ * このアダプタには到達しない。
+ */
+export function createNoopAdapter(): D1Database {
+  const emptyResult: D1Result<unknown> = {
+    results: [],
+    success: true,
+    meta: { duration: 0 } as any,
+  };
+
+  const stmt: D1PreparedStatementAdapter = {
+    bind: () => stmt,
+    first: async () => null,
+    run: async () => emptyResult,
+    all: async () => emptyResult as D1Result<any>,
+    raw: async () => [],
+  };
+
+  const adapter: D1Adapter = {
+    prepare: () => stmt,
+    dump: async () => new ArrayBuffer(0),
+    batch: async () => [],
+    exec: async () => ({ count: 0, duration: 0 }),
+  };
+
+  logger.warn(
+    "[noop D1 adapter] D1 binding 不在のため空アダプタを返します。実クエリは [] / null を返します",
+  );
+
+  return asD1Database(adapter);
+}

--- a/packages/database/src/core/d1-database.ts
+++ b/packages/database/src/core/d1-database.ts
@@ -2,6 +2,7 @@ import "server-only";
 
 import type { D1Database } from "@cloudflare/workers-types";
 import { logger } from "@stats47/logger";
+import { createNoopAdapter } from "../adapters/noop-adapter";
 import { createDatabaseClient } from "../client";
 import {
   getCachedStaticDb,
@@ -60,13 +61,29 @@ export function getStaticDatabase(): D1Database {
 
   // 4. クライアント作成
   // createDatabaseClientは binding があればそれを使い、なければ条件に応じてローカルアダプタを使う
-  const db = createDatabaseClient({
-    binding: contextDb, // undefined here, but standard pattern
-    localDbPath: localPath,
-    // アプリ固有の条件: 開発環境かつサーバーサイドならローカルアダプタを試行
-    // (createDatabaseClient内部のデフォルト判定と同じだが明示的に渡すことも可能)
-    useLocalAdapter: isDevelopmentEnv() && isServerSide()
-  });
+  let db: D1Database;
+  try {
+    db = createDatabaseClient({
+      binding: contextDb, // undefined here, but standard pattern
+      localDbPath: localPath,
+      // アプリ固有の条件: 開発環境かつサーバーサイドならローカルアダプタを試行
+      // (createDatabaseClient内部のデフォルト判定と同じだが明示的に渡すことも可能)
+      useLocalAdapter: isDevelopmentEnv() && isServerSide()
+    });
+  } catch (error) {
+    // build 時 (NEXT_PHASE=phase-production-build) は D1 binding も local DB も
+    // 利用不可 → throw すると静的生成が中断する。空アダプタで degrade する。
+    if (process.env.NEXT_PHASE === "phase-production-build") {
+      logger.warn(
+        { error: error instanceof Error ? error.message : String(error) },
+        "[getStaticDatabase] build 時に D1 binding 不在のため noop アダプタを使用",
+      );
+      db = createNoopAdapter();
+      // ビルド中はキャッシュしない (実 binding が来たときに切替えるため)
+      return db;
+    }
+    throw error;
+  }
 
   // 結果をキャッシュ
   setCachedStaticDb(db);


### PR DESCRIPTION
## Summary

Phase 2 (PR #163) 後の Workers deploy が `Generating static pages` 中に
`Error: D1データベースバインディングが見つからず` で exit 1 する原因を解消。

実は Phase 1 以前から同症状で `deploy-workers.yml` は連続失敗中だった (Cloudflare
Pages の auto-build とは別経路で本番反映自体は維持されていた)。

build 時に限り D1 binding 不在を soft-fail し、空結果を返す noop adapter で
代替して build を通過させる。実リクエスト時は Workers の D1 binding が context
経由で注入されるので noop には到達しない。

## 変更

- `packages/database/src/adapters/noop-adapter.ts` 新規 — 全クエリを空結果に固定する D1Adapter
- `packages/database/src/core/d1-database.ts` 修正 — `NEXT_PHASE === "phase-production-build"` の時のみ noop にフォールバック (それ以外は従来通り throw)

## 想定効果

- `deploy-workers.yml` の build phase が完走するようになる
- Phase 3 (ranking_values) / Phase 4 (blog) を待たずに Workers 経路の生死確認が可能

## Test plan

- [ ] PR merge 後、`Deploy to Cloudflare Workers` が完走 (exit 0)
- [ ] 本番 `/ranking/total-population` が引き続き 200 (D1 binding が context から取れる)
- [ ] 本番 `/correlation/foo` が 410 (Phase 1 middleware 維持)
- [ ] dev server で D1 binding 注入されるパスが影響受けないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)