### PR TITLE
feat(db): merge port_statistics into observations + drop (PR-6/7 of 3-layer schema migration)

### DIFF
--- a/apps/web/scripts/export-port-statistics-snapshot.ts
+++ b/apps/web/scripts/export-port-statistics-snapshot.ts
@@ -1,5 +1,5 @@
 /**
- * ports + port_statistics を R2 snapshot 化する (Phase 6)。
+ * ports + observations(entity_type=port) を R2 snapshot 化する (Phase 6, PR-6)。
  *
  * Outputs:
  *   - snapshots/ports/all.json (全 port メタ)
@@ -108,8 +108,37 @@ async function main() {
   });
   console.log(`✅ ports: ${portsMeta.length} 件`);
 
-  // 2. port_statistics 全件読み込み + group by year / portCode
-  const allStats = await db.select().from(schema.portStatistics);
+  // 2. observations(entity_type=port) を indicators JOIN で読み込み (PR-6)
+  // indicators.key 形式 'port-ships-total' → port_statistics の旧 metric_key 'ships_total' に逆変換
+  const { eq, and } = await import("drizzle-orm");
+  const observationRows = await db
+    .select({
+      portCode: schema.observations.entityCode,
+      year: schema.observations.yearCode,
+      indicatorKey: schema.indicators.key,
+      value: schema.observations.valueNumeric,
+      unit: schema.observations.unit,
+    })
+    .from(schema.observations)
+    .innerJoin(
+      schema.indicators,
+      and(
+        eq(schema.observations.indicatorId, schema.indicators.id),
+        eq(schema.indicators.areaType, "port")
+      )
+    )
+    .where(eq(schema.observations.entityType, "port"));
+
+  // R2 snapshot は旧 metric_key 形式 (snake_case) を維持する → 後方互換
+  const allStats = observationRows
+    .filter((r) => r.value !== null)
+    .map((r) => ({
+      portCode: r.portCode,
+      year: r.year,
+      metricKey: r.indicatorKey.replace(/^port-/, "").replace(/-/g, "_"),
+      value: Number(r.value),
+      unit: r.unit ?? "",
+    }));
 
   const byYear = new Map<string, PortStatRow[]>();
   const byPort = new Map<string, Array<{ year: string; metricKey: string; value: number; unit: string }>>();

--- a/packages/database/drizzle/0021_drop_port_statistics.sql
+++ b/packages/database/drizzle/0021_drop_port_statistics.sql
@@ -1,0 +1,9 @@
+-- PR-6 Commit 2: port_statistics を DROP
+--
+-- データは PR-3 の backfill で observations(entity_type='port') に既に COPY 済み
+-- (41,733 行 / 14 metric_keys、行数 100% 一致確認済み)。
+-- ローカル D1 では既に 2026-05-04 に DROP 済み。本マイグレーションは fresh setup 用。
+
+PRAGMA foreign_keys = OFF;
+DROP TABLE IF EXISTS port_statistics;
+PRAGMA foreign_keys = ON;

--- a/packages/database/scripts/populate-port-statistics.ts
+++ b/packages/database/scripts/populate-port-statistics.ts
@@ -328,18 +328,33 @@ console.log("");
 const db = new Database(dbPath);
 
 // 既知の港コード一覧を取得
-const knownPorts = new Set(
-  db.prepare("SELECT port_code FROM ports").all().map((r: any) => r.port_code as string)
+const knownPorts = new Map<string, string>(
+  db.prepare("SELECT port_code, port_name FROM ports").all().map((r: any) => [r.port_code as string, r.port_name as string])
 );
 console.log(`既知の港: ${knownPorts.size} 件`);
 
+// metric_key → indicator_id の lookup map (3 層 schema、PR-6)
+// indicators.key は "port-{metric_key}" 形式 (e.g. ships_total → port-ships-total)
+const metricToIndicatorId = new Map<string, number>();
+for (const r of db
+  .prepare("SELECT id, key FROM indicators WHERE area_type = 'port'")
+  .all() as { id: number; key: string }[]) {
+  const metricKey = r.key.replace(/^port-/, "").replace(/-/g, "_");
+  metricToIndicatorId.set(metricKey, r.id);
+}
+console.log(`port indicators: ${metricToIndicatorId.size} 件`);
+
 const upsertStmt = db.prepare(`
-  INSERT INTO port_statistics (port_code, year, metric_key, value, unit)
-  VALUES (?, ?, ?, ?, ?)
-  ON CONFLICT (port_code, year, metric_key) DO UPDATE SET
-    value = excluded.value,
-    unit = excluded.unit,
-    updated_at = CURRENT_TIMESTAMP
+  INSERT INTO observations (
+    indicator_id, entity_type, entity_code, entity_name,
+    year_code, year_name, unit, value_numeric
+  )
+  VALUES (?, 'port', ?, ?, ?, ?, ?, ?)
+  ON CONFLICT (indicator_id, entity_type, entity_code, year_code) DO UPDATE SET
+    value_numeric = excluded.value_numeric,
+    entity_name = excluded.entity_name,
+    year_name = excluded.year_name,
+    unit = excluded.unit
 `);
 
 /** プロキシ対応 fetch */
@@ -394,8 +409,14 @@ function isIndividualPort(code: string): boolean {
 async function processMetric(metric: MetricDef): Promise<number> {
   console.log(`\n--- ${metric.key}: ${metric.label} ---`);
 
+  const indicatorId = metricToIndicatorId.get(metric.key);
+  if (!indicatorId) {
+    console.warn(`  WARN: indicator が未登録 (key=port-${metric.key.replace(/_/g, "-")})、スキップ`);
+    return 0;
+  }
+
   if (metric.needsAggregation) {
-    return processAggregateMetric(metric);
+    return processAggregateMetric(metric, indicatorId);
   }
 
   const rawData = await fetchEstatData(metric.statsDataId, metric.filters);
@@ -412,12 +433,13 @@ async function processMetric(metric: MetricDef): Promise<number> {
 
       if (!portCode || !timeCode || isNaN(value)) continue;
       if (!isIndividualPort(portCode)) continue;
-      if (!knownPorts.has(portCode)) continue;
+      const portName = knownPorts.get(portCode);
+      if (!portName) continue;
 
       const year = timeCode.substring(0, 4);
 
       if (!isDryRun) {
-        upsertStmt.run(portCode, year, metric.key, value, metric.unit);
+        upsertStmt.run(indicatorId, portCode, portName, year, `${year}年`, metric.unit, value);
       }
       inserted++;
     }
@@ -429,7 +451,10 @@ async function processMetric(metric: MetricDef): Promise<number> {
 }
 
 /** 同一 port+year の複数行を合算して投入 */
-async function processAggregateMetric(metric: MetricDef): Promise<number> {
+async function processAggregateMetric(
+  metric: MetricDef,
+  indicatorId: number
+): Promise<number> {
   const portDimKey = `@${metric.portDimension}`;
 
   const rawData = await fetchEstatData(metric.statsDataId, metric.filters);
@@ -457,8 +482,10 @@ async function processAggregateMetric(metric: MetricDef): Promise<number> {
   const txn = db.transaction(() => {
     for (const [key, value] of aggregated) {
       const [portCode, year] = key.split("_");
+      const portName = knownPorts.get(portCode);
+      if (!portName) continue;
       if (!isDryRun) {
-        upsertStmt.run(portCode, year, metric.key, value, metric.unit);
+        upsertStmt.run(indicatorId, portCode, portName, year, `${year}年`, metric.unit, value);
       }
       inserted++;
     }
@@ -483,18 +510,29 @@ async function main() {
   }
 
   // 最終サマリー
-  const totalRows = db.prepare("SELECT COUNT(*) as cnt FROM port_statistics").get() as any;
+  const totalRows = db
+    .prepare(
+      "SELECT COUNT(*) as cnt FROM observations WHERE entity_type = 'port'"
+    )
+    .get() as any;
   console.log(`\n=== 完了 ===`);
   console.log(`投入合計: ${totalInserted} 件`);
-  console.log(`port_statistics 総行数: ${totalRows.cnt}`);
+  console.log(`observations(entity_type=port) 総行数: ${totalRows.cnt}`);
 
-  // metric_key 別の行数
-  const byMetric = db.prepare(
-    "SELECT metric_key, COUNT(*) as cnt FROM port_statistics GROUP BY metric_key ORDER BY metric_key"
-  ).all() as any[];
+  // indicator 別の行数
+  const byIndicator = db
+    .prepare(
+      `SELECT i.key, COUNT(*) as cnt
+       FROM observations o
+       INNER JOIN indicators i ON i.id = o.indicator_id
+       WHERE i.area_type = 'port'
+       GROUP BY i.key
+       ORDER BY i.key`
+    )
+    .all() as any[];
   console.log("\n指標別行数:");
-  for (const row of byMetric) {
-    console.log(`  ${row.metric_key}: ${row.cnt}`);
+  for (const row of byIndicator) {
+    console.log(`  ${row.key}: ${row.cnt}`);
   }
 
   db.close();

--- a/packages/database/src/schema/port_statistics.ts
+++ b/packages/database/src/schema/port_statistics.ts
@@ -5,21 +5,23 @@ import {
   real,
   sqliteTable,
   text,
-  uniqueIndex,
 } from "drizzle-orm/sqlite-core";
 import { createInsertSchema, createSelectSchema } from "drizzle-zod";
 
 /**
  * 港湾マスタ — 甲種港湾 171港
  * コード体系: 都道府県コード2桁 + 連番3桁（例: 01001 = 北海道_稚内）
+ *
+ * 旧 portStatistics は PR-6 で observations(entity_type='port') に統合し DROP した。
+ * port 別の時系列値を取得する場合は observations テーブルを参照すること。
  */
 export const ports = sqliteTable(
   "ports",
   {
-    portCode: text("port_code").primaryKey(), // "01001"
-    portName: text("port_name").notNull(), // "稚内"
-    prefectureCode: text("prefecture_code").notNull(), // "01"
-    prefectureName: text("prefecture_name").notNull(), // "北海道"
+    portCode: text("port_code").primaryKey(),
+    portName: text("port_name").notNull(),
+    prefectureCode: text("prefecture_code").notNull(),
+    prefectureName: text("prefecture_name").notNull(),
     portClass: text("port_class", {
       enum: ["甲種", "乙種"],
     })
@@ -27,9 +29,9 @@ export const ports = sqliteTable(
       .default("甲種"),
     latitude: real("latitude"),
     longitude: real("longitude"),
-    portGrade: text("port_grade"), // 国際戦略港湾 / 国際拠点港湾 / 重要港湾
-    administrator: text("administrator"), // 管理者（横浜市、東京都 等）
-    cyportCode: text("cyport_code"), // サイバーポート港湾コード
+    portGrade: text("port_grade"),
+    administrator: text("administrator"),
+    cyportCode: text("cyport_code"),
     isActive: integer("is_active", { mode: "boolean" }).default(true),
     createdAt: text("created_at").default(sql`CURRENT_TIMESTAMP`),
     updatedAt: text("updated_at").default(sql`CURRENT_TIMESTAMP`),
@@ -40,58 +42,8 @@ export const ports = sqliteTable(
   })
 );
 
-/**
- * 港湾統計データ — 港×年×指標ごとの値
- *
- * metricKey 例:
- * - ships_total: 入港船舶隻数（合計）
- * - ships_tonnage: 入港船舶総トン数
- * - cargo_total: 海上出入貨物トン数（合計）
- * - cargo_export: 輸出貨物トン数
- * - cargo_import: 輸入貨物トン数
- * - cargo_coastal_out: 移出貨物トン数
- * - cargo_coastal_in: 移入貨物トン数
- */
-export const portStatistics = sqliteTable(
-  "port_statistics",
-  {
-    id: integer("id").primaryKey({ autoIncrement: true }),
-    portCode: text("port_code")
-      .notNull()
-      .references(() => ports.portCode, { onDelete: "cascade" }),
-    year: text("year").notNull(), // "2023"
-    metricKey: text("metric_key").notNull(), // "ships_total", "cargo_export" etc.
-    value: real("value").notNull(),
-    unit: text("unit").notNull(), // "隻", "総トン", "トン"
-    createdAt: text("created_at").default(sql`CURRENT_TIMESTAMP`),
-    updatedAt: text("updated_at").default(sql`CURRENT_TIMESTAMP`),
-  },
-  (table) => ({
-    unq: uniqueIndex("port_statistics_unq").on(
-      table.portCode,
-      table.year,
-      table.metricKey
-    ),
-    portYearIdx: index("idx_port_statistics_port_year").on(
-      table.portCode,
-      table.year
-    ),
-    metricIdx: index("idx_port_statistics_metric").on(
-      table.metricKey,
-      table.year
-    ),
-    yearIdx: index("idx_port_statistics_year").on(table.year),
-  })
-);
-
 export type Port = typeof ports.$inferSelect;
 export type InsertPort = typeof ports.$inferInsert;
 
-export type PortStatistic = typeof portStatistics.$inferSelect;
-export type InsertPortStatistic = typeof portStatistics.$inferInsert;
-
 export const insertPortSchema = createInsertSchema(ports);
 export const selectPortSchema = createSelectSchema(ports);
-
-export const insertPortStatisticSchema = createInsertSchema(portStatistics);
-export const selectPortStatisticSchema = createSelectSchema(portStatistics);


### PR DESCRIPTION
## Summary

7-PR チェーン (sources/indicators/observations 3 層化) の **PR-6**。
旧 port_statistics テーブル (41,733 行 / 14 metric_keys) を新 observations(entity_type='port') に統合して DROP。完了後 22 → **21 テーブル**。

データ自体は PR-3 の `backfill-observations-ports.ts` で既に observations に完全 COPY 済み (行数 100% 一致確認済み)。本 PR は writer / exporter の切替と DROP のみ。

## Commits

| # | hash | 内容 |
|---|---|---|
| 1 | 60ed3014 | populate-port-statistics + export-port-statistics-snapshot を indicators+observations に切替 |
| 2 | 66a41cbb | port_statistics DROP + schema 削除 + drizzle 0021 |

## 主な設計判断

- **R2 snapshot 完全互換**: snapshot 内の metricKey は旧 snake_case (e.g. `ships_total`) を維持。indicators.key は kebab-case (`port-ships-total`) なので、exporter 側で逆変換してフロント reader 影響をゼロに保つ
- **ports マスタは残す**: 港湾の名称・座標は引き続き `ports` テーブルから取得（観測値のみ observations に集約）
- **indicators の port-* 14 個**: PR-3 で登録済み (id 9172〜9185)。本 PR では追加なし

## Test plan

- [x] tsc --noEmit 全 package OK
- [x] ローカル D1 で port_statistics DROP 済み、observations(entity_type='port') 41,733 行で代替
- [x] dev server 起動: `/ports` (港湾統計マップ) 200 / `/ranking/total-population` 200 / `/areas/13000` 200
- [ ] **merge 後**: `/export-snapshots` → `/push-r2` で本番 R2 snapshot を再生成 (新 exporter で出力されることを確認)

## 残タスク (本 PR 完了後)

- **PR-7**: ranking_page_cards (20 行) を page_components + page_component_assignments に統合、DROP

🤖 Generated with [Claude Code](https://claude.com/claude-code)