### PR TITLE
feat(instagram): W19スケジュール追加（05-21〜06-10）

### DIFF
--- a/.claude/scripts/instagram/post-from-schedule.cjs
+++ b/.claude/scripts/instagram/post-from-schedule.cjs
@@ -25,7 +25,7 @@ const TOKEN = process.env.INSTAGRAM_ACCESS_TOKEN;
 const IG_USER_ID = process.env.INSTAGRAM_BUSINESS_ACCOUNT_ID;
 const PUBLIC_R2_BASE = process.env.IG_PUBLIC_R2_BASE || "https://storage.stats47.jp";
 const SCHEDULE_FILE =
-  process.env.IG_SCHEDULE_FILE || ".claude/state/instagram-w18-schedule.json";
+  process.env.IG_SCHEDULE_FILE || ".claude/state/instagram-w19-schedule.json";
 const FORCE_DATE = process.env.IG_FORCE_DATE; // YYYY-MM-DD
 
 if (!TOKEN || !IG_USER_ID) {

--- a/.claude/state/instagram-w19-schedule.json
+++ b/.claude/state/instagram-w19-schedule.json
@@ -1,0 +1,23 @@
+[
+  {"date": "2026-05-21", "type": "image",  "domain": "ranking",        "content_key": "annual-precipitation-days"},
+  {"date": "2026-05-22", "type": "image",  "domain": "ranking",        "content_key": "per-capita-kenmin-shotoku-h27"},
+  {"date": "2026-05-23", "type": "image",  "domain": "ranking",        "content_key": "disposable-income-worker-households"},
+  {"date": "2026-05-24", "type": "image",  "domain": "ranking",        "content_key": "hobby-participation-rate-video-games"},
+  {"date": "2026-05-25", "type": "reels",  "domain": "bar-chart-race", "content_key": "total-population"},
+  {"date": "2026-05-26", "type": "image",  "domain": "ranking",        "content_key": "hobby-participation-rate-karaoke"},
+  {"date": "2026-05-27", "type": "image",  "domain": "ranking",        "content_key": "hobby-participation-rate-cooking"},
+  {"date": "2026-05-28", "type": "image",  "domain": "ranking",        "content_key": "hobby-participation-rate-cinema"},
+  {"date": "2026-05-29", "type": "image",  "domain": "ranking",        "content_key": "hobby-participation-rate-reading"},
+  {"date": "2026-05-30", "type": "image",  "domain": "ranking",        "content_key": "hobby-participation-rate-camping"},
+  {"date": "2026-05-31", "type": "image",  "domain": "ranking",        "content_key": "annual-sunshine-duration"},
+  {"date": "2026-06-01", "type": "reels",  "domain": "bar-chart-race", "content_key": "criminal-arrest-rate"},
+  {"date": "2026-06-02", "type": "image",  "domain": "ranking",        "content_key": "local-debt-current-ratio"},
+  {"date": "2026-06-03", "type": "image",  "domain": "ranking",        "content_key": "library-count-per-million"},
+  {"date": "2026-06-04", "type": "image",  "domain": "ranking",        "content_key": "hobby-participation-rate-diy"},
+  {"date": "2026-06-05", "type": "image",  "domain": "ranking",        "content_key": "junior-high-school-advancement-rate"},
+  {"date": "2026-06-06", "type": "image",  "domain": "ranking",        "content_key": "real-disposable-income"},
+  {"date": "2026-06-07", "type": "image",  "domain": "ranking",        "content_key": "night-soil-treatment-population-ratio"},
+  {"date": "2026-06-08", "type": "reels",  "domain": "bar-chart-race", "content_key": "welfare-expenditure-ratio-pref-finance"},
+  {"date": "2026-06-09", "type": "image",  "domain": "ranking",        "content_key": "hobby-participation-rate-gardening"},
+  {"date": "2026-06-10", "type": "image",  "domain": "ranking",        "content_key": "hobby-participation-rate-manga"}
+]

--- a/.github/workflows/post-instagram-scheduled.yml
+++ b/.github/workflows/post-instagram-scheduled.yml
@@ -2,7 +2,7 @@ name: 📸 Instagram scheduled post (daily)
 
 # Phase 9 後続 (2026-04-26): IG Graph API は scheduled_publish_time 非対応のため、
 # GitHub Actions cron で post-instagram (即時 API) を毎朝発火する形で予約投稿を代替。
-# 投稿対象は .claude/state/instagram-w18-schedule.json の today (JST) エントリのみ、
+# 投稿対象は .claude/state/instagram-w19-schedule.json の today (JST) エントリのみ、
 # 該当なしなら exit 0 で何もしない。
 # 投稿成功時は #127 (W18 Plan) に結果コメント投稿。
 


### PR DESCRIPTION
## Summary

- `.claude/state/instagram-w19-schedule.json` 追加（2026-05-21〜06-10、21エントリ）
- 18 ランキング画像 + 週1リール（3本）の構成
- 不良データ2件を代替: `gini-coefficient-disposable-income`→`annual-sunshine-duration`、`manufacturing-shipment-amount`→`hobby-participation-rate-diy`
- `post-from-schedule.cjs` のデフォルトスケジュールファイルを w18→w19 に更新

## スケジュール詳細

| 週 | 投稿数 | テーマ |
|---|---|---|
| W1 05-21〜05-27 | 6画像+1リール | 気候・生活水準、人口推移リール |
| W2 05-28〜06-03 | 6画像+1リール | 趣味・レジャー、検挙率リール |
| W3 06-04〜06-10 | 6画像+1リール | 趣味・行財政、民生費リール |

## R2 アップロード済み

- 18キー × 3スライド (54 PNG) → `sns/ranking/<key>/instagram/stills/`
- bar-chart-race 3本リール + cover → `sns/bar-chart-race/<key>/instagram/`
- caption.txt、data.json、ranking_items.json も全キー分

## Test plan

- [ ] `workflow_dispatch` で `force_date=2026-05-21` を指定してテスト投稿確認
- [ ] `force_date=2026-05-25` でリール投稿確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)