### PR TITLE
fix(gis): handle R2 unavailability in generateStaticParams gracefully

### DIFF
--- a/apps/web/src/app/gis/[dataId]/page.tsx
+++ b/apps/web/src/app/gis/[dataId]/page.tsx
@@ -13,11 +13,17 @@ interface PageProps {
   params: Promise<{ dataId: string }>;
 }
 
+export const dynamicParams = true;
+
 export async function generateStaticParams() {
-  const datasets = await fetchGisDatasets();
-  return datasets
-    .filter((d) => d.isDownloaded && d.r2Prefix)
-    .map((d) => ({ dataId: d.dataId }));
+  try {
+    const datasets = await fetchGisDatasets();
+    return datasets
+      .filter((d) => d.isDownloaded && d.r2Prefix)
+      .map((d) => ({ dataId: d.dataId }));
+  } catch {
+    return [];
+  }
 }
 
 export async function generateMetadata({ params }: PageProps): Promise<Metadata> {


### PR DESCRIPTION
## Summary

- `/gis/[dataId]/page.tsx` の `generateStaticParams` を try-catch で囲み、R2 が使えない場合 (CI ビルド時) は `[]` を返すよう修正
- `dynamicParams = true` を追加し、静的プレジェネレートされなかったページが on-demand でレンダリングされることを明示

## Root Cause

Next.js ビルド時、`generateStaticParams` が Cloudflare の `getCloudflareContext` を sync mode で呼び出そうとするが、静的ルートでは許可されていない。
`fetchGisDatasets` → `fetchFromR2AsJson` → `getR2Client` → `getCloudflareContext` の呼び出しチェーンで `Error: R2クライアントを取得できませんでした` が発生し、ビルドが失敗していた。

## Test plan

- [x] ローカル型チェック `npx tsc --noEmit -p apps/web/tsconfig.json` がパス

🤖 Generated with [Claude Code](https://claude.com/claude-code)