### PR TITLE
feat(phase8): production の D1 binding を削除

### DIFF
--- a/apps/web/wrangler.toml
+++ b/apps/web/wrangler.toml
@@ -70,12 +70,12 @@ NEXT_PUBLIC_GOOGLE_ADSENSE_ENABLED = "true"
 # Amazon アソシエイト
 NEXT_PUBLIC_AMAZON_ASSOCIATE_TAG = "stats47-22"
 
-# Static DB (Production)
-[[env.production.d1_databases]]
-binding = "STATS47_STATIC_DB"
-database_name = "stats47_static"
-database_id = "6cea2d7a-87c2-408b-9de3-72b1bc240478"
-migrations_dir = "../../packages/database/drizzle"
+# Phase 8 (2026-04-29): production の D1 binding を削除。
+# apps/web の全 D1 read は R2 snapshot に移行済み (Phase 0-7、PR #149/#163/#167-175)。
+# CI gate (.github/workflows/pr-quality-check.yml の D1 Import Gate) で再発を防ぐ。
+# ローカル開発用の binding (上の [[d1_databases]]) は残置 (バッチ実行に必要)。
+# ロールバック: この diff を revert + redeploy で 1 commit 復元可。
+# Phase 10 で D1 解約予定 (Time Travel ロールバック窓 30 日後)。
 
 [[env.production.r2_buckets]]
 binding = "STATS47_BUCKET"


### PR DESCRIPTION
## Summary

apps/web の本番 worker から D1 binding を撤廃。Phase 0-7 で全 D1 read を R2 snapshot に移行済み。

## 検証済

- Phase 7 grep gate で apps/web/src の D1 import 0 件確認
- PR #174/#175 デプロイ後の Cloudflare GraphQL 計測で:
  - rows read: 82,950/h → 404/h (-99.51%)
  - PR #175 で残存 152 q/h の出処 (\`getTagsForItem\`) も解消
- ローカルビルド成功

## マージ前のチェック

- [ ] PR #175 デプロイから 30 分以上経過し、Cloudflare GraphQL で D1 read が 0 (または write のみ) であること
- [ ] 全 production smoke test が 200 を返すこと
- [ ] 残ローカル開発用 binding (上の \`[[d1_databases]]\`) が動作すること（バッチ実行用）

## マージ後

1. デプロイ自動トリガー
2. 1-2 日 production を観察 (Phase 9)
3. 異常がなければ Phase 10 (D1 database 解約) PR を起こす

## ロールバック

このコミットを revert + redeploy で 1 commit 復元可。D1 database ID は Phase 10 まで保持されており即座に再接続できる。

🤖 Generated with [Claude Code](https://claude.com/claude-code)