### PR TITLE
fix(gis): /gis page を force-dynamic に設定してビルド時 R2 エラーを回避

### DIFF
--- a/apps/web/src/app/gis/page.tsx
+++ b/apps/web/src/app/gis/page.tsx
@@ -3,6 +3,8 @@ import { fetchGisDatasets } from "@/features/gis-catalog/repository/gis-datasets
 
 import type { Metadata } from "next";
 
+export const dynamic = "force-dynamic";
+
 export const metadata: Metadata = {
   title: "GIS データカタログ | stats47",
   robots: "noindex, follow",


### PR DESCRIPTION
## Summary
- `/gis/page.tsx` に `export const dynamic = "force-dynamic"` を追加
- Next.js がビルド時に `/gis` を静的プリレンダリングしようとして `fetchGisDatasets()` → R2 クライアント取得失敗でビルドが壊れていた
- `force-dynamic` によりビルド時プリレンダリングをスキップし、リクエスト時にサーバーサイドレンダリングする

## Test plan
- [ ] CI Build Check が pass することを確認
- [ ] `/gis` ページが本番環境で正常に表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)