### PR TITLE
fix(gis): topology fetch を build 時にスキップ

### DIFF
--- a/packages/gis/src/geoshape/services/geoshape-service.ts
+++ b/packages/gis/src/geoshape/services/geoshape-service.ts
@@ -113,6 +113,14 @@ export interface Logger {
 export async function fetchPrefectureTopology(
   logger?: Logger
 ): Promise<TopoJSONTopology> {
+  // build 時 (NEXT_PHASE=phase-production-build): 2,000 超のランキングページが
+  // 各々 topology を fetch すると build が 30 分超 に伸びる (1 fetch ~数 MB)。
+  // ここで throw → ページ側は catch して null を渡し、ISR で初回リクエスト時に
+  // 生 fetch する。
+  if (process.env.NEXT_PHASE === "phase-production-build") {
+    throw new Error("topology fetch skipped at build phase");
+  }
+
   const startTime = startPerformanceMeasurement();
 
   try {
@@ -219,6 +227,10 @@ export async function fetchMunicipalityTopology(
   wardMode: DesignatedCityWardMode = "merged",
   logger?: Logger
 ): Promise<TopoJSONTopology> {
+  if (process.env.NEXT_PHASE === "phase-production-build") {
+    throw new Error("topology fetch skipped at build phase");
+  }
+
   const startTime = startPerformanceMeasurement();
 
   try {
@@ -310,6 +322,10 @@ export async function fetchMunicipalityTopology(
 export async function fetchAllCitiesTopology(
   logger?: Logger
 ): Promise<TopoJSONTopology> {
+  if (process.env.NEXT_PHASE === "phase-production-build") {
+    throw new Error("topology fetch skipped at build phase");
+  }
+
   const startTime = startPerformanceMeasurement();
 
   try {


### PR DESCRIPTION
## Summary
- 2,000 超のランキングページ × topology fetch (~数 MB) で Workers build が 30 分超に伸びていた問題への対応
- \`NEXT_PHASE=phase-production-build\` 時は \`fetchPrefectureTopology\` / \`fetchMunicipalityTopology\` / \`fetchAllCitiesTopology\` を throw
- caller 側は既に try/catch + null フォールバック済み → ISR で初回リクエスト時に topology を取得

## Background
Phase 2 (R2 master snapshot) デプロイ過程で、Workers build が 32 分でタイムアウト。原因調査で:
- 2,023 ranking pages 各々が \`fetchPrefectureTopology()\` を呼出
- 内部で R2 → 外部 API フォールバック、キャッシュなし
- 1 fetch あたり数 MB の TopoJSON

PR #149 (per-key correlation skip) と同じパターンを topology にも適用。

## Test plan
- [x] 既存の null ハンドリング caller を全数確認 (5 箇所すべて try/catch or .catch)
- [ ] Workers build が 32 分未満で完了
- [ ] デプロイ後 \`/ranking/total-population\` の地図ブロックが ISR 経由で表示

🤖 Generated with [Claude Code](https://claude.com/claude-code)