### PR TITLE
feat(sns-metrics): Instagram + YouTube 週次自動収集 (X 廃止)

### DIFF
--- a/.claude/scripts/instagram/fetch-metrics-ci.cjs
+++ b/.claude/scripts/instagram/fetch-metrics-ci.cjs
@@ -1,0 +1,98 @@
+#!/usr/bin/env node
+/**
+ * Instagram メトリクス取得（CI 用）
+ *
+ * GitHub Actions から実行する。INSTAGRAM_ACCESS_TOKEN / INSTAGRAM_BUSINESS_ACCOUNT_ID
+ * を env から読み込み、全投稿のメトリクスを取得して SNS metrics CSV に記録する。
+ * D1 DB への書き込みは行わない（sns_post_id = "" でも CSV に記録可能）。
+ *
+ * 使い方:
+ *   INSTAGRAM_ACCESS_TOKEN=xxx INSTAGRAM_BUSINESS_ACCOUNT_ID=yyy node fetch-metrics-ci.cjs
+ */
+
+const fs = require("fs");
+const path = require("path");
+
+const PROJECT_ROOT = path.resolve(__dirname, "..", "..", "..");
+const store = require(path.join(PROJECT_ROOT, ".claude/scripts/lib/sns-metrics-store.cjs"));
+
+const TOKEN = process.env.INSTAGRAM_ACCESS_TOKEN;
+const IG_USER_ID = process.env.INSTAGRAM_BUSINESS_ACCOUNT_ID;
+
+if (!TOKEN || !IG_USER_ID) {
+  console.error("Error: INSTAGRAM_ACCESS_TOKEN / INSTAGRAM_BUSINESS_ACCOUNT_ID が未設定");
+  process.exit(1);
+}
+
+const BASE_URL = "https://graph.instagram.com/v21.0";
+const FETCHED_AT = new Date().toISOString();
+
+async function fetchJson(url) {
+  const res = await fetch(url);
+  const data = await res.json();
+  if (data.error) throw new Error(`Graph API: ${data.error.message} (code=${data.error.code})`);
+  return data;
+}
+
+async function fetchAllMedia() {
+  const all = [];
+  let url = `${BASE_URL}/${IG_USER_ID}/media?fields=id,caption,permalink,timestamp,like_count,comments_count&limit=100&access_token=${TOKEN}`;
+  while (url) {
+    const data = await fetchJson(url);
+    all.push(...(data.data || []));
+    url = data.paging?.next || null;
+    if (url) await new Promise((r) => setTimeout(r, 500));
+  }
+  return all;
+}
+
+async function fetchInsights(mediaId) {
+  try {
+    const data = await fetchJson(
+      `${BASE_URL}/${mediaId}/insights?metric=reach,saved,shares,views&access_token=${TOKEN}`,
+    );
+    const result = {};
+    for (const item of data.data || []) {
+      result[item.name] = item.values?.[0]?.value ?? item.value ?? 0;
+    }
+    return result;
+  } catch {
+    return {};
+  }
+}
+
+async function main() {
+  console.log("Instagram メトリクス取得開始...");
+  const media = await fetchAllMedia();
+  console.log(`取得: ${media.length} 件`);
+
+  let saved = 0;
+  for (const m of media) {
+    const insights = await fetchInsights(m.id);
+    store.upsertMetric({
+      sns_post_id: "",
+      platform: "instagram",
+      domain: "ranking",
+      content_key: m.id, // media_id をプロキシとして使用
+      fetched_at: FETCHED_AT,
+      impressions: "",
+      reach: insights.reach || "",
+      views: insights.views || "",
+      likes: m.like_count || 0,
+      comments: m.comments_count || 0,
+      shares: insights.shares || "",
+      saves: insights.saved || "",
+      quotes: "",
+    });
+    saved++;
+    if (saved % 10 === 0) console.log(`  ${saved}/${media.length} 件処理済み`);
+    await new Promise((r) => setTimeout(r, 200));
+  }
+
+  console.log(`✅ Instagram メトリクス記録完了: ${saved} 件`);
+}
+
+main().catch((e) => {
+  console.error("❌ Error:", e.message);
+  process.exit(1);
+});

--- a/.claude/scripts/lib/sns-metrics-store.cjs
+++ b/.claude/scripts/lib/sns-metrics-store.cjs
@@ -111,17 +111,23 @@ function writeCsv(file, rows) {
 }
 
 /**
- * 1 件のメトリクスを UPSERT する。キーは (sns_post_id, fetched_at)。
+ * 1 件のメトリクスを UPSERT する。
+ * sns_post_id がある場合は (sns_post_id, fetched_at) をキーに、
+ * ない場合は (platform, content_key, fetched_at) をキーにする（CI 用フォールバック）。
  */
 function upsertMetric(metric) {
-  if (metric.sns_post_id == null) throw new Error("sns_post_id is required");
   if (!metric.fetched_at) throw new Error("fetched_at is required");
   const file = csvPathFor(metric.fetched_at);
   const rows = readCsv(file);
-  const key = `${metric.sns_post_id}|${metric.fetched_at}`;
-  const filtered = rows.filter(
-    (r) => `${r.sns_post_id}|${r.fetched_at}` !== key,
-  );
+  const key = metric.sns_post_id != null
+    ? `${metric.sns_post_id}|${metric.fetched_at}`
+    : `${metric.platform}|${metric.content_key}|${metric.fetched_at}`;
+  const filtered = rows.filter((r) => {
+    const rKey = r.sns_post_id
+      ? `${r.sns_post_id}|${r.fetched_at}`
+      : `${r.platform}|${r.content_key}|${r.fetched_at}`;
+    return rKey !== key;
+  });
   const normalized = {};
   for (const c of COLUMNS) normalized[c] = metric[c] ?? "";
   filtered.push(normalized);

--- a/.claude/scripts/youtube/fetch-metrics-ci.cjs
+++ b/.claude/scripts/youtube/fetch-metrics-ci.cjs
@@ -1,0 +1,101 @@
+#!/usr/bin/env node
+/**
+ * YouTube メトリクス取得（CI 用）
+ *
+ * GitHub Actions から実行する。.env.local（GOOGLE_OAUTH_CLIENT_ID/SECRET/REFRESH_TOKEN）
+ * を読み込み、チャンネル全動画のメトリクスを取得して SNS metrics CSV に記録する。
+ * D1 DB への書き込みは行わない（sns_post_id = "" でも CSV に記録可能）。
+ */
+
+const fs = require("fs");
+const path = require("path");
+
+const PROJECT_ROOT = path.resolve(__dirname, "..", "..", "..");
+const store = require(path.join(PROJECT_ROOT, ".claude/scripts/lib/sns-metrics-store.cjs"));
+const { google } = require(path.join(PROJECT_ROOT, "node_modules/googleapis"));
+
+// .env.local から OAuth 認証情報を読み込む
+const envPath = path.join(PROJECT_ROOT, ".env.local");
+const envVars = {};
+if (fs.existsSync(envPath)) {
+  for (const line of fs.readFileSync(envPath, "utf-8").split("\n")) {
+    const m = line.match(/^([A-Z_]+)=(.+)$/);
+    if (m) envVars[m[1]] = m[2].trim();
+  }
+}
+
+const CLIENT_ID = envVars.GOOGLE_OAUTH_CLIENT_ID || process.env.GOOGLE_OAUTH_CLIENT_ID;
+const CLIENT_SECRET = envVars.GOOGLE_OAUTH_CLIENT_SECRET || process.env.GOOGLE_OAUTH_CLIENT_SECRET;
+const REFRESH_TOKEN = envVars.GOOGLE_OAUTH_REFRESH_TOKEN || process.env.GOOGLE_OAUTH_REFRESH_TOKEN;
+const CHANNEL_ID = "UCdRiwDSX1aUd0dSd7Cs08Kg";
+
+if (!CLIENT_ID || !CLIENT_SECRET || !REFRESH_TOKEN) {
+  console.error("Error: GOOGLE_OAUTH_CLIENT_ID / CLIENT_SECRET / REFRESH_TOKEN が未設定");
+  process.exit(1);
+}
+
+const FETCHED_AT = new Date().toISOString();
+
+async function main() {
+  console.log("YouTube メトリクス取得開始...");
+
+  const oauth2Client = new google.auth.OAuth2(CLIENT_ID, CLIENT_SECRET);
+  oauth2Client.setCredentials({ refresh_token: REFRESH_TOKEN });
+  const youtube = google.youtube({ version: "v3", auth: oauth2Client });
+
+  // uploads プレイリスト ID を取得
+  const ch = await youtube.channels.list({ id: [CHANNEL_ID], part: ["contentDetails"] });
+  const uploadsId = ch.data.items[0].contentDetails.relatedPlaylists.uploads;
+
+  // 全動画 ID を収集
+  const allVideoIds = [];
+  let nextPageToken;
+  do {
+    const pl = await youtube.playlistItems.list({
+      playlistId: uploadsId,
+      part: ["contentDetails"],
+      maxResults: 50,
+      pageToken: nextPageToken,
+    });
+    allVideoIds.push(...pl.data.items.map((i) => i.contentDetails.videoId));
+    nextPageToken = pl.data.nextPageToken;
+  } while (nextPageToken);
+  console.log(`動画数: ${allVideoIds.length} 件`);
+
+  // 50件ずつ statistics を取得
+  let saved = 0;
+  for (let i = 0; i < allVideoIds.length; i += 50) {
+    const chunk = allVideoIds.slice(i, i + 50);
+    const res = await youtube.videos.list({
+      id: chunk,
+      part: ["statistics"],
+    });
+    for (const v of res.data.items || []) {
+      const s = v.statistics || {};
+      store.upsertMetric({
+        sns_post_id: "",
+        platform: "youtube",
+        domain: "ranking",
+        content_key: v.id, // video_id をプロキシとして使用
+        fetched_at: FETCHED_AT,
+        impressions: "",
+        reach: "",
+        views: s.viewCount || 0,
+        likes: s.likeCount || 0,
+        comments: s.commentCount || 0,
+        shares: "",
+        saves: "",
+        quotes: "",
+      });
+      saved++;
+    }
+    console.log(`  ${Math.min(i + 50, allVideoIds.length)}/${allVideoIds.length} 件処理済み`);
+  }
+
+  console.log(`✅ YouTube メトリクス記録完了: ${saved} 件`);
+}
+
+main().catch((e) => {
+  console.error("❌ Error:", e.message);
+  process.exit(1);
+});

--- a/.github/workflows/sns-metrics-weekly.yml
+++ b/.github/workflows/sns-metrics-weekly.yml
@@ -1,0 +1,99 @@
+name: 📊 SNS Metrics Weekly (Instagram + YouTube)
+
+# X は API 従量課金のため収集対象外。Instagram (Graph API) + YouTube (Data API v3) のみ。
+# 毎週日曜 JST 20:30 に実行（fetch-metrics-weekly の 30 分後）。
+
+on:
+  schedule:
+    - cron: "30 11 * * 0" # JST 20:30 Sunday (UTC 11:30)
+  workflow_dispatch:
+    inputs:
+      platform:
+        description: "対象プラットフォーム (instagram / youtube / all)"
+        required: false
+        default: "all"
+
+permissions:
+  contents: write
+
+concurrency:
+  group: sns-metrics-weekly
+  cancel-in-progress: false
+
+jobs:
+  fetch:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: 🧰 Checkout main
+        uses: actions/checkout@v4
+        with:
+          ref: main
+          fetch-depth: 1
+
+      - name: 🟢 Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "npm"
+
+      - name: 📦 Install dependencies
+        run: npm ci
+
+      - name: 🔑 Compose .env.local (YouTube OAuth)
+        run: |
+          cat > .env.local <<EOF
+          GOOGLE_OAUTH_CLIENT_ID=${{ secrets.GOOGLE_OAUTH_CLIENT_ID }}
+          GOOGLE_OAUTH_CLIENT_SECRET=${{ secrets.GOOGLE_OAUTH_CLIENT_SECRET }}
+          GOOGLE_OAUTH_REFRESH_TOKEN=${{ secrets.GOOGLE_OAUTH_REFRESH_TOKEN }}
+          EOF
+
+      - name: 📸 Instagram metrics
+        if: inputs.platform == '' || inputs.platform == 'all' || inputs.platform == 'instagram'
+        env:
+          INSTAGRAM_ACCESS_TOKEN: ${{ secrets.INSTAGRAM_ACCESS_TOKEN }}
+          INSTAGRAM_BUSINESS_ACCOUNT_ID: ${{ secrets.INSTAGRAM_BUSINESS_ACCOUNT_ID }}
+        run: node .claude/scripts/instagram/fetch-metrics-ci.cjs
+
+      - name: 📺 YouTube metrics
+        if: inputs.platform == '' || inputs.platform == 'all' || inputs.platform == 'youtube'
+        run: node .claude/scripts/youtube/fetch-metrics-ci.cjs
+
+      - name: 📤 Commit snapshot to develop
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          git fetch origin develop
+          git checkout develop
+          git pull --rebase origin develop
+
+          SNAPSHOT_DIR=".claude/skills/analytics/sns-metrics-improvement/snapshots"
+          git add "$SNAPSHOT_DIR"
+
+          if git diff --cached --quiet; then
+            echo "変更なし、コミットをスキップ"
+            exit 0
+          fi
+
+          DATE=$(date -u +%Y-%m-%d)
+          git commit -m "chore(sns-metrics): weekly snapshot ${DATE} (instagram + youtube) [skip ci]"
+          git push origin develop
+
+      - name: 📄 Step Summary
+        if: always()
+        run: |
+          DATE=$(date -u +%Y-%m-%d)
+          SNAPSHOT=".claude/skills/analytics/sns-metrics-improvement/snapshots/${DATE}/metrics.csv"
+          echo "# SNS Metrics Weekly — ${DATE}" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          if [ -f "$SNAPSHOT" ]; then
+            COUNT=$(wc -l < "$SNAPSHOT")
+            echo "- 記録件数: $((COUNT - 1)) 行" >> $GITHUB_STEP_SUMMARY
+            echo "" >> $GITHUB_STEP_SUMMARY
+            echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
+            head -6 "$SNAPSHOT" >> $GITHUB_STEP_SUMMARY
+            echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
+          else
+            echo "スナップショットファイルが見つかりません" >> $GITHUB_STEP_SUMMARY
+          fi


### PR DESCRIPTION
## Summary
- X metrics 収集を廃止（API 従量課金 + browser-use の収集率 ~2% で改善不能）
- Instagram Graph API + YouTube Data API v3 を GitHub Actions で週次自動実行

## 変更点
- `.github/workflows/sns-metrics-weekly.yml` — 毎週日曜 JST 20:30、Instagram + YouTube を取得して develop に commit
- `.claude/scripts/instagram/fetch-metrics-ci.cjs` — Graph API で全 media メトリクス取得（DB 不要）
- `.claude/scripts/youtube/fetch-metrics-ci.cjs` — OAuth + Data API v3 で全動画 statistics 取得
- `.claude/scripts/lib/sns-metrics-store.cjs` — `sns_post_id` なし CI 用に UPSERT キーを拡張

## 検証
- [x] tsc --noEmit pass（.claude スクリプトは対象外）
- [x] R2 sync OK
- [x] workflow_dispatch で手動テスト可能

🤖 Generated with [Claude Code](https://claude.com/claude-code)