### PR TITLE
feat(ai-content): Phase 5 - ranking_ai_content を R2 化

### DIFF
--- a/apps/web/src/app/ranking/[rankingKey]/page.tsx
+++ b/apps/web/src/app/ranking/[rankingKey]/page.tsx
@@ -33,7 +33,7 @@ import { notFound } from "next/navigation";
 
 
 
-import { findRankingAiContent } from "@stats47/ai-content/server";
+import { readRankingAiContentFromR2 } from "@stats47/ai-content/server";
 import {
   Breadcrumb,
   BreadcrumbItem,
@@ -182,7 +182,7 @@ export default async function RankingKeyPage({
     return null;
   });
 
-  const aiContentPromise = findRankingAiContent(rankingKey, areaType).catch(
+  const aiContentPromise = readRankingAiContentFromR2(rankingKey, areaType).catch(
     (error) => {
       logger.error({ error }, "RankingKeyPage: AI content 取得失敗");
       return null;

--- a/packages/ai-content/package.json
+++ b/packages/ai-content/package.json
@@ -24,6 +24,8 @@
   "dependencies": {
     "@stats47/area": "*",
     "@stats47/database": "*",
+    "@stats47/logger": "*",
+    "@stats47/r2-storage": "*",
     "@stats47/ranking": "*",
     "drizzle-orm": "^0.45.1",
     "server-only": "^0.0.1"

--- a/packages/ai-content/src/exporters/ranking-ai-content-snapshot.ts
+++ b/packages/ai-content/src/exporters/ranking-ai-content-snapshot.ts
@@ -1,0 +1,50 @@
+import "server-only";
+
+import { getDrizzle, rankingAiContent } from "@stats47/database/server";
+import { logger } from "@stats47/logger/server";
+import { saveToR2 } from "@stats47/r2-storage/server";
+
+import {
+  AI_CONTENT_SNAPSHOT_KEY,
+  type AiContentSnapshot,
+} from "../types/snapshot";
+
+export interface ExportRankingAiContentSnapshotResult {
+  key: string;
+  count: number;
+  sizeBytes: number;
+  durationMs: number;
+}
+
+export async function exportRankingAiContentSnapshot(
+  db?: ReturnType<typeof getDrizzle>,
+): Promise<ExportRankingAiContentSnapshotResult> {
+  const startedAt = Date.now();
+  const drizzleDb = db ?? getDrizzle();
+
+  const rows = await drizzleDb.select().from(rankingAiContent);
+
+  const snapshot: AiContentSnapshot = {
+    generatedAt: new Date().toISOString(),
+    count: rows.length,
+    rows,
+  };
+
+  const body = JSON.stringify(snapshot);
+  const result = await saveToR2(AI_CONTENT_SNAPSHOT_KEY, body, {
+    contentType: "application/json; charset=utf-8",
+  });
+
+  const durationMs = Date.now() - startedAt;
+  logger.info(
+    { key: result.key, count: rows.length, sizeBytes: result.size, durationMs },
+    "ranking_ai_content snapshot を R2 に保存しました",
+  );
+
+  return {
+    key: result.key,
+    count: rows.length,
+    sizeBytes: result.size,
+    durationMs,
+  };
+}

--- a/packages/ai-content/src/repositories/read-ranking-ai-content-snapshot.ts
+++ b/packages/ai-content/src/repositories/read-ranking-ai-content-snapshot.ts
@@ -1,0 +1,84 @@
+import "server-only";
+
+import { type RankingAiContentRow } from "@stats47/database/schema";
+import { logger } from "@stats47/logger/server";
+import { fetchFromR2AsJson } from "@stats47/r2-storage/server";
+
+import {
+  AI_CONTENT_SNAPSHOT_KEY,
+  type AiContentSnapshot,
+} from "../types/snapshot";
+
+const STALE_AFTER_DAYS = 30;
+
+let cached: Map<string, RankingAiContentRow> | null = null;
+
+function compositeKey(rankingKey: string, areaType: string): string {
+  return `${rankingKey}|${areaType}`;
+}
+
+function warnIfStale(generatedAt: string): void {
+  const ageDays =
+    (Date.now() - new Date(generatedAt).getTime()) / (1000 * 60 * 60 * 24);
+  if (ageDays > STALE_AFTER_DAYS) {
+    logger.warn(
+      { generatedAt, ageDays: Math.round(ageDays) },
+      `ai-content snapshot が ${STALE_AFTER_DAYS} 日以上古い`,
+    );
+  }
+}
+
+async function loadIndex(): Promise<Map<string, RankingAiContentRow>> {
+  if (cached) return cached;
+  const snapshot = await fetchFromR2AsJson<AiContentSnapshot>(
+    AI_CONTENT_SNAPSHOT_KEY,
+  );
+  if (!snapshot) {
+    logger.warn(
+      { key: AI_CONTENT_SNAPSHOT_KEY },
+      "ai-content snapshot が R2 に存在しません。空 Map を返します",
+    );
+    cached = new Map();
+    return cached;
+  }
+  warnIfStale(snapshot.generatedAt);
+  const map = new Map<string, RankingAiContentRow>();
+  for (const row of snapshot.rows) {
+    map.set(compositeKey(row.rankingKey, row.areaType), row);
+  }
+  cached = map;
+  return map;
+}
+
+/**
+ * R2 上の ai-content snapshot から (rankingKey, areaType) で取得。
+ *
+ * findRankingAiContent (D1) のドロップイン代替。
+ *
+ * build 時 (NEXT_PHASE=phase-production-build) は null を返し、ISR で初回 fetch。
+ * 1,943 行 (~5MB) を 1 fetch で全ページ供給するため、build worker でも 1 回の
+ * R2 fetch + JSON.parse で済む。ただし、build hang 防止のため安全側で skip。
+ */
+export async function readRankingAiContentFromR2(
+  rankingKey: string,
+  areaType: string,
+): Promise<RankingAiContentRow | null> {
+  if (process.env.NEXT_PHASE === "phase-production-build") {
+    return null;
+  }
+
+  try {
+    const map = await loadIndex();
+    return map.get(compositeKey(rankingKey, areaType)) ?? null;
+  } catch (error) {
+    logger.error(
+      {
+        rankingKey,
+        areaType,
+        error: error instanceof Error ? error.message : String(error),
+      },
+      "readRankingAiContentFromR2: failed",
+    );
+    return null;
+  }
+}

--- a/packages/ai-content/src/scripts/export-snapshot.ts
+++ b/packages/ai-content/src/scripts/export-snapshot.ts
@@ -1,0 +1,26 @@
+#!/usr/bin/env tsx
+/**
+ * ranking_ai_content の R2 snapshot を書き出す。
+ *
+ * 通常は AI content 生成バッチ完了時 / sync 時に呼ばれるが、
+ * 手動で最新化したいときにも単独実行できる。
+ *
+ * Usage:
+ *   npx tsx -r ./packages/ranking/src/scripts/setup-cli.js \
+ *     packages/ai-content/src/scripts/export-snapshot.ts
+ */
+
+import { exportRankingAiContentSnapshot } from "../exporters/ranking-ai-content-snapshot";
+
+async function main() {
+  console.log("ai-content snapshot を R2 に書き出します…");
+  const result = await exportRankingAiContentSnapshot();
+  console.log(
+    `✅ ai_content: ${result.count} 件 / ${result.sizeBytes} bytes / ${result.durationMs}ms key=${result.key}`,
+  );
+}
+
+main().catch((err) => {
+  console.error("Fatal:", err);
+  process.exit(1);
+});

--- a/packages/ai-content/src/server.ts
+++ b/packages/ai-content/src/server.ts
@@ -22,6 +22,9 @@ export {
   upsertRankingAiContent,
 } from "./repositories";
 
+export { readRankingAiContentFromR2 } from "./repositories/read-ranking-ai-content-snapshot";
+export { exportRankingAiContentSnapshot } from "./exporters/ranking-ai-content-snapshot";
+
 // プロンプト
 export { buildRankingContentPrompt } from "./services/prompts/ranking-content-prompt";
 export type { RankingContentInput } from "./services/prompts/ranking-content-prompt";

--- a/packages/ai-content/src/types/snapshot.ts
+++ b/packages/ai-content/src/types/snapshot.ts
@@ -1,0 +1,9 @@
+import type { RankingAiContentRow } from "@stats47/database/schema";
+
+export const AI_CONTENT_SNAPSHOT_KEY = "snapshots/ai-content/all.json";
+
+export interface AiContentSnapshot {
+  generatedAt: string;
+  count: number;
+  rows: RankingAiContentRow[];
+}


### PR DESCRIPTION
## Summary
- D1→R2 マスタープラン Phase 5 の最大ボリューム部分: ranking_ai_content (1,943 行 / 11MB)
- /ranking/[rankingKey] が per-page で叩いていた D1 read を R2 in-memory cache に置換

## Changes
- 新規: \`packages/ai-content/src/types/snapshot.ts\`
- 新規: \`packages/ai-content/src/exporters/ranking-ai-content-snapshot.ts\`
- 新規: \`packages/ai-content/src/repositories/read-ranking-ai-content-snapshot.ts\` (in-memory Map cache)
- 新規: \`packages/ai-content/src/scripts/export-snapshot.ts\` (CLI)
- 更新: \`apps/web/src/app/ranking/[rankingKey]/page.tsx\` - \`findRankingAiContent\` → \`readRankingAiContentFromR2\`
- 更新: \`packages/ai-content/server.ts\` exports

## Test plan
- [x] exporter で R2 push 成功 (1,943 件 / 11.2MB)
- [x] dev server で /ranking/total-population 200 + AI content 描画
- [x] type-check clean (apps/web + packages/ai-content)

## Build safety
NEXT_PHASE=phase-production-build 時は null を返し ISR で初回 fetch、build hang を防ぐ。

## Effect
- D1 read 削減: ranking_ai_content 経由 (per ranking page × ~2,023) → 0
- 残 Phase 5: page_components / area_profile / fishing_ports / port_statistics

🤖 Generated with [Claude Code](https://claude.com/claude-code)