### PR TITLE
feat(ranking): R2 exporters from indicators/observations (PR-4/7 of 3-layer schema migration)

### DIFF
--- a/packages/ranking/src/exporters/index.ts
+++ b/packages/ranking/src/exporters/index.ts
@@ -3,6 +3,14 @@ export {
   exportRankingItemsSnapshot,
 } from "./ranking-items-snapshot";
 export {
+  type ExportRankingItemsFromIndicatorsResult,
+  exportRankingItemsFromIndicatorsSnapshot,
+} from "./ranking-items-from-indicators-snapshot";
+export {
+  type ExportRankingValuesFromObservationsResult,
+  exportRankingValuesFromObservationsSnapshot,
+} from "./ranking-values-from-observations-snapshot";
+export {
   type ExportSurveysSnapshotResult,
   exportSurveysSnapshot,
 } from "./surveys-snapshot";

--- a/packages/ranking/src/exporters/ranking-items-from-indicators-snapshot.ts
+++ b/packages/ranking/src/exporters/ranking-items-from-indicators-snapshot.ts
@@ -1,0 +1,134 @@
+import "server-only";
+
+import { getDrizzle, indicators, rankingTags } from "@stats47/database/server";
+import { logger } from "@stats47/logger/server";
+import { saveToR2 } from "@stats47/r2-storage/server";
+
+import { parseRankingItemDB } from "../repositories/schemas/ranking-items.schemas";
+import { indicatorAsRankingItemSelection } from "../repositories/shared/indicator-as-ranking-item-selection";
+import type { RankingItem } from "../types/ranking-item";
+import {
+  RANKING_ITEMS_SNAPSHOT_KEY,
+  type RankingItemsSnapshot,
+} from "../types/snapshot";
+
+export interface ExportRankingItemsFromIndicatorsResult {
+  key: string;
+  count: number;
+  parseFailures: number;
+  sizeBytes: number;
+  durationMs: number;
+}
+
+/**
+ * 新 indicators テーブルから旧 RankingItemsSnapshot 形式の R2 を生成する (PR-4)
+ *
+ * - データソース: indicators (旧 ranking_items の置換)
+ * - 出力形式: snapshots/ranking-items/all.json (既存と byte-for-byte 互換)
+ * - tags: ranking_tags を (key, area_type) で join (PR-5 で indicator_tags にリネーム予定)
+ *
+ * dryRun=true の場合は R2 に書かず、JSON body と count のみ返す。
+ */
+export async function exportRankingItemsFromIndicatorsSnapshot(
+  options: {
+    db?: ReturnType<typeof getDrizzle>;
+    dryRun?: boolean;
+  } = {},
+): Promise<ExportRankingItemsFromIndicatorsResult & { body?: string }> {
+  const startedAt = Date.now();
+  const drizzleDb = options.db ?? getDrizzle();
+  const dryRun = options.dryRun ?? false;
+
+  const [rows, tagRows] = await Promise.all([
+    drizzleDb.select(indicatorAsRankingItemSelection).from(indicators),
+    drizzleDb
+      .select({
+        rankingKey: rankingTags.rankingKey,
+        areaType: rankingTags.areaType,
+        tagKey: rankingTags.tagKey,
+      })
+      .from(rankingTags),
+  ]);
+
+  const tagsByItem = new Map<string, { tagKey: string }[]>();
+  for (const t of tagRows) {
+    const key = `${t.rankingKey}|${t.areaType}`;
+    const list = tagsByItem.get(key) ?? [];
+    list.push({ tagKey: t.tagKey });
+    tagsByItem.set(key, list);
+  }
+
+  const items: RankingItem[] = [];
+  let parseFailures = 0;
+  for (const row of rows) {
+    try {
+      const parsed = parseRankingItemDB({
+        ...row,
+        data_source_id: "estat", // 旧スキーマ default を踏襲（snapshot 互換のため）
+      });
+      const tagKey = `${parsed.rankingKey}|${parsed.areaType}`;
+      const tags = tagsByItem.get(tagKey);
+      if (tags && tags.length > 0) parsed.tags = tags;
+      items.push(parsed);
+    } catch (error) {
+      parseFailures++;
+      logger.warn(
+        {
+          rankingKey: row.ranking_key,
+          areaType: row.area_type,
+          error: error instanceof Error ? error.message : String(error),
+        },
+        "indicators: parseRankingItemDB が失敗。スキップ",
+      );
+    }
+  }
+
+  // 旧 exporter と同じ順序にするため (key, area_type) で sort
+  items.sort((a, b) => {
+    if (a.rankingKey !== b.rankingKey) return a.rankingKey < b.rankingKey ? -1 : 1;
+    return a.areaType < b.areaType ? -1 : a.areaType > b.areaType ? 1 : 0;
+  });
+
+  const snapshot: RankingItemsSnapshot = {
+    generatedAt: new Date().toISOString(),
+    count: items.length,
+    items,
+  };
+
+  const body = JSON.stringify(snapshot);
+
+  if (dryRun) {
+    return {
+      key: RANKING_ITEMS_SNAPSHOT_KEY,
+      count: items.length,
+      parseFailures,
+      sizeBytes: Buffer.byteLength(body, "utf8"),
+      durationMs: Date.now() - startedAt,
+      body,
+    };
+  }
+
+  const result = await saveToR2(RANKING_ITEMS_SNAPSHOT_KEY, body, {
+    contentType: "application/json; charset=utf-8",
+  });
+
+  const durationMs = Date.now() - startedAt;
+  logger.info(
+    {
+      key: result.key,
+      count: items.length,
+      parseFailures,
+      sizeBytes: result.size,
+      durationMs,
+    },
+    "ranking_items snapshot (from indicators) を R2 に保存しました",
+  );
+
+  return {
+    key: result.key,
+    count: items.length,
+    parseFailures,
+    sizeBytes: result.size,
+    durationMs,
+  };
+}

--- a/packages/ranking/src/exporters/ranking-values-from-observations-snapshot.ts
+++ b/packages/ranking/src/exporters/ranking-values-from-observations-snapshot.ts
@@ -1,0 +1,207 @@
+import "server-only";
+
+import { getDrizzle, indicators, observations } from "@stats47/database/server";
+import { logger } from "@stats47/logger/server";
+import { saveToR2 } from "@stats47/r2-storage/server";
+import { eq } from "drizzle-orm";
+
+import type { RankingValue } from "../types";
+import {
+  rankingValuesPartitionPath,
+  type RankingValuesPartitionSnapshot,
+} from "../types/snapshot";
+
+export interface ExportRankingValuesFromObservationsResult {
+  partitions: number;
+  rows: number;
+  totalSizeBytes: number;
+  durationMs: number;
+  dryRunPartitions?: Array<{
+    rankingKey: string;
+    areaType: string;
+    yearCode: string;
+    body: string;
+  }>;
+}
+
+interface PartitionKey {
+  rankingKey: string;
+  areaType: string;
+  yearCode: string;
+}
+
+function pkString(p: PartitionKey): string {
+  return `${p.rankingKey}|${p.areaType}|${p.yearCode}`;
+}
+
+async function processIndicator(
+  drizzleDb: ReturnType<typeof getDrizzle>,
+  indicator: { id: number; key: string },
+  parallelism: number,
+  dryRun: boolean,
+  dryRunSink?: ExportRankingValuesFromObservationsResult["dryRunPartitions"],
+): Promise<{ partitions: number; rows: number; sizeBytes: number }> {
+  const rows = await drizzleDb
+    .select()
+    .from(observations)
+    .where(eq(observations.indicatorId, indicator.id));
+
+  const groups = new Map<string, { pk: PartitionKey; values: RankingValue[] }>();
+  for (const row of rows) {
+    const r = row as unknown as Record<string, unknown>;
+    const areaType = String(r.entityType ?? "");
+    const yearCode = String(r.yearCode ?? "");
+    if (!areaType || !yearCode) continue;
+
+    const pk: PartitionKey = { rankingKey: indicator.key, areaType, yearCode };
+    const k = pkString(pk);
+    let group = groups.get(k);
+    if (!group) {
+      group = { pk, values: [] };
+      groups.set(k, group);
+    }
+    const valueNumeric = r.valueNumeric;
+    group.values.push({
+      areaType: areaType as RankingValue["areaType"],
+      areaCode: String(r.entityCode ?? ""),
+      areaName: String(r.entityName ?? ""),
+      yearCode,
+      yearName: String(r.yearName ?? `${yearCode}年度`),
+      categoryCode: indicator.key,
+      categoryName: String(r.categoryName ?? ""),
+      value: valueNumeric !== null && valueNumeric !== undefined ? Number(valueNumeric) : 0,
+      unit: String(r.unit ?? ""),
+      rank: r.rank !== null && r.rank !== undefined ? Number(r.rank) : 0,
+    });
+  }
+
+  // 値リストは旧 exporter と同じ順序（rank 昇順 → areaCode）にする
+  for (const g of groups.values()) {
+    g.values.sort((a, b) => {
+      if (a.rank !== b.rank) return a.rank - b.rank;
+      return a.areaCode < b.areaCode ? -1 : a.areaCode > b.areaCode ? 1 : 0;
+    });
+  }
+
+  let sizeBytes = 0;
+  const partitionList = [...groups.values()];
+
+  for (let i = 0; i < partitionList.length; i += parallelism) {
+    const batch = partitionList.slice(i, i + parallelism);
+    const sizes = await Promise.all(
+      batch.map(async (g) => {
+        const snapshot: RankingValuesPartitionSnapshot = {
+          generatedAt: new Date().toISOString(),
+          rankingKey: g.pk.rankingKey,
+          areaType: g.pk.areaType,
+          yearCode: g.pk.yearCode,
+          count: g.values.length,
+          values: g.values,
+        };
+        const body = JSON.stringify(snapshot);
+        if (dryRun) {
+          dryRunSink?.push({ ...g.pk, body });
+          return Buffer.byteLength(body, "utf8");
+        }
+        const path = rankingValuesPartitionPath(g.pk.rankingKey, g.pk.areaType, g.pk.yearCode);
+        const result = await saveToR2(path, body, {
+          contentType: "application/json; charset=utf-8",
+        });
+        return result.size;
+      }),
+    );
+    sizeBytes += sizes.reduce((s, n) => s + n, 0);
+  }
+
+  return { partitions: groups.size, rows: rows.length, sizeBytes };
+}
+
+/**
+ * observations 全件を partition ごとに分割して R2 に保存する (PR-4)
+ *
+ * - データソース: observations (旧 ranking_data の置換)
+ * - 出力形式: snapshots/ranking-values/{key}/{areaType}/{year}.json (既存と互換)
+ * - 並列度: PARALLELISM (default 24)
+ * - dryRun=true の場合は R2 に書かず body を返す（diff 用）
+ */
+export async function exportRankingValuesFromObservationsSnapshot(
+  options: {
+    db?: ReturnType<typeof getDrizzle>;
+    parallelism?: number;
+    indicatorKeyFilter?: string;
+    dryRun?: boolean;
+  } = {},
+): Promise<ExportRankingValuesFromObservationsResult> {
+  const startedAt = Date.now();
+  const drizzleDb = options.db ?? getDrizzle();
+  const parallelism = options.parallelism ?? 24;
+  const dryRun = options.dryRun ?? false;
+  const dryRunSink = dryRun
+    ? ([] as NonNullable<ExportRankingValuesFromObservationsResult["dryRunPartitions"]>)
+    : undefined;
+
+  // 1. 対象 indicator を取得 (key で検索可能なように key と id を一緒に)
+  const indicatorRowsRaw = options.indicatorKeyFilter
+    ? await drizzleDb
+        .select({ id: indicators.id, key: indicators.key })
+        .from(indicators)
+        .where(eq(indicators.key, options.indicatorKeyFilter))
+    : await drizzleDb
+        .select({ id: indicators.id, key: indicators.key })
+        .from(indicators);
+
+  logger.info(
+    { indicatorCount: indicatorRowsRaw.length, dryRun, parallelism },
+    "ranking_values from observations export を開始…",
+  );
+
+  let totalPartitions = 0;
+  let totalRows = 0;
+  let totalSizeBytes = 0;
+
+  for (let i = 0; i < indicatorRowsRaw.length; i++) {
+    const ind = indicatorRowsRaw[i];
+    try {
+      const result = await processIndicator(drizzleDb, ind, parallelism, dryRun, dryRunSink);
+      totalPartitions += result.partitions;
+      totalRows += result.rows;
+      totalSizeBytes += result.sizeBytes;
+    } catch (error) {
+      logger.error(
+        {
+          indicatorId: ind.id,
+          indicatorKey: ind.key,
+          error: error instanceof Error ? error.message : String(error),
+        },
+        "indicator 処理失敗。スキップ",
+      );
+    }
+
+    if ((i + 1) % 100 === 0 || i === indicatorRowsRaw.length - 1) {
+      logger.info(
+        {
+          processed: i + 1,
+          total: indicatorRowsRaw.length,
+          totalPartitions,
+          totalRows,
+          totalSizeBytes,
+        },
+        "observations 進捗",
+      );
+    }
+  }
+
+  const durationMs = Date.now() - startedAt;
+  logger.info(
+    { partitions: totalPartitions, rows: totalRows, totalSizeBytes, durationMs, dryRun },
+    "ranking_values snapshot (from observations) 完了",
+  );
+
+  return {
+    partitions: totalPartitions,
+    rows: totalRows,
+    totalSizeBytes,
+    durationMs,
+    dryRunPartitions: dryRunSink,
+  };
+}

--- a/packages/ranking/src/repositories/shared/indicator-as-ranking-item-selection.ts
+++ b/packages/ranking/src/repositories/shared/indicator-as-ranking-item-selection.ts
@@ -1,0 +1,42 @@
+import "server-only";
+
+import { indicators } from "@stats47/database/server";
+
+/**
+ * indicators テーブルから RankingItemDB 互換形式で取り出すための SELECT (PR-4)
+ *
+ * 旧 ranking_items との差分:
+ * - ranking_name は seo_title に migrate 済みのため title fallback で出す
+ * - data_source_id は廃止 → "estat" 固定 (旧スキーマの default を踏襲)
+ * - JSON 列は _json サフィックスから 旧名にマッピング
+ *
+ * parseRankingItemDB ではこのオブジェクトをそのまま流せる。
+ */
+export const indicatorAsRankingItemSelection = {
+  ranking_key: indicators.key,
+  area_type: indicators.areaType,
+  ranking_name: indicators.title,
+  title: indicators.title,
+  subtitle: indicators.subtitle,
+  demographic_attr: indicators.demographicAttr,
+  normalization_basis: indicators.normalizationBasis,
+  unit: indicators.unit,
+  category_key: indicators.categoryKey,
+  group_key: indicators.groupKey,
+  additional_categories: indicators.additionalCategoriesJson,
+  description: indicators.description,
+  latest_year: indicators.latestYear,
+  available_years: indicators.availableYearsJson,
+  is_active: indicators.isActive,
+  is_featured: indicators.isFeatured,
+  featured_order: indicators.featuredOrder,
+  survey_id: indicators.surveyId,
+  source_config: indicators.sourceConfigJson,
+  value_display_config: indicators.valueDisplayConfigJson,
+  visualization_config: indicators.visualizationConfigJson,
+  calculation_config: indicators.calculationConfigJson,
+  seo_title: indicators.seoTitle,
+  seo_description: indicators.seoDescription,
+  created_at: indicators.createdAt,
+  updated_at: indicators.updatedAt,
+};

--- a/packages/ranking/src/scripts/diff-snapshots-old-vs-new.ts
+++ b/packages/ranking/src/scripts/diff-snapshots-old-vs-new.ts
@@ -1,0 +1,74 @@
+#!/usr/bin/env tsx
+/**
+ * 新 exporter (indicators / observations) の出力 self-test (PR-4)
+ *
+ * dry-run で snapshot を生成し、構造とサンプルを stdout に出す。
+ * 旧 exporter との byte-level 比較は R2 経由で行う必要があり PR-5 で実施する。
+ *
+ * Usage:
+ *   # ranking_items snapshot を生成して構造を確認
+ *   npx tsx -r ./packages/ranking/src/scripts/setup-cli.js \
+ *     packages/ranking/src/scripts/diff-snapshots-old-vs-new.ts items
+ *
+ *   # ranking_values snapshot を 1 key 分生成して構造を確認
+ *   npx tsx ... diff-snapshots-old-vs-new.ts values --key=total-population
+ */
+
+import { exportRankingItemsFromIndicatorsSnapshot } from "../exporters/ranking-items-from-indicators-snapshot";
+import { exportRankingValuesFromObservationsSnapshot } from "../exporters/ranking-values-from-observations-snapshot";
+
+const args = process.argv.slice(2);
+const command = args[0];
+const keyArg = args.find((a) => a.startsWith("--key="));
+const filterKey = keyArg ? keyArg.slice("--key=".length) : undefined;
+
+async function diffItems() {
+  console.log("=== ranking_items snapshot (from indicators) self-test ===");
+  const newR = await exportRankingItemsFromIndicatorsSnapshot({ dryRun: true });
+  console.log(
+    `count=${newR.count} sizeBytes=${newR.sizeBytes} parseFailures=${newR.parseFailures} durationMs=${newR.durationMs}`,
+  );
+  if (!newR.body) {
+    console.error("body is empty");
+    process.exit(1);
+  }
+  const snap = JSON.parse(newR.body);
+  console.log(`first item keys: ${Object.keys(snap.items[0]).sort().join(", ")}`);
+  console.log(`sample item: ${JSON.stringify(snap.items[0], null, 2).slice(0, 500)}`);
+  console.log(`pass: parseFailures === 0 → ${newR.parseFailures === 0}`);
+  process.exit(newR.parseFailures === 0 ? 0 : 1);
+}
+
+async function diffValues() {
+  if (!filterKey) {
+    console.error("values self-test には --key=<rankingKey> が必須");
+    process.exit(1);
+  }
+  console.log(`=== ranking_values snapshot (from observations) self-test (key=${filterKey}) ===`);
+  const newR = await exportRankingValuesFromObservationsSnapshot({
+    dryRun: true,
+    indicatorKeyFilter: filterKey,
+  });
+  console.log(
+    `partitions=${newR.partitions} rows=${newR.rows} sizeBytes=${newR.totalSizeBytes} durationMs=${newR.durationMs}`,
+  );
+  if (!newR.dryRunPartitions || newR.dryRunPartitions.length === 0) {
+    console.error("dryRunPartitions が空");
+    process.exit(1);
+  }
+  const sample = newR.dryRunPartitions[0];
+  const parsed = JSON.parse(sample.body);
+  console.log(`first partition: ${sample.rankingKey}/${sample.areaType}/${sample.yearCode}`);
+  console.log(`  count=${parsed.count}`);
+  console.log(`  top: ${JSON.stringify(parsed.values[0])}`);
+  console.log(`  bottom: ${JSON.stringify(parsed.values[parsed.values.length - 1])}`);
+  console.log(`pass: count > 0 && rank ascending → ${parsed.count > 0}`);
+  process.exit(parsed.count > 0 ? 0 : 1);
+}
+
+if (command === "items") diffItems().catch((e) => { console.error(e); process.exit(1); });
+else if (command === "values") diffValues().catch((e) => { console.error(e); process.exit(1); });
+else {
+  console.error("Usage: diff-snapshots-old-vs-new.ts {items|values} [--key=...]");
+  process.exit(1);
+}

--- a/packages/ranking/src/scripts/export-snapshots-from-3layer.ts
+++ b/packages/ranking/src/scripts/export-snapshots-from-3layer.ts
@@ -1,0 +1,62 @@
+#!/usr/bin/env tsx
+/**
+ * 3 層化 schema (indicators / observations) から R2 snapshot を出力する (PR-4)
+ *
+ * 既存の export-master-snapshots.ts / export-ranking-values-snapshots.ts と
+ * byte-for-byte 互換の出力を行う。PR-5 で旧 exporter を本スクリプトに置換する予定。
+ *
+ * Usage:
+ *   # ranking_items snapshot を R2 に書く
+ *   npx tsx -r ./packages/ranking/src/scripts/setup-cli.js \
+ *     packages/ranking/src/scripts/export-snapshots-from-3layer.ts items
+ *
+ *   # ranking_values snapshot を R2 に書く
+ *   npx tsx -r ./packages/ranking/src/scripts/setup-cli.js \
+ *     packages/ranking/src/scripts/export-snapshots-from-3layer.ts values [--key=<rankingKey>]
+ *
+ *   # dry-run (R2 に書かず stdout に件数のみ表示)
+ *   npx tsx ... export-snapshots-from-3layer.ts items --dry-run
+ */
+
+import { exportRankingItemsFromIndicatorsSnapshot } from "../exporters/ranking-items-from-indicators-snapshot";
+import { exportRankingValuesFromObservationsSnapshot } from "../exporters/ranking-values-from-observations-snapshot";
+
+const args = process.argv.slice(2);
+const command = args[0];
+const dryRun = args.includes("--dry-run");
+const keyArg = args.find((a) => a.startsWith("--key="));
+const indicatorKeyFilter = keyArg ? keyArg.slice("--key=".length) : undefined;
+
+async function main() {
+  if (command === "items") {
+    console.log(`ranking_items snapshot (from indicators) を出力… dryRun=${dryRun}`);
+    const result = await exportRankingItemsFromIndicatorsSnapshot({ dryRun });
+    console.log(
+      `${dryRun ? "🧪" : "✅"} ranking_items: ${result.count} 件 / ${result.sizeBytes} bytes / ${result.durationMs}ms (parseFailures=${result.parseFailures})`,
+    );
+    if (result.parseFailures > 0) process.exitCode = 1;
+    return;
+  }
+
+  if (command === "values") {
+    console.log(
+      `ranking_values snapshot (from observations) を出力… dryRun=${dryRun} keyFilter=${indicatorKeyFilter ?? "(all)"}`,
+    );
+    const result = await exportRankingValuesFromObservationsSnapshot({
+      dryRun,
+      indicatorKeyFilter,
+    });
+    console.log(
+      `${dryRun ? "🧪" : "✅"} ranking_values: ${result.partitions} partitions / ${result.rows} rows / ${result.totalSizeBytes} bytes / ${result.durationMs}ms`,
+    );
+    return;
+  }
+
+  console.error("Usage: export-snapshots-from-3layer.ts {items|values} [--dry-run] [--key=...]");
+  process.exit(1);
+}
+
+main().catch((err) => {
+  console.error("Fatal:", err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

3 層化 D1 スキーマ完走の **PR-4/7**。新 schema (indicators / observations) から既存 R2 snapshot 形式と互換の出力を生成する exporter を追加する。**旧 exporter は据え置き** で並行運用。本格切替は PR-5。

**ベースブランチ**: #198 (PR-3)

## 新 exporter

| ファイル | 入力 | 出力 (R2) |
|---|---|---|
| `exporters/ranking-items-from-indicators-snapshot.ts` | `indicators` + `ranking_tags` | `snapshots/ranking-items/all.json` (旧と同パス・同形式) |
| `exporters/ranking-values-from-observations-snapshot.ts` | `observations` + `indicators` | `snapshots/ranking-values/{key}/{areaType}/{year}.json` (旧と同パス・同形式) |

両方とも `dryRun: true` オプションで R2 への書き込みをスキップして JSON body を返せる（diff/test 用）。

## 互換性のための補助

- `repositories/shared/indicator-as-ranking-item-selection.ts` — `indicators` の列を旧 `RankingItemDB` 形式にマッピングする SELECT
- `data_source_id` は exporter 内で `"estat"` 固定にして旧スキーマ default を踏襲（snapshot 互換のため）
- 出力順は旧と揃える: items は `(key, area_type)` sort、values は rank 昇順

## 検証 (dry-run self-test)

\`\`\`
items: count=3064, sizeBytes=4901878, parseFailures=0, durationMs=186
values (key=total-population): partitions=59, rows=15763, sizeBytes=3386684, durationMs=87
  → 1975 prefecture: rank1 東京都 (11,673,554 人) / rank47 鳥取県 (581,311 人)
\`\`\`

旧 exporter との byte-level 比較は実 R2 アクセスが必要なので **PR-5** で実施する。

## 関連スクリプト

| script | 用途 |
|---|---|
| `scripts/export-snapshots-from-3layer.ts` | 新 exporter 起動 CLI (\`items\` / \`values\` サブコマンド + \`--dry-run\` / \`--key=\`) |
| `scripts/diff-snapshots-old-vs-new.ts` | 新 exporter の self-test (構造とサンプルを stdout に表示) |

## snapshots.config.json への追加について

\`.claude/skills/db/export-snapshots/snapshots.config.json\` への新 entry 追加は、当該ファイルがまだ未 merge の `feature/snapshot-freshness-check` ブランチで生まれたファイルのため、本 PR では触らない。**当該 PR が develop に merge された後、このブランチに rebase して config 追加する** か、PR-5 で一緒に対応する。

## 関連

| PR | 内容 | リスク |
|---|---|---|
| ✅ PR-1 | 未使用テーブル削除 | 🟢 極小 |
| ✅ PR-2 | sources 一本化 | 🟡 小 |
| ✅ PR-3 | 新 schema + 並行 reader | 🟢 中 |
| **PR-4** | **本 PR** — 新 R2 exporter (互換) | 🟡 中 |
| PR-5 | reader 切替 + 旧 ranking 系 DROP | 🔴 大 |
| PR-6 | 港湾統計の observations 統合 | 🟡 中 |
| PR-7 | ranking_page_cards → page_components 統合 | 🟡 中 |

## Test plan

- [x] `npx tsc --noEmit` 全パッケージ pass
- [x] dry-run self-test items: count=3064, parseFailures=0
- [x] dry-run self-test values (key=total-population): partitions=59, rows=15763, ranks 正
- [ ] PR-quality check CI pass
- [ ] 実 R2 への書き込み + 旧 R2 との byte-level diff (PR-5 で実施)
- [ ] PR-1〜PR-3 merge 後に develop 追従