### PR TITLE
feat(ranking): xl以上で地図+テーブルを2列グリッド表示

### DIFF
--- a/apps/web/src/features/ranking/components/RankingKeyPage/RankingKeyPageClient.tsx
+++ b/apps/web/src/features/ranking/components/RankingKeyPage/RankingKeyPageClient.tsx
@@ -104,6 +104,7 @@ export function RankingKeyPageClient({
     const [isPending, startTransition] = useTransition();
     const pathname = usePathname();
     const isBelowLg = useBreakpoint("belowLg");
+    const isAboveXl = useBreakpoint("aboveXl");
 
     // ランキングページ閲覧イベント
     useEffect(() => {
@@ -395,8 +396,8 @@ export function RankingKeyPageClient({
                             </TabsContent>
                         </Tabs>
                     ) : (
-                        /* デスクトップ: 縦並び（地図→テーブル） */
-                        <div className="flex flex-col gap-4 relative">
+                        /* デスクトップ: xl以上は地図+テーブル2列、lg〜xl未満は縦並び */
+                        <div className={`relative ${isAboveXl ? "grid grid-cols-2 gap-4 items-start" : "flex flex-col gap-4"}`}>
                             {isPending && (
                                 <div className="absolute inset-0 z-10 bg-background/50 flex items-center justify-center backdrop-blur-[1px]">
                                     <Skeleton className="w-full h-full opacity-50" />


### PR DESCRIPTION
## Summary
- 1280px（xl）以上の画面幅でランキング詳細ページの地図とデータテーブルを横並び2列グリッドに変更

## 変更点
- `RankingKeyPageClient.tsx`: `isAboveXl` ブレイクポイント追加、xl+ で `grid grid-cols-2 gap-4 items-start`、lg〜xl未満は従来の `flex flex-col gap-4`

## 検証
- [x] tsc --noEmit pass
- [x] eslint pass
- [x] D1 sync OK（変更なし）
- [x] R2 sync OK（.local/r2/ に 24h 以内の未 push ファイルなし）

🤖 Generated with [Claude Code](https://claude.com/claude-code)