### PR TITLE
fix(blog): update article-service test to mock blog-snapshot-reader

### DIFF
--- a/apps/web/src/features/blog/services/article-service.test.ts
+++ b/apps/web/src/features/blog/services/article-service.test.ts
@@ -20,8 +20,8 @@ const { mockFindArticle } = vi.hoisted(() => ({
   mockFindArticle: vi.fn(),
 }));
 
-vi.mock("../repositories/article-repository", () => ({
-  findArticleBySlug: mockFindArticle,
+vi.mock("../repositories/blog-snapshot-reader", () => ({
+  readArticleBySlugFromR2: mockFindArticle,
 }));
 
 class TestArticleService extends ArticleService {


### PR DESCRIPTION
## Summary

- `article-service.test.ts` のモック対象を `article-repository` → `blog-snapshot-reader` に更新
- サービスが `readArticleBySlugFromR2` (from `blog-snapshot-reader`) を使うように変更されたが、テストのモックが古い `findArticleBySlug` (from `article-repository`) のままだった
- CI でモックが効かず R2 接続が試みられ `R2クライアントを取得できませんでした` エラーが発生

## Test plan

- [x] `npx vitest run apps/web/src/features/blog/services/article-service.test.ts` — 3 tests passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)