### PR TITLE
fix(correlation): add jsx to tsconfig to resolve TS6142

### DIFF
--- a/packages/correlation/tsconfig.json
+++ b/packages/correlation/tsconfig.json
@@ -7,7 +7,8 @@
     "module": "esnext",
     "moduleResolution": "bundler",
     "noEmit": true,
-    "skipLibCheck": true
+    "skipLibCheck": true,
+    "jsx": "react-jsx"
   },
   "include": ["src/**/*"],
   "exclude": ["node_modules", "dist", "**/__tests__/**"]


### PR DESCRIPTION
## Summary

- `packages/correlation` の `tsconfig.json` に `jsx: "react-jsx"` を追加
- correlation → ranking → `@stats47/visualization/d3` → `.tsx` ファイルの依存チェーンで TS6142 が発生していた
- correlation 自体は JSX を使わないが、型チェック時に `.tsx` ファイルが解決されるため `jsx` 設定が必要

## Root Cause

`packages/correlation/package.json` に `"type-check": "tsc --noEmit"` があり、
turbo の `type-check` タスクで実行される。correlation が ranking を通じて
`@stats47/visualization/d3` を間接的にインポートするが、visualization の
barrel ファイル (`index.ts`) が `.tsx` コンポーネントを再エクスポートするため、
`jsx` 未設定の correlation tsconfig で TS6142 が発生。

## Test plan

- [x] `cd packages/correlation && npx tsc --noEmit` がエラーなしで完了

🤖 Generated with [Claude Code](https://claude.com/claude-code)