### PR TITLE
fix(blog): add overflow-hidden to image containers to prevent hover scroll

### DIFF
--- a/apps/web/src/app/category/[categoryKey]/page.tsx
+++ b/apps/web/src/app/category/[categoryKey]/page.tsx
@@ -212,7 +212,7 @@ export default async function CategoryPage({ params }: PageProps) {
                       href={`/blog/${article.slug}`}
                       className="group block rounded-sm border border-border overflow-hidden hover:border-primary/50 transition-colors"
                     >
-                      <div className="relative aspect-[1200/630] w-full bg-muted">
+                      <div className="relative aspect-[1200/630] w-full bg-muted overflow-hidden">
                         <ThemeAwareImage
                           lightSrc={`${r2Url}/app/blog/${article.slug}/thumbnail-light.webp`}
                           darkSrc={`${r2Url}/app/blog/${article.slug}/thumbnail-dark.webp`}

--- a/apps/web/src/features/blog/components/blog-article-grid.tsx
+++ b/apps/web/src/features/blog/components/blog-article-grid.tsx
@@ -28,7 +28,7 @@ export function BlogArticleGrid({ articles }: BlogArticleGridProps) {
                     href={`/blog/${article.slug}`}
                     className="group block overflow-hidden rounded-lg transition-all duration-200 hover:-translate-y-1 hover:shadow-md"
                 >
-                    <div className="relative aspect-[1200/630] w-full bg-muted">
+                    <div className="relative aspect-[1200/630] w-full bg-muted overflow-hidden">
                         <ThemeAwareImage
                             lightSrc={`${R2_PUBLIC_URL}/app/blog/${article.slug}/thumbnail-light.webp`}
                             darkSrc={`${R2_PUBLIC_URL}/app/blog/${article.slug}/thumbnail-dark.webp`}


### PR DESCRIPTION
## Summary

- `blog-article-grid.tsx` の画像コンテナ div に `overflow-hidden` を追加
- `category/[categoryKey]/page.tsx` の画像コンテナ div に `overflow-hidden` を追加（`page.tsx` はすでに適用済み）

**根本原因**: `group-hover:scale-105` で画像が 5% 拡大する際、Next.js Image（`position: absolute`）の containing block である `relative` div に `overflow: hidden` がないためカード外にはみ出し、縦スクロールバーが発生していた。外側の Link の `overflow-hidden` は `position: static` のため absolutely positioned 要素を clip できない。

## Test plan

- [ ] `/blog` でカードをホバーし、縦スクロールバーが出ないことを確認
- [ ] `/category/[key]` ページでも同様に確認
- [ ] tsc pass 済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)