### PR TITLE
feat(skill): /sync-snapshots — 全 R2 snapshot を一括 export

### DIFF
--- a/.claude/skills/db/sync-snapshots/SKILL.md
+++ b/.claude/skills/db/sync-snapshots/SKILL.md
@@ -1,0 +1,81 @@
+---
+name: sync-snapshots
+description: ローカル D1 から全 R2 snapshot を一括 export する。Phase 0-6 で R2 化した 13 種類の snapshot を 1 コマンドで更新。データ変更後に必ず実行。
+argument-hint: [--only <category>] [--dry-run]
+disable-model-invocation: true
+---
+
+ローカル D1 SQLite から R2 上の全 snapshot を一括 export するオーケストレーションスキル。
+
+D1→R2 マスタープラン Phase 0-6 で 13 種類の snapshot に依存するようになった。データ変更 (`/populate-all-rankings`, `/sync-articles`, AI コンテンツ生成 等) のたびに、対応する snapshot を更新しないと本番で古いデータが配信される。
+
+本スキルは **全 snapshot を順次 export** する。各 export はべき等なので何度実行しても安全。
+
+## 実行する snapshot 一覧
+
+| Snapshot | スクリプト | サイズ目安 |
+|---|---|---|
+| ranking-items / surveys / categories | `packages/ranking/src/scripts/export-master-snapshots.ts` | < 1MB |
+| ai-content | `packages/ai-content/src/scripts/export-snapshot.ts` | ~11MB |
+| correlation by-key | `packages/correlation/src/scripts/export-snapshot.ts` | ~5MB (1,830 files) |
+| ranking-values partition | `packages/ranking/src/scripts/export-ranking-values-snapshots.ts` | ~800MB (29K files、`SKIP_VALUES=1` で skip) |
+| area-profile | `packages/area-profile/src/scripts/export-snapshot.ts` | ~3MB |
+| blog | `apps/web/scripts/export-blog-snapshot.ts` | ~150KB |
+| page-components | `apps/web/scripts/export-page-components-snapshot.ts` | ~150KB |
+| affiliate-ads | `apps/web/scripts/export-affiliate-ads-snapshot.ts` | ~15KB |
+| ranking-page-cards | `apps/web/scripts/export-ranking-page-cards-snapshot.ts` | ~16KB |
+| fishing-ports | `apps/web/scripts/export-fishing-ports-snapshot.ts` | ~620KB |
+| ports + port-statistics | `apps/web/scripts/export-port-statistics-snapshot.ts` | ~50MB (715 files) |
+
+## 使い方
+
+### 通常実行 (全 snapshot を順次更新、ranking-values は skip)
+
+```bash
+SKIP_VALUES=1 bash .claude/skills/db/sync-snapshots/run.sh
+```
+
+ranking-values (~30K files) は CF REST API rate limit で 30-60 分かかるため、デフォルトで skip。
+更新が必要な場合のみ環境変数を外す:
+
+```bash
+bash .claude/skills/db/sync-snapshots/run.sh
+```
+
+### 単独カテゴリのみ
+
+```bash
+bash .claude/skills/db/sync-snapshots/run.sh --only blog
+bash .claude/skills/db/sync-snapshots/run.sh --only port-statistics
+```
+
+### dry-run (実行しない、走るスクリプトをリスト表示)
+
+```bash
+bash .claude/skills/db/sync-snapshots/run.sh --dry-run
+```
+
+## いつ実行するか
+
+| トリガー | 必要 snapshot |
+|---|---|
+| `/populate-all-rankings` 完了 | master + ai-content + ranking-values |
+| `/register-ranking` 完了 | master + ranking-values |
+| `/sync-articles` 完了 | blog |
+| AI コンテンツ生成完了 | ai-content |
+| ダッシュボード設定変更 | page-components |
+| area_profile バッチ完了 | area-profile |
+| 港湾統計データ更新 | port-statistics |
+| 全部入れ替え (大規模リカバリ) | 全部 (`SKIP_VALUES` を外す) |
+
+## 注意
+
+- **ローカル D1 が編集済みであること**: snapshot は ローカル SQLite を読むため、まず DB を更新してから本スキルを実行する。リモート D1 とローカル D1 の整合は `/sync-remote-d1` を別途実行。
+- **CF REST API rate limit (429/504)**: 大量 snapshot (ranking-values, port-statistics by-port) は retry + parallelism=1 で守られているが、複数 export を同時に走らせると衝突する。本スキルは順次実行する。
+- **NEXT_PHASE skip パターン**: 本番 worker build 時は各 reader が空配列/null を返し ISR で初回 fetch する。snapshot 更新後の最初のリクエストで反映される (24h ISR 後にキャッシュ満了)。
+
+## 関連スキル
+
+- `/pull-remote-d1` — リモート D1 → ローカル D1 (新規 PC 等)
+- `/sync-remote-d1` — ローカル D1 → リモート D1 (本スキルとは目的が違う; D1 ↔ R2 整合用)
+- `/diff-d1` — ローカル / リモート D1 差分検知

--- a/.claude/skills/db/sync-snapshots/run.sh
+++ b/.claude/skills/db/sync-snapshots/run.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+# sync-snapshots: ローカル D1 から全 R2 snapshot を順次 export する
+# Phase 0-6 で R2 化した 13 種類の snapshot を 1 コマンドで更新
+
+set -e
+
+PROJECT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)/.."
+cd "$PROJECT_ROOT"
+
+# Args
+ONLY=""
+DRY_RUN=0
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --only) ONLY="$2"; shift 2 ;;
+    --dry-run) DRY_RUN=1; shift ;;
+    *) echo "Unknown arg: $1"; exit 1 ;;
+  esac
+done
+
+# Setup CLI で server-only バイパス + .env.local ロード
+TSX="npx tsx -r ./packages/ranking/src/scripts/setup-cli.js"
+
+# (label, script_path) のペアで定義
+declare -a TASKS=(
+  "master|packages/ranking/src/scripts/export-master-snapshots.ts"
+  "ai-content|packages/ai-content/src/scripts/export-snapshot.ts"
+  "correlation|packages/correlation/src/scripts/export-snapshot.ts"
+  "area-profile|packages/area-profile/src/scripts/export-snapshot.ts"
+  "blog|apps/web/scripts/export-blog-snapshot.ts"
+  "page-components|apps/web/scripts/export-page-components-snapshot.ts"
+  "affiliate-ads|apps/web/scripts/export-affiliate-ads-snapshot.ts"
+  "ranking-page-cards|apps/web/scripts/export-ranking-page-cards-snapshot.ts"
+  "fishing-ports|apps/web/scripts/export-fishing-ports-snapshot.ts"
+  "port-statistics|apps/web/scripts/export-port-statistics-snapshot.ts"
+)
+
+# ranking-values は重いので SKIP_VALUES で制御
+if [ -z "$SKIP_VALUES" ] || [ "$SKIP_VALUES" = "0" ]; then
+  TASKS+=("ranking-values|packages/ranking/src/scripts/export-ranking-values-snapshots.ts")
+fi
+
+run_task() {
+  local label="$1"
+  local script="$2"
+
+  if [ "$DRY_RUN" = "1" ]; then
+    echo "[dry-run] $label → $TSX $script"
+    return 0
+  fi
+
+  echo ""
+  echo "═══ $label ═══"
+  if eval "$TSX $script"; then
+    echo "✅ $label 完了"
+  else
+    echo "❌ $label 失敗"
+    return 1
+  fi
+}
+
+FAILED=()
+for task in "${TASKS[@]}"; do
+  label="${task%|*}"
+  script="${task##*|}"
+
+  if [ -n "$ONLY" ] && [ "$ONLY" != "$label" ]; then
+    continue
+  fi
+
+  if ! run_task "$label" "$script"; then
+    FAILED+=("$label")
+  fi
+done
+
+echo ""
+echo "════════════════════════════════════════"
+if [ ${#FAILED[@]} -eq 0 ]; then
+  echo "✅ 全 snapshot を R2 に push 完了"
+else
+  echo "❌ 失敗: ${FAILED[*]}"
+  exit 1
+fi


### PR DESCRIPTION
## Summary
D1→R2 マスタープラン Phase 0-6 で 13 種類の R2 snapshot に依存するようになった。データ変更後に 7+ 個の exporter を個別実行するのは非効率。

## Skill
- \`SKILL.md\`: 使い方 + 各 snapshot 説明
- \`run.sh\`: bash オーケストレーター

## Coverage
| Snapshot | スクリプト |
|---|---|
| master (3) / ai-content / correlation / area-profile | \`packages/*/src/scripts/\` |
| blog / page-components / affiliate-ads / ranking-page-cards | \`apps/web/scripts/\` |
| fishing-ports / port-statistics | \`apps/web/scripts/\` |
| ranking-values (~30K files、\`SKIP_VALUES=1\` で除外可能) | \`packages/ranking/src/scripts/\` |

## 使い方
\`\`\`bash
# 全部更新 (ranking-values 含む、~30 分)
bash .claude/skills/db/sync-snapshots/run.sh

# ranking-values skip (~5 分)
SKIP_VALUES=1 bash .claude/skills/db/sync-snapshots/run.sh

# 単独
bash .claude/skills/db/sync-snapshots/run.sh --only blog

# dry-run
bash .claude/skills/db/sync-snapshots/run.sh --dry-run
\`\`\`

## Test plan
- [x] \`--dry-run\` で 11 タスクが正しくリストされる
- [ ] 実 run はユーザー側でデータ更新後に検証

🤖 Generated with [Claude Code](https://claude.com/claude-code)