### PR TITLE
fix(build): per-key correlation snapshot を build 時にスキップ

### DIFF
--- a/packages/correlation/src/repositories/read-correlation-by-key.ts
+++ b/packages/correlation/src/repositories/read-correlation-by-key.ts
@@ -34,6 +34,13 @@ export async function readHighlyCorrelatedFromR2(
   rankingKey: string,
   limit = 10,
 ): Promise<Result<CorrelatedItem[], Error>> {
+  // build 時 (NEXT_PHASE=phase-production-build): 1,920 ranking_key 各々に R2 fetch すると
+  // build が 30 分超 に伸びる。ここで空配列を返し、ISR (revalidate=86400) で初回リクエスト時に
+  // 生 fetch する。CorrelationSection は空のとき非表示なので first request の品質低下のみ。
+  if (process.env.NEXT_PHASE === "phase-production-build") {
+    return ok([]);
+  }
+
   try {
     const path = correlationByKeyPath(rankingKey);
     const snapshot = await fetchFromR2AsJson<CorrelationByKeySnapshot>(path);


### PR DESCRIPTION
## Summary

Phase 2 + noop D1 adapter (PR #163, #164) 後の Workers build が **32 分経過しても完了せず** キャンセル。原因はランキング詳細ページ (2,023 件) の `CorrelationSection` が 1,920 個の R2 fetch を build 時に発行していること。

## 修正

`readHighlyCorrelatedFromR2` の冒頭で `NEXT_PHASE === "phase-production-build"` を判定し、即 `ok([])` を返す。CorrelationSection は初回 ISR (revalidate 24h) で生 fetch する。

## 影響と緩和

- 初回ユーザーアクセス時のみ CorrelationSection が空表示
- 1 リクエスト後は CDN キャッシュされ次回以降フル表示
- SEO/UX への影響は最小 (RSS/sitemap には影響なし)

## Test plan

- [ ] PR merge 後、`Deploy to Cloudflare Workers` build が 10 分以内に完了
- [ ] 本番 `/ranking/total-population` 200
- [ ] 初回アクセス後の 2回目 `/ranking/total-population` で CorrelationSection が描画される

🤖 Generated with [Claude Code](https://claude.com/claude-code)