### PR TITLE
feat: 人口・面積あたり正規化トグル + 国際関係指標6件追加

### DIFF
--- a/.claude/scripts/metrics/add-normalization-options.cjs
+++ b/.claude/scripts/metrics/add-normalization-options.cjs
@@ -1,0 +1,158 @@
+/**
+ * metrics テーブルの calculation_config_json に normalizationOptions を一括追加する
+ *
+ * 対象: is_active = 1 かつ isCalculated が false/null の指標
+ * 除外: 比率・すでに正規化済み・意味をなさない unit の指標
+ *
+ * 実行: node .claude/scripts/metrics/add-normalization-options.cjs [--dry-run]
+ */
+
+const path = require("path");
+const Database = require("better-sqlite3");
+
+const PROJECT_ROOT = path.resolve(__dirname, "../../..");
+const DB_PATH = path.join(
+  PROJECT_ROOT,
+  ".local/d1/v3/d1/miniflare-D1DatabaseObject/baffe56c6b0173e34c63a5333065bcdb6642a01b4c2cfecd70ad3607b00c9972.sqlite"
+);
+
+const isDryRun = process.argv.includes("--dry-run");
+
+// 指標の unit から正規化後の表示 unit を生成する
+function buildNormalizationOptions(metricUnit) {
+  const u = metricUnit || "件";
+  return [
+    {
+      type: "per_population",
+      label: "人口10万人あたり",
+      unit: `${u}/10万人`,
+      scaleFactor: 100000,
+      decimalPlaces: 1,
+    },
+    {
+      type: "per_area",
+      label: "面積100km²あたり",
+      unit: `${u}/100km²`,
+      scaleFactor: 100,
+      decimalPlaces: 2,
+    },
+  ];
+}
+
+// 割り算が意味をなさない unit のパターン
+// - 比率・割合: %, ％, ‰
+// - すでに正規化済み: 人（人口10万対）
+// - 比倍: 倍
+// - 年齢・温度・期間（平均値）: 歳, ℃, 年, 日, 時間, 畳
+// - ‐ (指数・特殊): ‐
+// - すでに /unit 形式: kg/日, 台/12h, 円/m2, m3/日 etc.
+const EXCLUDED_UNITS = new Set([
+  "%",
+  "％",
+  "‰",
+  "人（人口10万対）",
+  "倍",
+  "歳",
+  "℃",
+  "年",
+  "日",
+  "時間",
+  "畳",
+  "‐",
+]);
+
+function isExcludedUnit(unit) {
+  if (!unit) return false;
+  if (EXCLUDED_UNITS.has(unit)) return true;
+  // /を含む単位（すでに正規化済み）
+  if (unit.includes("/")) return true;
+  return false;
+}
+
+function main() {
+  const db = new Database(DB_PATH, { readonly: isDryRun });
+
+  // 対象指標を取得
+  const rows = db
+    .prepare(
+      `SELECT key, title, unit, calculation_config_json
+       FROM metrics
+       WHERE is_active = 1`
+    )
+    .all();
+
+  let updated = 0;
+  let skippedCalculated = 0;
+  let skippedUnit = 0;
+  let skippedAlreadyHas = 0;
+
+  const updateStmt = isDryRun
+    ? null
+    : db.prepare(
+        "UPDATE metrics SET calculation_config_json = ? WHERE key = ?"
+      );
+
+  for (const row of rows) {
+    let config = {};
+    if (row.calculation_config_json) {
+      try {
+        config = JSON.parse(row.calculation_config_json);
+      } catch {
+        config = {};
+      }
+    }
+
+    // すでに isCalculated: true の指標は除外
+    if (config.isCalculated === true) {
+      skippedCalculated++;
+      continue;
+    }
+
+    // 意味をなさない unit は除外
+    if (isExcludedUnit(row.unit)) {
+      skippedUnit++;
+      if (isDryRun) {
+        console.log(`[SKIP unit] ${row.key} (unit="${row.unit}")`);
+      }
+      continue;
+    }
+
+    // すでに normalizationOptions を持つ場合も再生成（unit修正のため上書き）
+    // ただし denominatorKey がカスタム指定されている場合はスキップ（手動設定の優先）
+    if (
+      Array.isArray(config.normalizationOptions) &&
+      config.normalizationOptions.some((o) => o.denominatorKey)
+    ) {
+      skippedAlreadyHas++;
+      continue;
+    }
+
+    // normalizationOptions を追加（指標の unit を反映）
+    const newConfig = {
+      ...config,
+      normalizationOptions: buildNormalizationOptions(row.unit),
+    };
+
+    if (isDryRun) {
+      console.log(`[UPDATE] ${row.key} "${row.title}" (unit="${row.unit}")`);
+    } else {
+      updateStmt.run(JSON.stringify(newConfig), row.key);
+    }
+    updated++;
+  }
+
+  console.log("\n=== 結果 ===");
+  console.log(`対象合計: ${rows.length}`);
+  console.log(`更新${isDryRun ? "(予定)" : "済み"}: ${updated}`);
+  console.log(`スキップ(isCalculated:true): ${skippedCalculated}`);
+  console.log(`スキップ(unit除外): ${skippedUnit}`);
+  console.log(`スキップ(normalizationOptions既存): ${skippedAlreadyHas}`);
+
+  if (isDryRun) {
+    console.log("\n[DRY RUN] 実際の更新は行われていません。--dry-run を外して実行してください。");
+  } else {
+    console.log("\n完了。/sync-snapshots で R2 スナップショットを再生成してください。");
+  }
+}
+
+main();

--- a/apps/web/scripts/generate-known-ranking-keys.ts
+++ b/apps/web/scripts/generate-known-ranking-keys.ts
@@ -32,7 +32,7 @@ if (!fs.existsSync(D1_PATH)) {
 const db = new Database(D1_PATH, { readonly: true });
 const rows = db
   .prepare(
-    "SELECT DISTINCT key AS ranking_key FROM metrics WHERE is_active = 1 AND area_type = 'prefecture' ORDER BY key"
+    "SELECT DISTINCT m.key AS ranking_key FROM metrics m WHERE m.is_active = 1 AND EXISTS (SELECT 1 FROM stats_prefecture sp WHERE sp.metric_key = m.key) ORDER BY m.key"
   )
   .all() as { ranking_key: string }[];
 db.close();

--- a/apps/web/src/config/known-ranking-keys.ts
+++ b/apps/web/src/config/known-ranking-keys.ts
@@ -3,12 +3,15 @@
  *
  * **このファイルは自動生成されます。手動編集しないこと。**
  *
- * 更新方法:
- *   - 手動: `cd apps/web && npx tsx scripts/sync-known-keys-from-remote.ts`
- *   - 自動: GitHub Actions `.github/workflows/sync-known-keys.yml` (毎日 JST 07:00)
+ * middleware.ts の Fix 6 が参照する。CI ビルド環境では D1 binding が使えないため、
+ * 静的ファイルとして git commit する。page.tsx は触らない（SSG は従来どおり）。
  *
- * 最終生成日: 2026-04-26
- * 件数: 1920
+ * 更新方法: `/generate-known-ranking-keys` スキル or
+ *           `cd apps/web && npx tsx scripts/generate-known-ranking-keys.ts`
+ * 更新タイミング: /register-ranking 実行後。必ず git commit してからデプロイ。
+ *
+ * 最終生成日: 2026-05-08
+ * 件数: 1925
  */
 export const KNOWN_RANKING_KEYS: ReadonlySet<string> = new Set([
   "abandoned-cultivated-land-area",
@@ -767,8 +770,6 @@ export const KNOWN_RANKING_KEYS: ReadonlySet<string> = new Set([
   "independent-revenue-prefecture",
   "industrial-and-semi-industrial-area-ratio",
   "industrial-exclusive-area-ratio",
-  "industrial-land-price",
-  "industrial-land-price-change-rate",
   "industrial-water-usage",
   "infant-clothes-consumption-expenditure",
   "infant-clothes-consumption-quantity",
@@ -927,8 +928,6 @@ export const KNOWN_RANKING_KEYS: ReadonlySet<string> = new Set([
   "manufacturing-establishment-site-area",
   "manufacturing-establishments",
   "manufacturing-industry-added-value",
-  "manufacturing-net-value-added-private",
-  "manufacturing-sales-private",
   "manufacturing-shipment-amount",
   "manufacturing-shipment-amount-per-employee",
   "manufacturing-shipment-amount-per-establishment",
@@ -1076,6 +1075,7 @@ export const KNOWN_RANKING_KEYS: ReadonlySet<string> = new Set([
   "non-car-vehicle-insurance-consumption-expenditure",
   "non-car-vehicle-maintenance-consumption-expenditure",
   "non-car-vehicle-purchase-consumption-expenditure",
+  "non-regular-employment-rate",
   "notebooks-paper-consumption-expenditure",
   "nuclear-family-households-ratio",
   "nuclear-power-plant-count",
@@ -1461,7 +1461,13 @@ export const KNOWN_RANKING_KEYS: ReadonlySet<string> = new Set([
   "repair-materials-consumption-expenditure",
   "researcher-annual-income",
   "reserve-funds-prefecture",
+  "resident-foreigner-asia",
+  "resident-foreigner-china",
+  "resident-foreigner-europe",
+  "resident-foreigner-korea",
+  "resident-foreigner-north-america",
   "resident-foreigner-population",
+  "resident-foreigner-south-america",
   "residential-and-mixed-area-ratio",
   "residential-area-ratio",
   "residential-building-construction-cost",

--- a/apps/web/src/features/ranking/components/NormalizationToggle.tsx
+++ b/apps/web/src/features/ranking/components/NormalizationToggle.tsx
@@ -1,0 +1,42 @@
+"use client";
+
+import { ToggleGroup, ToggleGroupItem } from "@stats47/components/atoms/ui/toggle-group";
+import type { NormalizationOption } from "@stats47/ranking";
+
+interface NormalizationToggleProps {
+  options: NormalizationOption[];
+  value: string;
+  onChange: (value: string) => void;
+  disabled?: boolean;
+}
+
+export function NormalizationToggle({ options, value, onChange, disabled }: NormalizationToggleProps) {
+  return (
+    <ToggleGroup
+      type="single"
+      value={value}
+      onValueChange={(v) => {
+        if (v) onChange(v);
+      }}
+      className="bg-muted p-0.5 rounded-xs h-6"
+    >
+      <ToggleGroupItem
+        value="original"
+        disabled={disabled}
+        className="text-xs px-2 h-5 data-[state=on]:bg-background data-[state=on]:text-primary data-[state=on]:shadow-sm rounded-xs transition-all"
+      >
+        総数
+      </ToggleGroupItem>
+      {options.map((opt) => (
+        <ToggleGroupItem
+          key={opt.type}
+          value={opt.type}
+          disabled={disabled}
+          className="text-xs px-2 h-5 data-[state=on]:bg-background data-[state=on]:text-primary data-[state=on]:shadow-sm rounded-xs transition-all"
+        >
+          {opt.label}
+        </ToggleGroupItem>
+      ))}
+    </ToggleGroup>
+  );
+}

--- a/apps/web/src/features/ranking/components/NormalizationToggle.tsx
+++ b/apps/web/src/features/ranking/components/NormalizationToggle.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { ToggleGroup, ToggleGroupItem } from "@stats47/components/atoms/ui/toggle-group";
+
 import type { NormalizationOption } from "@stats47/ranking";
 
 interface NormalizationToggleProps {

--- a/apps/web/src/features/ranking/components/RankingKeyPage/RankingKeyPageClient.tsx
+++ b/apps/web/src/features/ranking/components/RankingKeyPage/RankingKeyPageClient.tsx
@@ -32,6 +32,7 @@ import {
     RankingYearSelector,
     AreaTypeToggle,
     DataDownloadIconButton,
+    NormalizationToggle,
 } from "@/features/ranking";
 
 import { trackRankingView, trackYearChange, trackAreaTypeChange } from "@/lib/analytics/events";
@@ -194,11 +195,16 @@ export function RankingKeyPageClient({
         });
     };
 
-    // ブックマーク・共有URL対応: ?year= / ?areaType= パラメータからデータ取得
+    // ブックマーク・共有URL対応: ?year= / ?areaType= / ?norm= パラメータからデータ取得
     useEffect(() => {
         const params = new URLSearchParams(window.location.search);
         const urlYear = params.get("year");
         const urlAreaType = params.get("areaType") as AreaType | null;
+        const urlNorm = params.get("norm") ?? undefined;
+
+        if (urlNorm) {
+            setNormalizationType(urlNorm);
+        }
 
         if (urlAreaType === "city" && cityRankingItem) {
             setCurrentAreaType("city");
@@ -207,12 +213,18 @@ export function RankingKeyPageClient({
             if (year !== selectedYear || urlAreaType !== areaType) {
                 setCurrentYear(year);
                 startTransition(async () => {
-                    const result = await fetchRankingValuesAction(rankingKey, "city", year, normalizationType, parentAreaCode);
+                    const result = await fetchRankingValuesAction(rankingKey, "city", year, urlNorm, parentAreaCode);
                     if (isOk(result)) setRankingValues(result.data);
                 });
             }
         } else if (urlYear && urlYear !== selectedYear) {
             handleYearChange(urlYear);
+        } else if (urlNorm) {
+            startTransition(async () => {
+                if (!currentYear) return;
+                const result = await fetchRankingValuesAction(rankingKey, currentAreaType, currentYear, urlNorm, parentAreaCode);
+                if (isOk(result)) setRankingValues(result.data);
+            });
         }
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, []);
@@ -270,10 +282,18 @@ export function RankingKeyPageClient({
         </div>
     );
 
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars -- kept for future normalization toggle feature
-    const _handleNormalizationChange = (value: string) => {
+    const handleNormalizationChange = (value: string) => {
         const nextType = value === "original" ? undefined : value;
         setNormalizationType(nextType);
+
+        const params = new URLSearchParams(window.location.search);
+        if (nextType) {
+            params.set("norm", nextType);
+        } else {
+            params.delete("norm");
+        }
+        const qs = params.toString();
+        window.history.replaceState(null, "", qs ? `${pathname}?${qs}` : pathname);
 
         startTransition(async () => {
             if (!currentYear) return;
@@ -300,7 +320,7 @@ export function RankingKeyPageClient({
                 })()}
             </h1>
 
-            {/* normalization_basis グループトグル */}
+            {/* normalization_basis グループトグル（別URL切替）*/}
             {groupMembers.length > 1 && (
                 <div className="flex items-center gap-0.5 mt-2 w-fit">
                     {[...groupMembers].sort((a, b) => (a.normalizationBasis ? 1 : 0) - (b.normalizationBasis ? 1 : 0)).map((member) => {
@@ -323,6 +343,18 @@ export function RankingKeyPageClient({
                             </Link>
                         );
                     })}
+                </div>
+            )}
+
+            {/* 正規化トグル（同一ページ内で per_population / per_area に切替） */}
+            {rankingItem.calculation?.normalizationOptions && rankingItem.calculation.normalizationOptions.length > 0 && (
+                <div className="mt-2">
+                    <NormalizationToggle
+                        options={rankingItem.calculation.normalizationOptions}
+                        value={normalizationType ?? "original"}
+                        onChange={handleNormalizationChange}
+                        disabled={isPending}
+                    />
                 </div>
             )}
 

--- a/apps/web/src/features/ranking/components/index.ts
+++ b/apps/web/src/features/ranking/components/index.ts
@@ -1,5 +1,6 @@
 export * from "./CorrelationSection";
 export * from "./FeaturedRankings";
+export * from "./NormalizationToggle";
 export * from "./RankingBarChartRace";
 export * from "./RankingBoxplotChart";
 export * from "./RankingDataTable";

--- a/apps/web/src/features/ranking/index.ts
+++ b/apps/web/src/features/ranking/index.ts
@@ -60,6 +60,7 @@ export * from "./utils";
 
 // Additional client components
 export { AreaTypeToggle } from "./components/AreaTypeToggle";
+export { NormalizationToggle } from "./components/NormalizationToggle";
 export { DataDownloadIconButton, DataDownloadFooterCard } from "./components/DataDownloadButton";
 
 // Skeleton components


### PR DESCRIPTION
## Summary

- **NormalizationToggle UI**: ランキングページに「総数 / 人口10万人あたり / 面積100km²あたり」切替トグルを追加。とどらんの人口・面積正規化ランキングへの対抗機能。
- **国際関係指標 6件**: 在留外国人数（アジア・中国・韓国・ヨーロッパ・北アメリカ・南アメリカ）を D1 に登録・2024年度データ投入済み。
- **generate-known-ranking-keys.ts バグ修正**: 旧スキーマの `area_type` カラム参照を `EXISTS (SELECT 1 FROM stats_prefecture ...)` に修正。

## Test plan

- [ ] `/ranking/resident-foreigner-china` → 2024年データ表示・Top1 東京
- [ ] `/ranking/average-temperature` → NormalizationToggle が表示される（単位: ℃ は除外対象のため表示しない）
- [ ] `/ranking/annual-precipitation` → NormalizationToggle「総数 / 人口10万人あたり / 面積100km²あたり」が表示される
- [ ] `?norm=per_population` URL パラメータを付けて遷移後、トグルが per_population 状態で初期化される
- [ ] 型チェック `npx tsc --noEmit -p apps/web/tsconfig.json` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)