### PR TITLE
fix: EXP-004 ロールバック — ranking pages 500 緊急修正

### DIFF
--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -26,8 +26,6 @@
 
 import { Suspense } from "react";
 
-import { cookies } from "next/headers";
-
 import NextTopLoader from "nextjs-toploader";
 import { Toaster } from "sonner";
 
@@ -62,16 +60,12 @@ export const metadata = generateRootMetadata();
  * @param children - レイアウト内に表示するコンテンツ（各ページのコンポーネント）
  * @returns ルートレイアウトのJSX要素
  */
-const CONSENT_COOKIE_NAME = "stats47_consent";
-
-export default async function RootLayout({
+export default function RootLayout({
   children,
 }: Readonly<{
   children: React.ReactNode;
 }>) {
   const baseUrl = getRequiredBaseUrl();
-  const cookieStore = await cookies();
-  const serverConsent = (cookieStore.get(CONSENT_COOKIE_NAME)?.value ?? null) as "granted" | "denied" | null;
 
   return (
     <html
@@ -153,8 +147,8 @@ export default async function RootLayout({
           </div>
           {/* トースト通知（成功、エラー、警告などの通知を表示） */}
           <Toaster position="top-right" richColors />
-          {/* Cookie 同意バナー（SSR 対応: consent cookie を server で確認） */}
-          <CookieConsentBanner serverConsent={serverConsent} />
+          {/* Cookie 同意バナー */}
+          <CookieConsentBanner />
         </ThemeProvider>
       </body>
     </html>

--- a/apps/web/src/lib/analytics/components/CookieConsentBanner.tsx
+++ b/apps/web/src/lib/analytics/components/CookieConsentBanner.tsx
@@ -24,8 +24,8 @@ export function CookieConsentBanner() {
   useEffect(() => {
     const stored = localStorage.getItem(CONSENT_LS_KEY);
     if (!stored) {
-      setVisible(true);
-      return;
+      const timer = setTimeout(() => setVisible(true), 0);
+      return () => clearTimeout(timer);
     }
 
     // gtag consent 同期

--- a/apps/web/src/lib/analytics/components/CookieConsentBanner.tsx
+++ b/apps/web/src/lib/analytics/components/CookieConsentBanner.tsx
@@ -12,47 +12,36 @@ function setConsentCookie(value: string) {
   document.cookie = `${CONSENT_COOKIE_NAME}=${value}; path=/; max-age=${COOKIE_MAX_AGE}; SameSite=Lax`;
 }
 
-interface Props {
-  /** サーバーサイドで読み取った consent 状態。null = 未設定（新規ユーザー） */
-  serverConsent: "granted" | "denied" | null;
-}
-
 /**
- * Cookie 同意バナー（SSR 対応版）
+ * Cookie 同意バナー（クライアントサイド）
  *
- * serverConsent が null（新規ユーザー）の場合は SSR 時点からバナーを表示し、
- * LCP element がバナー出現で遅延しないようにする（EXP-004）。
- * 既存ユーザーは localStorage → cookie マイグレーションを初回ロード時に実行。
+ * localStorage に consent が保存済みの場合は非表示。
+ * 未設定の新規ユーザーにのみバナーを表示する。
  */
-export function CookieConsentBanner({ serverConsent }: Props) {
-  const [visible, setVisible] = useState(serverConsent === null);
+export function CookieConsentBanner() {
+  const [visible, setVisible] = useState(false);
 
   useEffect(() => {
     const stored = localStorage.getItem(CONSENT_LS_KEY);
-    const effective = serverConsent ?? stored;
+    if (!stored) {
+      setVisible(true);
+      return;
+    }
 
     // gtag consent 同期
-    if (effective === "granted") {
+    if (stored === "granted") {
       window.gtag?.("consent", "update", {
         ad_storage: "granted",
         // eslint-disable-next-line @typescript-eslint/no-explicit-any -- gtag consent API types not available
       } as any);
-    } else if (effective === "denied") {
+    } else if (stored === "denied") {
       window.gtag?.("consent", "update", {
         analytics_storage: "denied",
         ad_storage: "denied",
         // eslint-disable-next-line @typescript-eslint/no-explicit-any -- gtag consent API types not available
       } as any);
     }
-
-    // 後方互換マイグレーション: localStorage に consent があるが cookie が未設定の場合
-    // （既存ユーザーの初回ロード時に一度だけ実行）
-    if (!serverConsent && stored) {
-      setConsentCookie(stored);
-      const timer = setTimeout(() => setVisible(false), 0);
-      return () => clearTimeout(timer);
-    }
-  }, [serverConsent]);
+  }, []);
 
   const handleAccept = () => {
     setConsentCookie("granted");


### PR DESCRIPTION
## 問題

PR #252 (EXP-004) で `layout.tsx` を `async` 化し `cookies()` を呼んだ結果、
`/ranking/*` 全ページが 500 Internal Server Error になった（smoke test で確認済み）。

## 根本原因

`cookies()` は Next.js の Dynamic API。root layout で使うと **全 route segment が動的レンダリング強制** になる。
`/ranking/[rankingKey]` は `generateStaticParams` で SSG しているが、
layout が dynamic になったことで Cloudflare Workers/OpenNext 上でのレンダリングが崩れた。

## 修正内容

- `layout.tsx`: `async` 除去・`cookies()` import 削除・`serverConsent` 渡し削除
- `CookieConsentBanner`: `serverConsent` prop 除去、`useEffect` で `localStorage` 参照に戻す（EXP-003 以前の実装）

## 影響

- EXP-004 の LCP 改善効果は失われる（別手段で再実装予定）
- ranking ページの 500 は本 PR マージ + デプロイで解消される

## Test plan

- [ ] デプロイ後 smoke test `✅ ランキング詳細（総人口）` が 200 になること
- [ ] `curl -s -o /dev/null -w "%{http_code}" https://stats47.jp/ranking/total-population` → 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)