### PR TITLE
feat(blog): Phase 4 - articles を R2 snapshot 化

### DIFF
--- a/apps/web/scripts/export-blog-snapshot.ts
+++ b/apps/web/scripts/export-blog-snapshot.ts
@@ -1,0 +1,122 @@
+/**
+ * Blog snapshot exporter
+ *
+ * D1 articles / article_tags / tags をローカル SQLite から読み、
+ * `snapshots/blog/all.json` を R2 に書き出す。
+ *
+ * 使用方法: npx tsx scripts/export-blog-snapshot.ts
+ */
+
+import dotenv from "dotenv";
+import { drizzle } from "drizzle-orm/better-sqlite3";
+import { eq } from "drizzle-orm";
+import fs from "fs";
+import path from "path";
+import BetterSqlite3 from "better-sqlite3";
+
+import { LOCAL_DB_PATHS } from "../../../packages/database/src/config/local-db-paths";
+import * as schema from "../../../packages/database/src/schema";
+import { saveToR2 } from "@stats47/r2-storage/server";
+
+import {
+  BLOG_SNAPSHOT_KEY,
+  type BlogSnapshot,
+  type SnapshotArticle,
+  type SnapshotTagMeta,
+} from "../src/features/blog/types/snapshot";
+
+dotenv.config({ path: ".env.local" });
+dotenv.config({ path: ".env" });
+
+function resolveDatabasePath(): string {
+  if (process.env.LOCAL_DB_PATH && fs.existsSync(process.env.LOCAL_DB_PATH)) {
+    return process.env.LOCAL_DB_PATH;
+  }
+  const standardPath = LOCAL_DB_PATHS.STATIC.getPath();
+  if (fs.existsSync(standardPath)) return standardPath;
+  throw new Error(
+    `ローカル D1 SQLite が見つかりません: ${standardPath}`,
+  );
+}
+
+async function main() {
+  const dbPath = resolveDatabasePath();
+  console.log(`📁 DB: ${dbPath}`);
+
+  const sqlite = new BetterSqlite3(dbPath, { readonly: true });
+  const db = drizzle(sqlite, { schema });
+
+  const articleRows = await db.select().from(schema.articles);
+  const articleTagRows = await db
+    .select({
+      slug: schema.articleTags.slug,
+      tagKey: schema.articleTags.tagKey,
+      tagName: schema.tags.tagName,
+    })
+    .from(schema.articleTags)
+    .innerJoin(schema.tags, eq(schema.articleTags.tagKey, schema.tags.tagKey));
+
+  const tagsBySlug = new Map<string, Array<{ tagKey: string; tagName: string }>>();
+  for (const row of articleTagRows) {
+    const list = tagsBySlug.get(row.slug);
+    const entry = { tagKey: row.tagKey, tagName: row.tagName };
+    if (list) {
+      list.push(entry);
+    } else {
+      tagsBySlug.set(row.slug, [entry]);
+    }
+  }
+
+  const snapshotArticles: SnapshotArticle[] = articleRows.map((a) => ({
+    ...a,
+    tags: tagsBySlug.get(a.slug) ?? [],
+  }));
+
+  const tagMetaCounter = new Map<
+    string,
+    { tagName: string; articleCount: number }
+  >();
+  for (const a of snapshotArticles) {
+    if (!a.published) continue;
+    for (const t of a.tags) {
+      const existing = tagMetaCounter.get(t.tagKey);
+      if (existing) {
+        existing.articleCount++;
+      } else {
+        tagMetaCounter.set(t.tagKey, {
+          tagName: t.tagName,
+          articleCount: 1,
+        });
+      }
+    }
+  }
+  const tagMeta: SnapshotTagMeta[] = [...tagMetaCounter.entries()]
+    .map(([tagKey, { tagName, articleCount }]) => ({
+      tagKey,
+      tagName,
+      articleCount,
+    }))
+    .sort((a, b) => b.articleCount - a.articleCount);
+
+  const snapshot: BlogSnapshot = {
+    generatedAt: new Date().toISOString(),
+    articles: snapshotArticles,
+    tagMeta,
+  };
+
+  const body = JSON.stringify(snapshot);
+  const result = await saveToR2(BLOG_SNAPSHOT_KEY, body, {
+    contentType: "application/json; charset=utf-8",
+  });
+
+  console.log(
+    `✅ blog snapshot: articles=${snapshot.articles.length} tags=${snapshot.tagMeta.length} bytes=${result.size} key=${result.key}`,
+  );
+
+  sqlite.close();
+}
+
+main().catch((err) => {
+  console.error("Fatal:", err);
+  process.exit(1);
+});

--- a/apps/web/src/app/blog/[slug]/page.tsx
+++ b/apps/web/src/app/blog/[slug]/page.tsx
@@ -10,7 +10,6 @@ import {
     BreadcrumbSeparator,
 } from "@stats47/components/atoms/ui/breadcrumb";
 import { Card, CardContent, CardHeader, CardTitle } from "@stats47/components/atoms/ui/card";
-import { getDrizzle } from "@stats47/database/server";
 
 import { ShareButtons } from "@/components/molecules/ShareButtons";
 
@@ -43,12 +42,7 @@ interface PageProps {
 }
 
 export async function generateStaticParams() {
-    try {
-        getDrizzle();
-    } catch {
-        return [];
-    }
-    const articles = await listLatestArticles(1000);
+    const articles = await listLatestArticles(1000).catch(() => []);
     return articles.map((a) => ({ slug: a.slug }));
 }
 

--- a/apps/web/src/app/blog/page.tsx
+++ b/apps/web/src/app/blog/page.tsx
@@ -8,7 +8,6 @@ import {
     BreadcrumbPage,
     BreadcrumbSeparator,
 } from "@stats47/components/atoms/ui/breadcrumb";
-import { getDrizzle } from "@stats47/database/server";
 
 import { BlogArticleGrid } from "@/features/blog";
 import { listLatestArticles } from "@/features/blog/server";
@@ -25,13 +24,7 @@ export const metadata: Metadata = {
 };
 
 export default async function BlogIndexPage() {
-    let articles: Awaited<ReturnType<typeof listLatestArticles>> = [];
-    try {
-        getDrizzle();
-        articles = await listLatestArticles(200);
-    } catch {
-        // CI ビルド時など D1 が利用できない場合は空データで SSG し、ISR で再生成
-    }
+    const articles = await listLatestArticles(200).catch(() => []);
 
     return (
         <>

--- a/apps/web/src/app/blog/tags/page.tsx
+++ b/apps/web/src/app/blog/tags/page.tsx
@@ -8,7 +8,6 @@ import {
     BreadcrumbPage,
     BreadcrumbSeparator,
 } from "@stats47/components/atoms/ui/breadcrumb";
-import { getDrizzle } from "@stats47/database/server";
 
 import { TagCloud } from "@/features/blog";
 import { listAllTagsWithCount } from "@/features/blog/server";
@@ -25,13 +24,7 @@ export const metadata: Metadata = {
 };
 
 export default async function TagsIndexPage() {
-    let tags: Awaited<ReturnType<typeof listAllTagsWithCount>> = [];
-    try {
-        getDrizzle();
-        tags = await listAllTagsWithCount();
-    } catch {
-        // CI ビルド時など D1 が利用できない場合は空データで SSG し、ISR で再生成
-    }
+    const tags = await listAllTagsWithCount().catch(() => []);
 
     return (
         <>

--- a/apps/web/src/app/sitemap.ts
+++ b/apps/web/src/app/sitemap.ts
@@ -11,16 +11,15 @@
 
 import { readCategoriesFromR2 } from "@stats47/category/server";
 import {
-  articleTags,
-  articles,
-  getDrizzle,
-} from "@stats47/database/server";
-import {
   readActiveKeysForSitemapFromR2,
   readSurveysFromR2,
 } from "@stats47/ranking/server";
 import { isOk } from "@stats47/types";
-import { eq, and, isNotNull, sql } from "drizzle-orm";
+
+import {
+  listLatestArticles,
+  listAllTagsWithCount,
+} from "@/features/blog/server";
 
 import { ALL_THEMES } from "@/features/theme-dashboard/config/all-themes";
 
@@ -119,17 +118,13 @@ async function getRankingPages(): Promise<MetadataRoute.Sitemap> {
 }
 
 async function getBlogPages(): Promise<MetadataRoute.Sitemap> {
-  const db = getDrizzle();
-  const rows = await db
-    .select({ slug: articles.slug, publishedAt: articles.publishedAt })
-    .from(articles)
-    .where(and(eq(articles.published, true), isNotNull(articles.publishedAt)));
+  const rows = await listLatestArticles(10000).catch(() => []);
 
   const redirected = new Set(Object.keys(BLOG_SLUG_REDIRECTS));
   return [
     { url: `${BASE_URL}/blog`, changeFrequency: "daily", priority: 0.8 },
     ...rows
-      .filter((row) => !redirected.has(row.slug))
+      .filter((row) => row.publishedAt && !redirected.has(row.slug))
       .map((row) => ({
         url: `${BASE_URL}/blog/${row.slug}`,
         lastModified: row.publishedAt ? new Date(row.publishedAt) : undefined,
@@ -165,24 +160,36 @@ async function getSurveyPages(): Promise<MetadataRoute.Sitemap> {
 }
 
 async function getTagPages(): Promise<MetadataRoute.Sitemap> {
-  const db = getDrizzle();
-  const rows = await db
-    .select({
-      tagKey: articleTags.tagKey,
-      latestPublishedAt: sql<string | null>`max(${articles.publishedAt})`.as(
-        "latestPublishedAt",
-      ),
-    })
-    .from(articleTags)
-    .innerJoin(articles, eq(articleTags.slug, articles.slug))
-    .where(eq(articles.published, true))
-    .groupBy(articleTags.tagKey)
-    .having(sql`count(*) >= 5`);
+  const tagMeta = await listAllTagsWithCount().catch(() => []);
+  // 旧クエリで count >= 5 を要求していたため踏襲
+  const eligible = tagMeta.filter((t) => t.count >= 5);
+  if (eligible.length === 0) return [];
 
-  return rows.map((row) => ({
+  const articlesAll = await listLatestArticles(10000).catch(() => []);
+  // 各 tag の最新 publishedAt を slug→tags リレーション無しで安価に解決するため、
+  // 全 article から tagKey 別の max(publishedAt) を組み立てる。
+  // 全 article 取得は snapshot in-memory cache 経由なので追加 fetch は発生しない。
+  const { readBlogSnapshotMetaFromR2: _unused, readTagsForArticlesFromR2 } =
+    await import("@/features/blog/repositories/blog-snapshot-reader");
+  const slugTagMap = await readTagsForArticlesFromR2(
+    articlesAll.map((a) => a.slug),
+  );
+  const latestByTag = new Map<string, string>();
+  for (const article of articlesAll) {
+    if (!article.published || !article.publishedAt) continue;
+    const tags = slugTagMap.get(article.slug) ?? [];
+    for (const t of tags) {
+      const prev = latestByTag.get(t.tagKey);
+      if (!prev || article.publishedAt > prev) {
+        latestByTag.set(t.tagKey, article.publishedAt);
+      }
+    }
+  }
+
+  return eligible.map((row) => ({
     url: `${BASE_URL}/tag/${row.tagKey}`,
-    lastModified: row.latestPublishedAt
-      ? new Date(row.latestPublishedAt)
+    lastModified: latestByTag.get(row.tagKey)
+      ? new Date(latestByTag.get(row.tagKey) as string)
       : undefined,
     changeFrequency: "weekly" as const,
     priority: 0.4,

--- a/apps/web/src/app/tag/[tagKey]/page.tsx
+++ b/apps/web/src/app/tag/[tagKey]/page.tsx
@@ -15,21 +15,18 @@ import {
     CardHeader,
     CardTitle,
 } from "@stats47/components/atoms/ui/card";
-import { getDrizzle, tags as tagsTable } from "@stats47/database/server";
-import { eq } from "drizzle-orm";
 
-import { listAllUniqueTags, listArticleSummariesByTagKey } from "@/features/blog/server";
+import {
+    listAllTagsWithCount,
+    listAllUniqueTags,
+    listArticleSummariesByTagKey,
+} from "@/features/blog/server";
 
 import type { Metadata } from "next";
 
 
 export async function generateStaticParams() {
-    try {
-        getDrizzle();
-    } catch {
-        return [];
-    }
-    const tagKeys = await listAllUniqueTags();
+    const tagKeys = await listAllUniqueTags().catch(() => []);
     return tagKeys.map((tagKey) => ({ tagKey }));
 }
 
@@ -38,17 +35,8 @@ interface PageProps {
 }
 
 async function getTagName(tagKey: string): Promise<string> {
-    try {
-        const db = getDrizzle();
-        const result = await db
-            .select({ tagName: tagsTable.tagName })
-            .from(tagsTable)
-            .where(eq(tagsTable.tagKey, tagKey))
-            .limit(1);
-        return result[0]?.tagName ?? tagKey;
-    } catch {
-        return tagKey;
-    }
+    const tags = await listAllTagsWithCount().catch(() => []);
+    return tags.find((t) => t.tagKey === tagKey)?.tag ?? tagKey;
 }
 
 export async function generateMetadata({ params }: PageProps): Promise<Metadata> {

--- a/apps/web/src/features/blog/repositories/blog-snapshot-reader.ts
+++ b/apps/web/src/features/blog/repositories/blog-snapshot-reader.ts
@@ -1,0 +1,194 @@
+import "server-only";
+
+import { logger } from "@stats47/logger/server";
+import { fetchFromR2AsJson } from "@stats47/r2-storage/server";
+
+import {
+  BLOG_SNAPSHOT_KEY,
+  type BlogSnapshot,
+  type SnapshotArticle,
+  type SnapshotTagMeta,
+} from "../types/snapshot";
+import type { Article, ArticleFrontmatter } from "../types/article.types";
+
+const STALE_AFTER_DAYS = 30;
+
+let cached: BlogSnapshot | null = null;
+
+function warnIfStale(generatedAt: string): void {
+  const ageDays =
+    (Date.now() - new Date(generatedAt).getTime()) / (1000 * 60 * 60 * 24);
+  if (ageDays > STALE_AFTER_DAYS) {
+    logger.warn(
+      { generatedAt, ageDays: Math.round(ageDays) },
+      `blog snapshot が ${STALE_AFTER_DAYS} 日以上古い`,
+    );
+  }
+}
+
+async function loadSnapshot(): Promise<BlogSnapshot> {
+  if (cached) return cached;
+  const snapshot = await fetchFromR2AsJson<BlogSnapshot>(BLOG_SNAPSHOT_KEY);
+  if (!snapshot) {
+    logger.warn(
+      { key: BLOG_SNAPSHOT_KEY },
+      "blog snapshot が R2 に存在しません。空配列を返します",
+    );
+    cached = { generatedAt: new Date(0).toISOString(), articles: [], tagMeta: [] };
+    return cached;
+  }
+  warnIfStale(snapshot.generatedAt);
+  cached = snapshot;
+  return snapshot;
+}
+
+function toArticle(row: SnapshotArticle): Article {
+  const frontmatter: ArticleFrontmatter = {
+    title: row.title,
+    seoTitle: row.seoTitle ?? undefined,
+    description: row.description ?? undefined,
+    tags: [],
+    published: row.published === true,
+    publishedAt: row.publishedAt ?? undefined,
+  };
+  return {
+    slug: row.slug,
+    title: row.title,
+    seoTitle: row.seoTitle,
+    description: row.description,
+    filePath: row.filePath,
+    published: row.published,
+    publishedAt: row.publishedAt,
+    format: row.format,
+    hasCharts: row.hasCharts,
+    ogImageType: row.ogImageType,
+    proofreadAt: row.proofreadAt,
+    createdAt: row.createdAt,
+    updatedAt: row.updatedAt,
+    content: "",
+    frontmatter,
+  };
+}
+
+function compareByPublishedAtDesc(a: SnapshotArticle, b: SnapshotArticle): number {
+  const ap = a.publishedAt ?? "";
+  const bp = b.publishedAt ?? "";
+  if (ap !== bp) return ap < bp ? 1 : -1;
+  const ac = a.createdAt ?? "";
+  const bc = b.createdAt ?? "";
+  if (ac !== bc) return ac < bc ? 1 : -1;
+  return 0;
+}
+
+export async function readArticleBySlugFromR2(slug: string): Promise<Article | null> {
+  const snapshot = await loadSnapshot();
+  const row = snapshot.articles.find(
+    (a) => a.slug === slug && a.published === true,
+  );
+  return row ? toArticle(row) : null;
+}
+
+export async function readLatestArticlesFromR2(
+  limit = 10,
+  offset = 0,
+): Promise<Article[]> {
+  const snapshot = await loadSnapshot();
+  const published = snapshot.articles
+    .filter((a) => a.published === true)
+    .sort(compareByPublishedAtDesc);
+  return published.slice(offset, offset + limit).map(toArticle);
+}
+
+export async function readArticlesByTagKeyFromR2(
+  tagKey: string,
+  limit = 10,
+  offset = 0,
+): Promise<Article[]> {
+  const snapshot = await loadSnapshot();
+  const matched = snapshot.articles
+    .filter(
+      (a) => a.published === true && a.tags.some((t) => t.tagKey === tagKey),
+    )
+    .sort(compareByPublishedAtDesc);
+  return matched.slice(offset, offset + limit).map(toArticle);
+}
+
+export async function readArticlesByTagFromR2(
+  tagName: string,
+  limit = 10,
+  offset = 0,
+): Promise<Article[]> {
+  const snapshot = await loadSnapshot();
+  const tagKey = snapshot.tagMeta.find((t) => t.tagName === tagName)?.tagKey;
+  if (!tagKey) return [];
+  return readArticlesByTagKeyFromR2(tagKey, limit, offset);
+}
+
+export async function readAllTagsWithCountFromR2(): Promise<
+  { tag: string; tagKey: string; count: number }[]
+> {
+  const snapshot = await loadSnapshot();
+  return snapshot.tagMeta
+    .map((t) => ({ tag: t.tagName, tagKey: t.tagKey, count: t.articleCount }))
+    .sort((a, b) => b.count - a.count);
+}
+
+export async function readAllUniqueTagsFromR2(): Promise<string[]> {
+  const tags = await readAllTagsWithCountFromR2();
+  return tags.map((t) => t.tagKey);
+}
+
+export async function readArticleTitlesBySlugsFromR2(
+  slugs: string[],
+): Promise<Record<string, string>> {
+  if (slugs.length === 0) return {};
+  const snapshot = await loadSnapshot();
+  const set = new Set(slugs);
+  return Object.fromEntries(
+    snapshot.articles.filter((a) => set.has(a.slug)).map((a) => [a.slug, a.title]),
+  );
+}
+
+export async function readTagKeysForArticleFromR2(
+  slug: string,
+): Promise<Array<{ tagKey: string; tagName: string }>> {
+  const snapshot = await loadSnapshot();
+  const article = snapshot.articles.find((a) => a.slug === slug);
+  return article ? article.tags.map((t) => ({ ...t })) : [];
+}
+
+export async function readTagsForArticlesFromR2(
+  slugs: string[],
+): Promise<Map<string, Array<{ tagKey: string; tagName: string }>>> {
+  if (slugs.length === 0) return new Map();
+  const snapshot = await loadSnapshot();
+  const set = new Set(slugs);
+  const result = new Map<string, Array<{ tagKey: string; tagName: string }>>();
+  for (const a of snapshot.articles) {
+    if (!set.has(a.slug)) continue;
+    result.set(a.slug, a.tags.map((t) => ({ ...t })));
+  }
+  return result;
+}
+
+export async function readArticleSummariesByTagKeyFromR2(
+  tagKey: string,
+  limit = 10,
+): Promise<Array<{ slug: string; title: string; description: string | null }>> {
+  const snapshot = await loadSnapshot();
+  return snapshot.articles
+    .filter(
+      (a) => a.published === true && a.tags.some((t) => t.tagKey === tagKey),
+    )
+    .sort(compareByPublishedAtDesc)
+    .slice(0, limit)
+    .map((a) => ({ slug: a.slug, title: a.title, description: a.description }));
+}
+
+export async function readBlogSnapshotMetaFromR2(): Promise<{
+  tagMeta: SnapshotTagMeta[];
+  generatedAt: string;
+}> {
+  const snapshot = await loadSnapshot();
+  return { tagMeta: snapshot.tagMeta, generatedAt: snapshot.generatedAt };
+}

--- a/apps/web/src/features/blog/server.ts
+++ b/apps/web/src/features/blog/server.ts
@@ -9,25 +9,21 @@ import "server-only";
  * @module BlogDomain/Server
  */
 
-// リポジトリ: article-repository
+// リポジトリ: blog snapshot R2 reader (Phase 4 D1→R2 移行後の主経路)
+// D1 版 (article-repository / article-tag-repository) は現状未使用だが、
+// 緊急時のフォールバックとして残置。
 export {
-  findArticleBySlug,
-  listArticlesByTagKey,
-  listArticlesByTag,
-  listAllTagsWithCount,
-  listAllUniqueTags,
-  findArticleTitlesBySlugs,
-  listLatestArticles,
-} from "./repositories/article-repository";
-
-// リポジトリ: article-tag-repository
-// listArticlesByTagKey は article-repository にも存在するため、
-// article-tag-repository 版（サマリー返却）は別名でエクスポート
-export {
-  listArticlesByTagKey as listArticleSummariesByTagKey,
-  getTagKeysForArticle,
-  getTagsForArticles,
-} from "./repositories/article-tag-repository";
+  readArticleBySlugFromR2 as findArticleBySlug,
+  readArticlesByTagKeyFromR2 as listArticlesByTagKey,
+  readArticlesByTagFromR2 as listArticlesByTag,
+  readAllTagsWithCountFromR2 as listAllTagsWithCount,
+  readAllUniqueTagsFromR2 as listAllUniqueTags,
+  readArticleTitlesBySlugsFromR2 as findArticleTitlesBySlugs,
+  readLatestArticlesFromR2 as listLatestArticles,
+  readArticleSummariesByTagKeyFromR2 as listArticleSummariesByTagKey,
+  readTagKeysForArticleFromR2 as getTagKeysForArticle,
+  readTagsForArticlesFromR2 as getTagsForArticles,
+} from "./repositories/blog-snapshot-reader";
 
 // サービス
 export { articleService, ArticleService } from "./services/article-service";

--- a/apps/web/src/features/blog/types/snapshot.ts
+++ b/apps/web/src/features/blog/types/snapshot.ts
@@ -1,0 +1,24 @@
+import { type ArticleRow } from "@stats47/database/schema";
+
+export const BLOG_SNAPSHOT_KEY = "snapshots/blog/all.json";
+
+export interface SnapshotArticleTag {
+  tagKey: string;
+  tagName: string;
+}
+
+export interface SnapshotArticle extends ArticleRow {
+  tags: SnapshotArticleTag[];
+}
+
+export interface SnapshotTagMeta {
+  tagKey: string;
+  tagName: string;
+  articleCount: number;
+}
+
+export interface BlogSnapshot {
+  generatedAt: string;
+  articles: SnapshotArticle[];
+  tagMeta: SnapshotTagMeta[];
+}


### PR DESCRIPTION
## Summary
- D1→R2 移行マスタープラン Phase 4: blog ドメインの全 D1 read を撤廃
- snapshot key: \`snapshots/blog/all.json\` (134 articles + 327 tags = 158KB)
- in-memory cache (per-worker) で 1 fetch を全ページで共有

## Changes
- **新規**: \`apps/web/src/features/blog/types/snapshot.ts\` - snapshot 型
- **新規**: \`apps/web/src/features/blog/repositories/blog-snapshot-reader.ts\` - R2 reader
- **新規**: \`apps/web/scripts/export-blog-snapshot.ts\` - exporter (D1→R2)
- **更新**: \`apps/web/src/features/blog/server.ts\` - hub を R2 reader に切替
- **更新**: \`/blog\`, \`/blog/[slug]\`, \`/blog/tags\`, \`/tag/[tagKey]\`, \`/sitemap\`

## Test plan
- [x] \`npx tsx -r setup-cli.js apps/web/scripts/export-blog-snapshot.ts\` 成功 (158KB R2 push)
- [x] dev server で \`/blog\`, \`/blog/tags\`, \`/blog/[slug]\`, \`/tag/[tagKey]\` 全 200
- [x] \`npx tsc --noEmit -p apps/web/tsconfig.json\` clean

## Effect
- 月次 D1 read 想定削減: articles + article_tags + tags 由来の数 M rows → 0
- 残存 D1 read (apps/web): areas/[areaCode], page_components 等 (Phase 5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)