### PR TITLE
chore(db): consolidate sources (PR-2/7 of 3-layer schema migration)

### DIFF
--- a/packages/database/drizzle/0017_sources_consolidation.sql
+++ b/packages/database/drizzle/0017_sources_consolidation.sql
@@ -1,0 +1,41 @@
+-- Sources consolidation (PR-2 of 3-layer schema migration)
+--
+-- 旧 data_sources (5 行) と source_metadata (402 行) を統合して、すでに投入済みの
+-- sources テーブル (110 行) に一本化する。
+--
+-- - data_sources: id 全 5 件 (estat / ssdse / ipss / mlit_ksj / mlit_dpf) は
+--   既に sources に存在するため、参照先を rewire するのみ。
+-- - source_metadata: 402 行のうち実質的な内容（adapter_type 5 / memo 1 / その他 396 は
+--   estat_stats_tables に重複）はすべて他テーブルで代替可能なため DROP。
+--
+-- ranking_items.data_source_id の FK 参照先は sources(id) に変更
+-- （Drizzle schema 上のみ。SQLite では既存テーブルの FK 制約は ALTER できないが、
+--  値は全て sources(id) と一致しているため runtime 整合性は確保済み）。
+
+CREATE TABLE IF NOT EXISTS `sources` (
+  `id` TEXT PRIMARY KEY,
+  `source_kind` TEXT NOT NULL CHECK(`source_kind` IN ('platform','survey','estat_table')),
+  `external_id` TEXT,
+  `parent_source_id` TEXT,
+  `name` TEXT NOT NULL,
+  `organization` TEXT,
+  `url` TEXT,
+  `description` TEXT,
+  `attribution_text` TEXT,
+  `license` TEXT,
+  `license_url` TEXT,
+  `base_url` TEXT,
+  `link_template` TEXT,
+  `display_order` INTEGER DEFAULT 0,
+  `is_active` INTEGER DEFAULT 1,
+  `created_at` TEXT DEFAULT CURRENT_TIMESTAMP,
+  `updated_at` TEXT DEFAULT CURRENT_TIMESTAMP
+);--> statement-breakpoint
+
+CREATE INDEX IF NOT EXISTS `idx_sources_kind` ON `sources`(`source_kind`);--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS `idx_sources_parent` ON `sources`(`parent_source_id`);--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS `idx_sources_external_id` ON `sources`(`source_kind`,`external_id`);--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS `idx_sources_active` ON `sources`(`is_active`);--> statement-breakpoint
+
+DROP TABLE IF EXISTS `source_metadata`;--> statement-breakpoint
+DROP TABLE IF EXISTS `data_sources`;

--- a/packages/database/scripts/d1-diff-report.ts
+++ b/packages/database/scripts/d1-diff-report.ts
@@ -92,7 +92,7 @@ const SMALL_TABLES = [
   "affiliate_ads",
   "categories",
   "subcategories",
-  "data_sources",
+  "sources",
   "surveys",
   "ranking_page_cards",
   "ranking_tags",
@@ -102,7 +102,6 @@ const SMALL_TABLES = [
   "area_profile_rankings",
   "ports",
   "fishing_ports",
-  "port_trade_detail",
 ];
 
 const SYSTEM_TABLE_PATTERNS = [/^sqlite_/, /^_cf_/, /^__drizzle/, /^d1_/];

--- a/packages/database/src/schema/index.ts
+++ b/packages/database/src/schema/index.ts
@@ -1,5 +1,6 @@
 export * from "./affiliate_ads";
 export * from "./ai_content";
+export * from "./sources";
 export * from "./area_profile_rankings";
 export * from "./article_tags";
 export * from "./articles";

--- a/packages/database/src/schema/ranking_items.ts
+++ b/packages/database/src/schema/ranking_items.ts
@@ -9,6 +9,8 @@ import {
     uniqueIndex,
 } from "drizzle-orm/sqlite-core";
 
+import { sources } from "./sources";
+
 export const surveys = sqliteTable("surveys", {
   id: text("id").primaryKey(),
   organization: text("organization").notNull(),
@@ -22,22 +24,6 @@ export const surveys = sqliteTable("surveys", {
 
 export type Survey = typeof surveys.$inferSelect;
 export type InsertSurvey = typeof surveys.$inferInsert;
-
-export const dataSources = sqliteTable("data_sources", {
-  id: text("id").primaryKey(),
-  name: text("name").notNull(),
-  description: text("description"),
-  adapterType: text("adapter_type").notNull(),
-  configSchema: text("config_schema"),
-  isActive: integer("is_active", { mode: "boolean" }).default(true),
-  baseUrl: text("base_url"),
-  linkTemplate: text("link_template"),
-  attributionText: text("attribution_text"),
-  license: text("license"),
-  licenseUrl: text("license_url"),
-  createdAt: text("created_at").default(sql`CURRENT_TIMESTAMP`),
-  updatedAt: text("updated_at").default(sql`CURRENT_TIMESTAMP`),
-});
 
 export const rankingItems = sqliteTable(
   "ranking_items",
@@ -62,7 +48,7 @@ export const rankingItems = sqliteTable(
     dataSourceId: text("data_source_id")
       .default("estat")
       .notNull()
-      .references(() => dataSources.id),
+      .references(() => sources.id),
     surveyId: text("survey_id").references(() => surveys.id),
     sourceConfig: text("source_config"), // JSON
     valueDisplayConfig: text("value_display_config"), // JSON
@@ -113,9 +99,6 @@ export const rankingData = sqliteTable("ranking_data", {
   areaIdx: index("idx_ranking_data_area").on(table.areaCode, table.yearCode),
 }));
 
-export type DataSource = typeof dataSources.$inferSelect;
-export type InsertDataSource = typeof dataSources.$inferInsert;
-
 export type RankingItem = typeof rankingItems.$inferSelect;
 export type InsertRankingItem = typeof rankingItems.$inferInsert;
 
@@ -152,9 +135,6 @@ export const rankingTags = sqliteTable(
 );
 
 import { createInsertSchema, createSelectSchema } from "drizzle-zod";
-
-export const insertDataSourceSchema = createInsertSchema(dataSources);
-export const selectDataSourceSchema = createSelectSchema(dataSources);
 
 export const insertRankingItemSchema = createInsertSchema(rankingItems);
 export const selectRankingItemSchema = createSelectSchema(rankingItems);

--- a/packages/database/src/schema/sources.ts
+++ b/packages/database/src/schema/sources.ts
@@ -1,0 +1,59 @@
+import { sql } from "drizzle-orm";
+import {
+  index,
+  integer,
+  sqliteTable,
+  text,
+} from "drizzle-orm/sqlite-core";
+import { createInsertSchema, createSelectSchema } from "drizzle-zod";
+
+/**
+ * 統一ソースマスタ — platform / survey / estat_table の 3 階層を 1 テーブルで表現
+ *
+ * source_kind:
+ * - platform: e-Stat / SSDSE / IPSS / 国土数値情報 / 総務省 等の発行元
+ * - survey: 国勢調査 / 人口動態統計 等の調査名
+ * - estat_table: e-Stat 内の個別統計表（statsDataId 単位）
+ *
+ * parent_source_id で estat_table → platform などの階層を表現。
+ * 旧 data_sources / source_metadata を統合した結果 (PR-2)。
+ */
+export const sources = sqliteTable(
+  "sources",
+  {
+    id: text("id").primaryKey(),
+    sourceKind: text("source_kind", {
+      enum: ["platform", "survey", "estat_table"],
+    }).notNull(),
+    externalId: text("external_id"),
+    parentSourceId: text("parent_source_id"),
+    name: text("name").notNull(),
+    organization: text("organization"),
+    url: text("url"),
+    description: text("description"),
+    attributionText: text("attribution_text"),
+    license: text("license"),
+    licenseUrl: text("license_url"),
+    baseUrl: text("base_url"),
+    linkTemplate: text("link_template"),
+    displayOrder: integer("display_order").default(0),
+    isActive: integer("is_active", { mode: "boolean" }).default(true),
+    createdAt: text("created_at").default(sql`CURRENT_TIMESTAMP`),
+    updatedAt: text("updated_at").default(sql`CURRENT_TIMESTAMP`),
+  },
+  (table) => ({
+    kindIdx: index("idx_sources_kind").on(table.sourceKind),
+    parentIdx: index("idx_sources_parent").on(table.parentSourceId),
+    externalIdIdx: index("idx_sources_external_id").on(
+      table.sourceKind,
+      table.externalId
+    ),
+    activeIdx: index("idx_sources_active").on(table.isActive),
+  })
+);
+
+export type Source = typeof sources.$inferSelect;
+export type InsertSource = typeof sources.$inferInsert;
+
+export const insertSourceSchema = createInsertSchema(sources);
+export const selectSourceSchema = createSelectSchema(sources);


### PR DESCRIPTION
## Summary

3 層化 D1 スキーマ完走の **PR-2/7**。旧 `data_sources` (5 行) と `source_metadata` (402 行) を、すでに投入済みの統一 `sources` テーブル (110 行) に一本化する。

**ベースブランチ**: #196 (PR-1)

## 統合の根拠

| 旧テーブル | 行数 | 統合先 | 理由 |
|---|---|---|---|
| `data_sources` | 5 | `sources` (platform 7 行に既存) | 全 5 件 (estat / ssdse / ipss / mlit_ksj / mlit_dpf) は sources にすでに存在。`adapter_type` カラムは未使用 (コード参照ゼロ) |
| `source_metadata` | 402 | DROP（重複） | 396/402 行が `estat_stats_tables` (8,460 行) と重複（area_type / stat_name / class_inf / gov_org / status / category_key / stats_field）。残り 5 行は `adapter_type`、1 行はテストデータ (`FIXED_TEST_555`) |

`ranking_items.data_source_id` の全値 (`estat / ssdse / ipss / mlit_ksj / calculated / soumu`) は sources.id に既に存在するため、FK rewire のみで runtime 整合性は確保済み。

## 変更内容

- `packages/database/src/schema/sources.ts` 新設 — platform/survey/estat_table を `parent_source_id` で階層表現する単一マスタ
- `packages/database/src/schema/ranking_items.ts`:
  - `dataSources` テーブル定義削除
  - `DataSource` / `InsertDataSource` 型・`insertDataSourceSchema` / `selectDataSourceSchema` 削除
  - `rankingItems.dataSourceId` の FK 参照先を `dataSources.id` → `sources.id` に rewire
- `packages/database/src/schema/index.ts` に `sources` を追加
- `packages/database/scripts/d1-diff-report.ts` の `SMALL_TABLES` から `data_sources` / `port_trade_detail` を除去、`sources` を追加
- `packages/database/drizzle/0017_sources_consolidation.sql` 追加 — sources の CREATE と data_sources / source_metadata の DROP

ローカル D1 では DROP 済み。

## 関連

| PR | 内容 | リスク |
|---|---|---|
| ✅ PR-1 | 未使用テーブル削除 | 🟢 極小 |
| **PR-2** | **本 PR** — sources 一本化 | 🟡 小 |
| PR-3 | 新 schema.ts (indicators / observations) + 並行 reader | 🟢 中 |
| PR-4 | 新 R2 exporter (既存 snapshot と byte-for-byte 互換) | 🟡 中 |
| PR-5 | reader 切替 + 旧 ranking 系 DROP | 🔴 大 |
| PR-6 | 港湾統計の observations 統合 | 🟡 中 |
| PR-7 | ranking_page_cards → page_components 統合 | 🟡 中 |

## Test plan

- [x] `npx tsc --noEmit -p apps/web/tsconfig.json` pass
- [x] `cd packages/database && npx tsc --noEmit` pass
- [x] ローカル D1 で `DROP TABLE data_sources / source_metadata` 実行済み
- [x] `ranking_items.data_source_id NOT IN (SELECT id FROM sources)` がゼロ件で整合性確認済み
- [ ] PR-quality check CI pass
- [ ] PR-1 merge 後に develop に追従