### PR TITLE
feat: Instagram Reels カバー画像自動生成（黒サムネイル修正）

### DIFF
--- a/.claude/scripts/instagram/post-from-schedule.cjs
+++ b/.claude/scripts/instagram/post-from-schedule.cjs
@@ -68,19 +68,32 @@ function mediaUrlFor(type, domain, contentKey) {
   return `${PUBLIC_R2_BASE}/sns/${domain}/${contentKey}/instagram/stills/slide-1-cover-1080x1350.png`;
 }
 
-async function postReels({ contentKey, caption, videoUrl }) {
+async function postReels({ contentKey, caption, videoUrl, domain }) {
+  // カバー画像が R2 に存在するか確認（存在すれば cover_url で指定）
+  const coverUrl = `${PUBLIC_R2_BASE}/sns/${domain}/${contentKey}/instagram/stills/cover.png`;
+  let useCoverUrl = false;
+  try {
+    const headRes = await fetch(coverUrl, { method: "HEAD" });
+    useCoverUrl = headRes.ok;
+    console.log(`🖼️  cover_url: ${useCoverUrl ? coverUrl : "なし（先頭フレーム使用）"}`);
+  } catch {
+    // cover なしで続行
+  }
+
   console.log(`📦 reels container 作成...`);
+  const containerParams = {
+    media_type: "REELS",
+    video_url: videoUrl,
+    caption,
+    access_token: TOKEN,
+    ...(useCoverUrl && { cover_url: coverUrl }),
+  };
   const containerRes = await fetch(
     `https://graph.instagram.com/v21.0/${IG_USER_ID}/media`,
     {
       method: "POST",
       headers: { "Content-Type": "application/x-www-form-urlencoded" },
-      body: new URLSearchParams({
-        media_type: "REELS",
-        video_url: videoUrl,
-        caption,
-        access_token: TOKEN,
-      }),
+      body: new URLSearchParams(containerParams),
     },
   );
   const containerJson = await containerRes.json();
@@ -218,7 +231,7 @@ async function main() {
   console.log(`✅ media URL OK: ${mediaUrl}`);
 
   if (entry.type === "reels") {
-    await postReels({ contentKey: entry.content_key, caption, videoUrl: mediaUrl });
+    await postReels({ contentKey: entry.content_key, caption, videoUrl: mediaUrl, domain: entry.domain });
   } else {
     await postImage({ contentKey: entry.content_key, caption, imageUrl: mediaUrl });
   }

--- a/apps/remotion/scripts/pipeline/render-bar-chart-race.ts
+++ b/apps/remotion/scripts/pipeline/render-bar-chart-race.ts
@@ -24,6 +24,7 @@ import {
   renderMedia,
   selectComposition,
 } from "@remotion/renderer";
+import { execSync } from "child_process";
 import fs from "fs/promises";
 import path from "path";
 
@@ -319,6 +320,22 @@ async function main() {
           codec: "h264",
           puppeteerInstance: browser,
         });
+
+        // instagram reel のみ: 末尾 3 秒前のフレームをカバー画像として抽出
+        if (job.outputPath.includes("instagram/reel.mp4")) {
+          const coverDir = path.join(path.dirname(job.outputPath), "stills");
+          const coverPath = path.join(coverDir, "cover.png");
+          await fs.mkdir(coverDir, { recursive: true });
+          try {
+            execSync(
+              `ffmpeg -y -sseof -3 -i "${job.outputPath}" -vframes 1 -q:v 2 "${coverPath}"`,
+              { stdio: "pipe" }
+            );
+            console.log(`   🖼️  cover → stills/cover.png\n`);
+          } catch {
+            console.log(`   ⚠️  cover 生成スキップ (ffmpeg エラー)\n`);
+          }
+        }
 
         const elapsed = ((Date.now() - startTime) / 1000 / 60).toFixed(1);
         console.log(`   ✅ 完了 (経過: ${elapsed}min)\n`);


### PR DESCRIPTION
## Summary

- **問題**: bar-chart-race リールのサムネイルがイントロの黒画面になっていた
- **対応**: Instagram Graph API の `cover_url` パラメータで動画末尾 3 秒前のフレームを指定

## 変更内容

**`apps/remotion/scripts/pipeline/render-bar-chart-race.ts`**
- `instagram/reel.mp4` レンダリング完了後、ffmpeg で末尾 3 秒前のフレームを `instagram/stills/cover.png` として自動生成
- 次回以降のレンダリングから自動適用

**`.claude/scripts/instagram/post-from-schedule.cjs`**
- `postReels` に `cover_url` 対応を追加
- R2 公開 URL（`storage.stats47.jp/sns/.../instagram/stills/cover.png`）に HEAD リクエストで存在確認し、あれば `cover_url` を渡す

## 残作業（このPRとは別）

既存リール 7 本の `cover.png` をローカルで生成済み（`.local/r2/sns/bar-chart-race/*/instagram/stills/cover.png`）。`/push-r2` で R2 に push 後、次回リール投稿からサムネイルが反映される。

🤖 Generated with [Claude Code](https://claude.com/claude-code)