### PR TITLE
feat(ci): Phase 7 - D1 runtime import gate

### DIFF
--- a/.github/workflows/pr-quality-check.yml
+++ b/.github/workflows/pr-quality-check.yml
@@ -36,6 +36,22 @@ jobs:
         run: npm run lint
         continue-on-error: false # Lintエラーで失敗させる
 
+      - name: 🚫 D1 Import Gate (Phase 7)
+        run: |
+          # apps/web から runtime D1 import (getDrizzle / @stats47/database/server) が
+          # 0 件であることを担保。型のみ import (@stats47/database/schema) は許可。
+          # Phase 0-6 で R2 snapshot 化が完了しており、ここに新規追加すると
+          # Phase 8 (D1 binding 削除) と Phase 10 (D1 解約) を阻害する。
+          set +e
+          MATCHES=$(grep -rln 'getDrizzle\|@stats47/database/server' apps/web/src/ 2>/dev/null)
+          if [ -n "$MATCHES" ]; then
+            echo "::error::apps/web/src から D1 runtime import が検出されました。R2 snapshot 経由に切替えてください。"
+            echo "$MATCHES"
+            exit 1
+          fi
+          echo "✅ apps/web/src に D1 runtime import なし"
+        continue-on-error: false
+
       - name: 📐 Type Check
         run: npm run type-check
         env:


### PR DESCRIPTION
## Summary
D1→R2 マスタープラン Phase 7。Phase 0-6 で apps/web/src の \`getDrizzle\` / \`@stats47/database/server\` 利用は 0 件に到達済 (PR #170)。退行を防ぐため pr-quality-check.yml に grep gate を追加。

## Behavior
- 型のみ import (\`@stats47/database/schema\`) は許可
- runtime import (\`getDrizzle\` / \`@stats47/database/server\`) を検出したら CI fail
- ESLint Check の直後に実行

## Why
Phase 8 (D1 binding 削除) と Phase 10 (D1 解約) の前提を恒久的に守る。新しい開発者・エージェントが誤って D1 を追加するのを防ぐ。

## Test plan
- [x] 現状の apps/web/src に grep ヒット 0 件 (確認済)
- [ ] 本 PR の CI で gate が pass することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)