### PR TITLE
fix(ogp): フォント OpenType シグネチャ検証 + ImageResponse を try-catch で保護

### DIFF
--- a/apps/web/src/app/opengraph-image.tsx
+++ b/apps/web/src/app/opengraph-image.tsx
@@ -10,8 +10,11 @@ export const revalidate = 2592000; // 30d
 export const dynamic = 'force-dynamic';
 
 export default async function OGImage() {
-  return new ImageResponse(<DefaultOgp />, {
-    ...size,
-    fonts: await loadOgpFonts(),
-  });
+  const fonts = await loadOgpFonts();
+  try {
+    return new ImageResponse(<DefaultOgp />, { ...size, fonts });
+  } catch {
+    // Font data may be invalid in non-Cloudflare environments — retry without fonts
+    return new ImageResponse(<DefaultOgp />, { ...size });
+  }
 }

--- a/apps/web/src/features/ogp/font-loader.ts
+++ b/apps/web/src/features/ogp/font-loader.ts
@@ -1,6 +1,14 @@
 // Old UA forces Google Fonts to return TTF (not WOFF2), which Satori supports
 const UA_TTF = 'Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.1)';
 
+// Valid OpenType/TrueType font signatures (first 4 bytes)
+const VALID_FONT_SIGS = [
+  0x00010000, // TrueType
+  0x4f54544f, // 'OTTO' — CFF OpenType
+  0x74746366, // 'ttcf' — TTC collection
+  0x74727565, // 'true' — old Mac TrueType
+];
+
 type OgWeight = 100 | 200 | 300 | 400 | 500 | 600 | 700 | 800 | 900;
 type OgFont = { data: ArrayBuffer; name: string; weight: OgWeight; style: 'normal' | 'italic' };
 
@@ -14,7 +22,11 @@ async function fetchFontData(family: string, weight: number): Promise<ArrayBuffe
   });
   const urlMatch = css.match(/src:\s*url\(([^)]+)\)/);
   if (!urlMatch) throw new Error(`Font URL not found for ${family}:${weight}`);
-  return fetch(urlMatch[1]).then((r) => r.arrayBuffer());
+  const buffer = await fetch(urlMatch[1]).then((r) => r.arrayBuffer());
+  // Validate OpenType signature to guard against non-font responses (e.g. CI network filtering)
+  const sig = new DataView(buffer).getUint32(0, false);
+  if (!VALID_FONT_SIGS.includes(sig)) throw new Error(`Invalid font signature for ${family}:${weight}`);
+  return buffer;
 }
 
 export async function loadOgpFonts(): Promise<OgFont[]> {


### PR DESCRIPTION
## Summary
- CI 環境で Google Fonts から取得したバイナリが不正（non-OpenType）になる場合に `Unsupported OpenType signature` エラーでビルドが壊れていた
- `font-loader.ts`: 4 バイト OpenType シグネチャ検証で不正バッファを早期にエラーに変換（`loadOgpFonts` の catch が正しく機能するよう）
- `opengraph-image.tsx`: フォント付き `ImageResponse` が失敗した場合にフォントなしでリトライするフォールバックを追加

## Root cause
CI（GitHub Actions）では `loadOgpFonts()` が Google Fonts から non-OpenType バイナリを取得し、try-catch を素通りして `ImageResponse` の `addFonts()` でクラッシュしていた。

## Test plan
- [ ] CI Build Check が pass することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)