### PR TITLE
fix(blog): ブログ画像URL を /blog/ → /app/blog/ に修正

### DIFF
--- a/apps/web/src/app/blog/[slug]/page.tsx
+++ b/apps/web/src/app/blog/[slug]/page.tsx
@@ -65,7 +65,7 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
     const title = article.frontmatter.seoTitle ?? article.title;
     const description = article.frontmatter.description ?? `${article.title} | stats47 ブログ`;
     const R2_PUBLIC_URL = process.env.NEXT_PUBLIC_R2_PUBLIC_URL || "https://storage.stats47.jp";
-    const imageUrl = `${R2_PUBLIC_URL}/blog/${slug}/ogp/ogp.png`;
+    const imageUrl = `${R2_PUBLIC_URL}/app/blog/${slug}/ogp/ogp.png`;
 
     return {
         title,
@@ -155,7 +155,7 @@ export default async function BlogPostPage({ params }: PageProps) {
         "@type": "Article",
         headline: article.title,
         description: article.frontmatter.description ?? "",
-        image: `${R2_PUBLIC_URL}/blog/${slug}/ogp/ogp.png`,
+        image: `${R2_PUBLIC_URL}/app/blog/${slug}/ogp/ogp.png`,
         url: `${baseUrl}/blog/${slug}`,
         datePublished: article.publishedAt ?? undefined,
         dateModified: article.updatedAt ?? article.publishedAt ?? undefined,

--- a/apps/web/src/app/category/[categoryKey]/page.tsx
+++ b/apps/web/src/app/category/[categoryKey]/page.tsx
@@ -214,8 +214,8 @@ export default async function CategoryPage({ params }: PageProps) {
                     >
                       <div className="relative aspect-[1200/630] w-full bg-muted">
                         <ThemeAwareImage
-                          lightSrc={`${r2Url}/blog/${article.slug}/thumbnail-light.webp`}
-                          darkSrc={`${r2Url}/blog/${article.slug}/thumbnail-dark.webp`}
+                          lightSrc={`${r2Url}/app/blog/${article.slug}/thumbnail-light.webp`}
+                          darkSrc={`${r2Url}/app/blog/${article.slug}/thumbnail-dark.webp`}
                           alt={article.title}
                           fill
                           sizes="256px"

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -188,8 +188,8 @@ export default async function HomePage() {
                     >
                       <div className="relative aspect-[1200/630] w-full bg-muted overflow-hidden">
                         <ThemeAwareImage
-                          lightSrc={`${r2}/blog/${article.slug}/thumbnail-light.webp`}
-                          darkSrc={`${r2}/blog/${article.slug}/thumbnail-dark.webp`}
+                          lightSrc={`${r2}/app/blog/${article.slug}/thumbnail-light.webp`}
+                          darkSrc={`${r2}/app/blog/${article.slug}/thumbnail-dark.webp`}
                           alt={article.title}
                           fill
                           sizes="(max-width: 768px) 50vw, 25vw"

--- a/apps/web/src/features/blog/components/blog-article-grid.tsx
+++ b/apps/web/src/features/blog/components/blog-article-grid.tsx
@@ -30,8 +30,8 @@ export function BlogArticleGrid({ articles }: BlogArticleGridProps) {
                 >
                     <div className="relative aspect-[1200/630] w-full bg-muted">
                         <ThemeAwareImage
-                            lightSrc={`${R2_PUBLIC_URL}/blog/${article.slug}/thumbnail-light.webp`}
-                            darkSrc={`${R2_PUBLIC_URL}/blog/${article.slug}/thumbnail-dark.webp`}
+                            lightSrc={`${R2_PUBLIC_URL}/app/blog/${article.slug}/thumbnail-light.webp`}
+                            darkSrc={`${R2_PUBLIC_URL}/app/blog/${article.slug}/thumbnail-dark.webp`}
                             alt={article.title}
                             fill
                             sizes="(max-width: 768px) 100vw, (max-width: 1024px) 50vw, 33vw"

--- a/apps/web/src/features/blog/components/md-content.tsx
+++ b/apps/web/src/features/blog/components/md-content.tsx
@@ -77,7 +77,7 @@ function makeMdComponents(slug?: string): Record<string, React.ComponentType<Com
             const altText = typeof alt === "string" ? alt : "";
             const resolvedSrc =
                 slug && !src.startsWith("http") && !src.startsWith("/")
-                    ? `https://storage.stats47.jp/blog/${slug}/${src}`
+                    ? `https://storage.stats47.jp/app/blog/${slug}/${src}`
                     : src;
             // SVG はファイル名で判定してアスペクト比予約 (CLS 対策)。
             // 2026-04 Web Analytics で spending-ranking.svg が LCP 5,496ms、CLS 原因の 1 つ。


### PR DESCRIPTION
## Summary
- `/blog` 一覧・`/blog/[slug]` 記事ページ・トップページ・カテゴリページでブログ画像が表示されない不具合を修正

## 根本原因
R2 ストレージ移行（`blog/[slug]/...` → `app/blog/[slug]/...`）は完了済みだったが、コード側の URL 構築が旧パス `/blog/` のまま残っていたため全画像が 404 になっていた。

## 変更点
- `src/features/blog/components/blog-article-grid.tsx`: thumbnail URL を `app/blog/` に修正
- `src/features/blog/components/md-content.tsx`: 記事内インライン画像 URL を `app/blog/` に修正
- `src/app/blog/[slug]/page.tsx`: OGP 画像 URL を `app/blog/` に修正（2箇所）
- `src/app/page.tsx`: トップページのブログカード thumbnail URL を `app/blog/` に修正
- `src/app/category/[categoryKey]/page.tsx`: カテゴリページのブログカード thumbnail URL を `app/blog/` に修正

## 検証
- [x] tsc --noEmit pass
- [x] eslint pass
- [x] D1 sync OK（変更なし）
- [x] R2 sync OK（.local/r2/ に 24h 以内の未 push ファイルなし）

🤖 Generated with [Claude Code](https://claude.com/claude-code)