### PR TITLE
fix(d1-leak): getTagsForItem を R2 化（残存 152 q/h 解消）

### DIFF
--- a/.github/workflows/pr-quality-check.yml
+++ b/.github/workflows/pr-quality-check.yml
@@ -54,7 +54,7 @@ jobs:
           # apps/web/src から @stats47/<pkg>/server 経由で D1 を叩く known-bad シンボルを
           # import していないか確認 (Phase 7 強化、2026-04-29 に Phase 8 ブロッカーを発見した教訓)。
           # 各シンボルは package 内で getDrizzle を呼ぶため、間接的に D1 read を発生させる。
-          BAD_SYMBOLS='findFirstKeyByTag|findRankingItemsByTag|findLatestYear\b|listRankingItemsByAreaType\b|listRankingValuesByPrefecture\b'
+          BAD_SYMBOLS='findFirstKeyByTag|findRankingItemsByTag|findLatestYear\b|listRankingItemsByAreaType\b|listRankingValuesByPrefecture\b|getTagsForItem'
           MATCHES2=$(grep -rEn "$BAD_SYMBOLS" apps/web/src/ --include='*.ts' --include='*.tsx' 2>/dev/null | grep -v '__tests__')
           if [ -n "$MATCHES2" ]; then
             echo "::error::apps/web/src から D1 を叩く間接的シンボル import が検出されました。R2 reader (read*FromR2) に切替えてください。"

--- a/apps/web/src/features/ranking/components/RankingSidebar/RelatedArticlesCard.tsx
+++ b/apps/web/src/features/ranking/components/RankingSidebar/RelatedArticlesCard.tsx
@@ -6,7 +6,7 @@ import {
   CardHeader,
   CardTitle,
 } from "@stats47/components/atoms/ui/card";
-import { getTagsForItem } from "@stats47/ranking/server";
+import { readTagsForItemFromR2 } from "@stats47/ranking/server";
 import { isOk, type AreaType } from "@stats47/types";
 import { Newspaper } from "lucide-react";
 
@@ -21,10 +21,10 @@ export async function RelatedArticlesCard({
   rankingKey,
   areaType,
 }: RelatedArticlesCardProps) {
-  const tagsResult = await getTagsForItem(rankingKey, areaType);
+  const tagsResult = await readTagsForItemFromR2(rankingKey, areaType);
   if (!isOk(tagsResult) || tagsResult.data.length === 0) return null;
 
-  const tagKeys = tagsResult.data.map((t) => t.tagKey);
+  const tagKeys = tagsResult.data;
 
   // 全タグの記事を並列取得し、重複を除去して最大3件
   const allResults = await Promise.all(


### PR DESCRIPTION
## Summary

PR #174 デプロイ後、Cloudflare GraphQL \`d1QueriesAdaptiveGroups\` で D1 read の SQL 内訳を取得した結果、残存リーク 152 q/h の出処を特定:

\`\`\`sql
select "tag_key" from "ranking_tags"
  where ("ranking_tags"."ranking_key" = ?
    and "ranking_tags"."area_type" = ?)
\`\`\`

= \`getTagsForItem(rankingKey, areaType)\` が \`apps/web/src/features/ranking/components/RankingSidebar/RelatedArticlesCard.tsx\` から呼ばれていた。PR #174 で readTagsForItemFromR2 を実装済だが caller を取り残していた。

## 計測（PR #174 デプロイ後 3.3h）

| 指標 | Before | After | 変化 |
|---|---|---|---|
| Queries/h | 265 | 152 | -43% |
| Rows read/h | 82,950 | 404 | **-99.51%** |

本 PR で残存 152 q/h も解消され、本番 D1 read = 0 を期待。

## 変更

1. \`RelatedArticlesCard.tsx\` を \`readTagsForItemFromR2\` に置換
2. Phase 7 grep gate に \`getTagsForItem\` を追加

## Test plan

- [x] tsc clean
- [x] vitest pass
- [x] grep gate ローカルで通過
- [ ] デプロイ後に Cloudflare GraphQL で D1 read = 0 を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)