### PR TITLE
feat(ads): AdSense広告枠をランキング・都道府県・調査ページに追加

### DIFF
--- a/apps/web/src/app/areas/[areaCode]/page.tsx
+++ b/apps/web/src/app/areas/[areaCode]/page.tsx
@@ -22,6 +22,7 @@ import { SetSidebarSection } from "@/components/molecules/SetSidebarSection";
 
 import { FurusatoNozeiCard } from "@/features/ads";
 import { AreaBannerAd } from "@/features/ads/server";
+import { AdSenseAd, RANKING_SIDEBAR_TOP } from "@/lib/google-adsense";
 import {
     AreaProfilePageClient,
     AreaProfileSidebar,
@@ -200,6 +201,12 @@ export default async function AreaProfilePage({ params }: PageProps) {
                         areaName={profile.areaName}
                     />
 
+                    {/* 広告①: チャート読了後 */}
+                    <AdSenseAd
+                        format={RANKING_SIDEBAR_TOP.format}
+                        slotId={RANKING_SIDEBAR_TOP.slotId}
+                    />
+
                     {/* カテゴリナビゲーション */}
                     <CategoryNavGrid
                         categories={categories}
@@ -208,6 +215,12 @@ export default async function AreaProfilePage({ params }: PageProps) {
 
                     {/* 関連エリア */}
                     <RelatedAreas areaCode={areaCode} />
+
+                    {/* 広告②: アフィリエイト直前 */}
+                    <AdSenseAd
+                        format={RANKING_SIDEBAR_TOP.format}
+                        slotId={RANKING_SIDEBAR_TOP.slotId}
+                    />
 
                     {/* アフィリエイト */}
                     <AreaBannerAd />

--- a/apps/web/src/app/areas/[areaCode]/page.tsx
+++ b/apps/web/src/app/areas/[areaCode]/page.tsx
@@ -22,7 +22,6 @@ import { SetSidebarSection } from "@/components/molecules/SetSidebarSection";
 
 import { FurusatoNozeiCard } from "@/features/ads";
 import { AreaBannerAd } from "@/features/ads/server";
-import { AdSenseAd, RANKING_SIDEBAR_TOP } from "@/lib/google-adsense";
 import {
     AreaProfilePageClient,
     AreaProfileSidebar,
@@ -34,6 +33,8 @@ import {
 } from "@/features/area-profile";
 import { getAreaProfileAction } from "@/features/area-profile/server";
 import { listCategories } from "@/features/category/server";
+
+import { AdSenseAd, RANKING_SIDEBAR_TOP } from "@/lib/google-adsense";
 
 
 import type { Metadata } from "next";

--- a/apps/web/src/app/survey/[surveyKey]/page.tsx
+++ b/apps/web/src/app/survey/[surveyKey]/page.tsx
@@ -21,6 +21,7 @@ import {
   type CategoryRankingListItem,
 } from "@/features/ranking";
 
+import { AdSenseAd, RANKING_PAGE_FOOTER } from "@/lib/google-adsense";
 import { generateOGMetadata } from "@/lib/metadata/og-generator";
 
 import type { Metadata } from "next";
@@ -187,6 +188,13 @@ export default async function SurveyPage({ params }: PageProps) {
               </div>
             </section>
           )}
+
+          {/* 広告: 注目カード後・テーブル前 */}
+          <AdSenseAd
+            format={RANKING_PAGE_FOOTER.format}
+            slotId={RANKING_PAGE_FOOTER.slotId}
+            className="mb-6"
+          />
 
           <CategoryRankingTable items={allItems} />
         </>

--- a/apps/web/src/features/ranking/components/RankingKeyPage/RankingKeyPageClient.tsx
+++ b/apps/web/src/features/ranking/components/RankingKeyPage/RankingKeyPageClient.tsx
@@ -38,6 +38,7 @@ import { trackRankingView, trackYearChange, trackAreaTypeChange } from "@/lib/an
 import {
     AdSenseAd,
     RANKING_PAGE_TABLE_SIDE,
+    RANKING_PAGE_FOOTER,
 } from "@/lib/google-adsense";
 
 import { useBreakpoint } from "@/hooks/useBreakpoint";
@@ -393,6 +394,12 @@ export function RankingKeyPageClient({
                             shareText={shareText}
                         />
                     </div>
+
+                    {/* 広告: テーブル読了後 */}
+                    <AdSenseAd
+                        format={RANKING_PAGE_FOOTER.format}
+                        slotId={RANKING_PAGE_FOOTER.slotId}
+                    />
 
                     {/* データの考察（折りたたみ） */}
                     {insightsSection}


### PR DESCRIPTION
## Summary

- **ランキング詳細** (`/ranking/[rankingKey]`): テーブル読了後（ShareButtons直後）に1枠追加 → 視認可能率の高い位置
- **都道府県ページ** (`/areas/[areaCode]`): チャート後 + アフィリエイト前の2箇所追加（広告ゼロ→2枠）
- **調査ページ** (`/survey/[surveyKey]`): 注目カード後・テーブル前に1枠追加（広告ゼロ→1枠）

既存の `RANKING_PAGE_FOOTER` / `RANKING_SIDEBAR_TOP` スロット定数を再利用。AdSenseダッシュボード操作不要。

## Test plan

- [ ] 型チェック通過済み (`npx tsc --noEmit`)
- [ ] dev server で各ページにグレーの広告プレースホルダーが正しい位置に表示されること
  - `/ranking/population` — テーブル下・考察前
  - `/areas/13000` — チャート後、関連エリア後
  - `/survey/0003445758` — 注目カード後・テーブル前

🤖 Generated with [Claude Code](https://claude.com/claude-code)