### PR TITLE
feat(blog): content-first right sidebar (related articles/rankings/books + ads)

### DIFF
--- a/apps/web/src/app/blog/[slug]/page.tsx
+++ b/apps/web/src/app/blog/[slug]/page.tsx
@@ -261,14 +261,18 @@ export default async function BlogPostPage({ params }: PageProps) {
                         {/* バナー広告（タグキーベース・ランダム表示） */}
                         <ArticleAffiliateBanner tagKeys={tagKeys} />
 
-                        {/* 関連書籍（タグキーベース自動配置） */}
-                        <ArticleRelatedBooks tagKeys={tagKeys} />
+                        {/* 関連書籍・関連ランキング・関連記事: xl+ ではサイドバーに表示するため非表示 */}
+                        <div className="xl:hidden">
+                            <ArticleRelatedBooks tagKeys={tagKeys} />
+                        </div>
 
-                        {/* 関連ランキング（タグキーベース・ブログ→ランキング導線） */}
-                        <RelatedRankingsSection tagKeys={tagKeys} />
+                        <div className="xl:hidden">
+                            <RelatedRankingsSection tagKeys={tagKeys} />
+                        </div>
 
-                        {/* 関連記事 */}
-                        <BlogRelatedArticlesSection articles={relatedArticles} currentSlug={slug} articleTagsMap={articleTagsMap} />
+                        <div className="xl:hidden">
+                            <BlogRelatedArticlesSection articles={relatedArticles} currentSlug={slug} articleTagsMap={articleTagsMap} />
+                        </div>
 
                         {/* 広告（関連記事後）: xl+ ではサイドバーに表示するため非表示 */}
                         <div className="xl:hidden">
@@ -285,6 +289,18 @@ export default async function BlogPostPage({ params }: PageProps) {
 
                     {/* 右スティッキーサイドバー: xl+ のみ表示 */}
                     <aside className="hidden xl:flex xl:w-72 xl:shrink-0 xl:flex-col xl:gap-4 xl:sticky xl:top-20">
+                        {/* コンテンツ（優先度順） */}
+                        <BlogRelatedArticlesSection articles={relatedArticles} currentSlug={slug} articleTagsMap={articleTagsMap} compact />
+                        <RelatedRankingsSection tagKeys={tagKeys} compact />
+                        <Card>
+                            <CardHeader className="py-3 px-4">
+                                <CardTitle className="text-base">関連書籍</CardTitle>
+                            </CardHeader>
+                            <CardContent className="p-4 pt-0">
+                                <ArticleRelatedBooks tagKeys={tagKeys} compact />
+                            </CardContent>
+                        </Card>
+                        {/* 末尾広告（サイドバーが空にならないよう常時表示） */}
                         <Card>
                             <CardHeader className="pb-2">
                                 <CardTitle className="text-sm font-medium text-muted-foreground">広告</CardTitle>
@@ -313,10 +329,12 @@ function BlogRelatedArticlesSection({
     articles,
     currentSlug,
     articleTagsMap,
+    compact = false,
 }: {
     articles: Article[];
     currentSlug: string;
     articleTagsMap: Map<string, Array<{ tagKey: string }>>;
+    compact?: boolean;
 }) {
     const filtered = articles.filter((a) => a.slug !== currentSlug);
     if (filtered.length === 0) return null;
@@ -327,7 +345,7 @@ function BlogRelatedArticlesSection({
                 <CardTitle className="text-base">関連記事</CardTitle>
             </CardHeader>
             <CardContent className="p-4 pt-0">
-                <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3">
+                <div className={compact ? "grid grid-cols-1 gap-2" : "grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3"}>
                     {filtered.map((article) => (
                         <Link
                             key={article.slug}

--- a/apps/web/src/features/blog/components/RelatedRankingsSection.tsx
+++ b/apps/web/src/features/blog/components/RelatedRankingsSection.tsx
@@ -12,10 +12,12 @@ import { BarChart3 } from "lucide-react";
 
 interface RelatedRankingsSectionProps {
   tagKeys: string[];
+  compact?: boolean;
 }
 
 export async function RelatedRankingsSection({
   tagKeys,
+  compact = false,
 }: RelatedRankingsSectionProps) {
   if (tagKeys.length === 0) return null;
 
@@ -51,7 +53,7 @@ export async function RelatedRankingsSection({
         <CardTitle className="text-base">関連ランキング</CardTitle>
       </CardHeader>
       <CardContent className="p-4 pt-0">
-        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3">
+        <div className={compact ? "grid grid-cols-1 gap-2" : "grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3"}>
           {rankings.map((ranking) => (
             <Link
               key={ranking.rankingKey}

--- a/apps/web/src/features/blog/components/article-related-books.tsx
+++ b/apps/web/src/features/blog/components/article-related-books.tsx
@@ -12,13 +12,14 @@ import {
 
 interface ArticleRelatedBooksProps {
   tagKeys: string[];
+  compact?: boolean;
 }
 
 /**
  * 記事タグキーから関連書籍を自動判定し表示するサーバーコンポーネント。
  * 最大 2 冊まで表示。マッチなしの場合は何も表示しない。
  */
-export function ArticleRelatedBooks({ tagKeys }: ArticleRelatedBooksProps) {
+export function ArticleRelatedBooks({ tagKeys, compact = false }: ArticleRelatedBooksProps) {
   const books: { category: AffiliateCategory; book: BookRecommendation }[] = [];
   const seen = new Set<AffiliateCategory>();
 
@@ -36,6 +37,37 @@ export function ArticleRelatedBooks({ tagKeys }: ArticleRelatedBooksProps) {
 
   if (books.length === 0) return null;
 
+  const grid = (
+    <div className={compact ? "grid gap-3 grid-cols-1" : "grid gap-4 md:grid-cols-2"}>
+      {books.map(({ category, book }) => {
+        const theme = AFFILIATE_THEME[category];
+        return (
+          <TrackedAffiliateLink
+            key={category}
+            href={buildAmazonUrl(book.amazonDp)}
+            category={category}
+            label={book.title}
+            position="related-books"
+            className={`flex gap-3 rounded-xl border ${theme.border} ${theme.bg} p-4 transition-shadow hover:shadow-md`}
+          >
+            <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-white shadow-sm">
+              <BookOpen size={20} className={theme.icon} />
+            </div>
+            <div className="min-w-0">
+              <p className="text-sm font-bold text-foreground">{book.title}</p>
+              <p className="mt-0.5 text-xs text-muted-foreground">{book.author}</p>
+              <p className="mt-1 text-xs leading-relaxed text-muted-foreground">
+                {book.description}
+              </p>
+            </div>
+          </TrackedAffiliateLink>
+        );
+      })}
+    </div>
+  );
+
+  if (compact) return grid;
+
   return (
     <aside className="mt-8 border-t pt-8">
       <div className="mb-4 flex items-center gap-2">
@@ -44,32 +76,7 @@ export function ArticleRelatedBooks({ tagKeys }: ArticleRelatedBooksProps) {
         </span>
         <h2 className="text-lg font-bold text-foreground">関連書籍</h2>
       </div>
-      <div className="grid gap-4 md:grid-cols-2">
-        {books.map(({ category, book }) => {
-          const theme = AFFILIATE_THEME[category];
-          return (
-            <TrackedAffiliateLink
-              key={category}
-              href={buildAmazonUrl(book.amazonDp)}
-              category={category}
-              label={book.title}
-              position="related-books"
-              className={`flex gap-3 rounded-xl border ${theme.border} ${theme.bg} p-4 transition-shadow hover:shadow-md`}
-            >
-              <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-white shadow-sm">
-                <BookOpen size={20} className={theme.icon} />
-              </div>
-              <div className="min-w-0">
-                <p className="text-sm font-bold text-foreground">{book.title}</p>
-                <p className="mt-0.5 text-xs text-muted-foreground">{book.author}</p>
-                <p className="mt-1 text-xs leading-relaxed text-muted-foreground">
-                  {book.description}
-                </p>
-              </div>
-            </TrackedAffiliateLink>
-          );
-        })}
-      </div>
+      {grid}
     </aside>
   );
 }


### PR DESCRIPTION
## Summary

- xl+ の右サイドバーを「広告のみ」→「関連記事・関連ランキング・関連書籍 + 末尾広告」に刷新
- 3 コンポーネントに `compact?: boolean` prop を追加し、288px サイドバー内でも `grid-cols-1` を強制
- モバイル・タブレット（xl 未満）は既存の 1 カラム表示を維持

## 変更ファイル

- `RelatedRankingsSection.tsx`: `compact` prop 追加（`sm:grid-cols-2 lg:grid-cols-3` → `grid-cols-1`）
- `article-related-books.tsx`: `compact` prop 追加（`aside` ラッパーを外しグリッドのみ返す）
- `blog/[slug]/page.tsx`: `BlogRelatedArticlesSection` に `compact` prop、サイドバーのコンテンツ刷新

## 検証チェックリスト

- [x] tsc pass
- [ ] xl+ でサイドバーに関連記事→関連ランキング→関連書籍→広告が縦 1 列に並ぶことを確認
- [ ] サイドバー内でカードが横に並ばないことを確認（compact 効果）
- [ ] モバイルで全コンテンツが 1 カラムで表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)