### PR TITLE
feat(ads): ランキング詳細ページ 右サイドバー カテゴリcard直下に広告追加

### DIFF
--- a/apps/web/src/app/ranking/[rankingKey]/page.tsx
+++ b/apps/web/src/app/ranking/[rankingKey]/page.tsx
@@ -76,6 +76,7 @@ import {
   cachedFindRankingItem,
 } from "@/features/ranking/server";
 
+import { AdSenseAd, RANKING_SIDEBAR_TOP } from "@/lib/google-adsense";
 import { logger } from "@/lib/logger";
 
 import type { RankingValue } from "@stats47/ranking";
@@ -290,6 +291,7 @@ export default async function RankingKeyPage({
         sidebarSection={
           <Suspense fallback={<div className="space-y-4 animate-pulse"><div className="h-64 bg-muted rounded-lg" /><div className="h-32 bg-muted rounded-lg" /></div>}>
             <RankingItemsSidebar rankingKey={rankingKey} areaType={areaType} categoryKey={rankingItem.categoryKey} />
+            <AdSenseAd format={RANKING_SIDEBAR_TOP.format} slotId={RANKING_SIDEBAR_TOP.slotId} />
             <RelatedArticlesCard rankingKey={rankingKey} areaType={areaType} />
             <SurveyCard surveys={allSurveys.map((s: { id: string; name: string }) => ({ id: s.id, name: s.name }))} currentSurveyId={rankingItem.surveyId ?? undefined} />
             <PortStatisticsMapCard rankingKey={rankingKey} groupKey={rankingItem.groupKey} />


### PR DESCRIPTION
## Summary

- ランキング詳細ページ（`/ranking/[rankingKey]`）の右サイドバーに広告枠を追加
- 配置: `RankingItemsSidebar`（同カテゴリランキング一覧）の直下
- スロット: `RANKING_SIDEBAR_TOP`（rectangle、既存スロット）
- PC の右サイドバー + モバイルのページ下部に両対応（`sidebarSection` の構造を活用）

todo-ran.com との比較で「サイドバー広告が少ない」点の改善。

## Test plan

- [ ] tsc OK
- [ ] ESLint OK
- [ ] `/ranking/total-population` を PC 幅で開いて右サイドバーのカテゴリcard直下に広告枠が表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)