### PR TITLE
feat: ブログ記事内専用 AdSense スロット（in-article / fluid）

### DIFF
--- a/.claude/skills/blog/md-syntax/SKILL.md
+++ b/.claude/skills/blog/md-syntax/SKILL.md
@@ -99,10 +99,60 @@ MDX 不要。HTML カスタムタグとして `react-markdown` の `components` 
 
 ### 広告スロット
 
-記事中盤に1つ配置する。
+記事の**セクション末尾**（次の `##` の直前）に配置する。H2 直下への配置は禁止。
+
+**配置ルール（H2セクション数による）:**
+
+| H2 数 | ad-slot 数 | 推奨配置位置 |
+|---|---|---|
+| 3 以下 | 1 箇所 | セクション 2 の末尾 |
+| 4〜5 | 2 箇所 | セクション 2・4 の末尾 |
+| 6 以上 | 3 箇所 | セクション 2・4・6 の末尾 |
+
+「セクション末尾」= そのセクションの最後の非空行と次の `## ` の間。`<data-source>` や `<source-link>` がある場合はその後に配置。まとめ（`## まとめ` 等）セクションには置かない。
 
 ```html
+<!-- ✅ 正しい配置（セクション末尾） -->
+（セクション2の本文...）
+
 <ad-slot></ad-slot>
+
+## 次のセクション見出し
+```
+
+```html
+<!-- ❌ 禁止パターン（H2直下） -->
+## 見出し
+
+<ad-slot></ad-slot>
+
+（本文...）
+```
+
+### アフィリエイトバナー（記事内）
+
+記事のテーマと最も関連するセクションの末尾に 1 箇所配置する。`<ad-slot>` と同じセクション末尾には置かず、隣接セクションに配置する。
+
+**category ベース（推奨）:** カテゴリを指定するとコードが適切なバナーを自動解決する。
+
+```html
+<affiliate-banner category="labor">
+<affiliate-banner category="housing">
+<affiliate-banner category="economy">
+```
+
+利用可能カテゴリ: `labor` / `housing` / `population` / `economy` / `health` / `energy` / `tourism` / `furusato`
+
+**URL 直書き（後方互換・特殊バナー用）:**
+
+```html
+<affiliate-banner
+  src="https://storage.stats47.jp/app/ads/XXX.png"
+  href="https://..."
+  tracking="https://..."
+  width="300"
+  height="250"
+  label="バナー説明文">
 ```
 
 ### データ出典

--- a/.claude/skills/blog/monetize-article/SKILL.md
+++ b/.claude/skills/blog/monetize-article/SKILL.md
@@ -1,0 +1,86 @@
+---
+name: monetize-article
+description: 既存ブログ記事に <ad-slot> と <affiliate-banner> を適切な位置に挿入する。Use when user says "/monetize-article", "広告挿入", "記事に広告を入れて", "ad-slot配置". スラッグを引数として受け取る.
+---
+
+既存ブログ記事の markdown に `<ad-slot>` と `<affiliate-banner>` を適切な位置に挿入する。
+
+## 引数
+
+```
+$ARGUMENTS — {slug}
+             例: noodle-consumption-prefecture-character
+             省略時はスラッグを対話で確認する
+```
+
+## 手順
+
+### Phase 1: 記事を読む
+
+1. スラッグを特定する（引数がなければユーザーに確認）
+2. `.local/r2/app/blog/{slug}/article.md` を読む
+3. H2 セクション一覧を把握する（行番号付き）:
+   - 各 `## ` の行番号・見出しテキスト
+   - 各セクションの最後の非空行（末尾位置）
+4. 現在の `<ad-slot>` と `<affiliate-banner>` の位置を確認する
+
+### Phase 2: `<ad-slot>` の配置を最適化
+
+**配置ルール（H2セクション数による）:**
+
+| H2 数 | ad-slot 数 | 推奨配置位置 |
+|---|---|---|
+| 3 以下 | 1 箇所 | セクション 2 の末尾 |
+| 4〜5 | 2 箇所 | セクション 2・4 の末尾 |
+| 6 以上 | 3 箇所 | セクション 2・4・6 の末尾 |
+
+**「セクション末尾」の定義:**
+- そのセクションの最後の非空行の直後、次の `## ` の直前
+- `<data-source>` や `<source-link>` がある場合はその後に配置
+- まとめ（`## まとめ`）・データ出典・関連記事セクションには置かない
+
+**現在の配置を評価して修正:**
+- H2直下にある場合 → セクション末尾へ移動
+- 目標数より少ない場合 → 追加
+- 同一セクション内に複数ある場合 → 1つ残して削除
+- 目標数を超えている場合 → 優先度の低い位置から削除
+
+### Phase 3: `<affiliate-banner>` の配置
+
+1. 記事のタグを確認する（記事 frontmatter またはファイル名から推測）
+2. `TAG_AFFILIATE_MAP`（`apps/web/src/features/ads/constants/affiliate-category.ts`）でカテゴリを特定:
+   - タグが複数ある場合は最初にマッチしたカテゴリを使用
+3. 記事本文・セクションタイトルを見て、カテゴリと最も関連するセクションを選択
+4. そのセクション末尾に `<affiliate-banner category="{category}">` を挿入
+
+**配置条件:**
+- すでに `<affiliate-banner>` がある場合はスキップ（位置も確認して適切なら維持）
+- `<ad-slot>` と同じセクション末尾を避ける
+- まとめ・データ出典セクションには置かない
+- 1 記事 1 箇所まで
+
+**利用可能カテゴリ:**
+`labor` / `housing` / `population` / `economy` / `health` / `energy` / `tourism` / `furusato`
+
+### Phase 4: ファイルを更新する
+
+1. 変更後の markdown を `.local/r2/app/blog/{slug}/article.md` に書き戻す
+2. 変更点のサマリーを報告:
+   - 移動した `<ad-slot>` の位置（before → after）
+   - 追加した `<ad-slot>` の位置
+   - 挿入した `<affiliate-banner>` のカテゴリと配置セクション
+3. R2 への反映は `/push-r2 app/blog/{slug}` で別途実行するよう案内する
+
+## 使用例
+
+```
+/monetize-article noodle-consumption-prefecture-character
+/monetize-article household-savings-prefecture-ranking
+/monetize-article          ← 引数なしの場合はスラッグを対話で確認
+```
+
+## 関連スキル
+
+- `/md-syntax` — ad-slot・affiliate-banner の記法詳細
+- `/push-r2` — 修正後の R2 反映
+- `/plan-blog-affiliate` — アフィリエイト記事企画

--- a/.claude/skills/blog/plan-blog-affiliate/SKILL.md
+++ b/.claude/skills/blog/plan-blog-affiliate/SKILL.md
@@ -207,7 +207,7 @@ WHERE tags LIKE '%賃金%' OR tags LIKE '%転職%' -- etc.
 ## 注意
 
 - **記事の価値を最優先**: アフィリエイトはあくまで補助導線。データ分析記事としての価値が第一
-- **押し売りしない**: 記事本文にアフィリエイトリンクは入れない。`ArticleAffiliateSections` コンポーネントがタグベースで自動配置する
+- **押し売りしない**: 記事本文への `<affiliate-banner>` 配置は 1 箇所まで。配置ルールと記法は `/monetize-article` と `md-syntax` を参照。`ArticleAffiliateSections` コンポーネントによるタグベース自動配置も引き続き機能する
 - **TAG_AFFILIATE_MAP を意識**: 記事の `tags` にマッピング対象のタグを含めれば、アフィリエイトが自動表示される
 - **DB + e-Stat API の両面で探索**: `estat_metainfo` を出発点としつつ、e-Stat API（`/search-estat`）で DB にない関連データも積極的に探す
 - **時系列データの活用**: `/fetch-article-data` で `cdArea: "00000"` を使えば、ランキング用と同じ statsDataId + cdCat01 で全国時系列が取得できる。別の statsDataId を探す必要がないケースが多い

--- a/apps/web/src/app/blog/[slug]/page.tsx
+++ b/apps/web/src/app/blog/[slug]/page.tsx
@@ -13,6 +13,7 @@ import { Card, CardContent, CardHeader, CardTitle } from "@stats47/components/at
 
 import { ShareButtons } from "@/components/molecules/ShareButtons";
 
+import { resolveAffiliateBannersByCategory } from "@/features/ads/server";
 import { TagBadge, ArticleRelatedBooks, ArticleRenderer, type Article } from "@/features/blog";
 import {
     ArticleAffiliateBanner,
@@ -25,8 +26,6 @@ import {
     getTagsForArticles,
     articleService,
 } from "@/features/blog/server";
-
-import { resolveAffiliateBannersByCategory } from "@/features/ads/server";
 
 import { getRequiredBaseUrl } from "@/lib/env";
 import { AdSenseAd, RANKING_SIDEBAR_TOP, RANKING_PAGE_SIDEBAR } from "@/lib/google-adsense";

--- a/apps/web/src/app/blog/[slug]/page.tsx
+++ b/apps/web/src/app/blog/[slug]/page.tsx
@@ -26,6 +26,8 @@ import {
     articleService,
 } from "@/features/blog/server";
 
+import { resolveAffiliateBannersByCategory } from "@/features/ads/server";
+
 import { getRequiredBaseUrl } from "@/lib/env";
 import { AdSenseAd, RANKING_SIDEBAR_TOP, RANKING_PAGE_SIDEBAR } from "@/lib/google-adsense";
 import { buildPersonAsAuthor } from "@/lib/structured-data/person";
@@ -136,7 +138,10 @@ export default async function BlogPostPage({ params }: PageProps) {
 
     const articleTagData = await getTagKeysForArticle(slug);
     const tagKeys = articleTagData.map((t) => t.tagKey);
-    const relatedArticles = await getRelatedArticles(tagKeys, slug);
+    const [relatedArticles, affiliateBannersByCategory] = await Promise.all([
+        getRelatedArticles(tagKeys, slug),
+        resolveAffiliateBannersByCategory(),
+    ]);
 
     // 記事本文中の /blog/{slug} リンクからスラッグを抽出し、DB からタイトルを取得
     const blogLinkSlugs = [...article.content.matchAll(/\]\(\/blog\/([a-z0-9-]+)\)/g)]
@@ -237,7 +242,7 @@ export default async function BlogPostPage({ params }: PageProps) {
                                 </header>
 
                                 {/* 記事本文 */}
-                                <ArticleRenderer article={article} slug={slug} relatedArticleTitles={relatedArticleTitles} />
+                                <ArticleRenderer article={article} slug={slug} relatedArticleTitles={relatedArticleTitles} affiliateBannersByCategory={affiliateBannersByCategory} />
 
                                 {/* SNSシェアボタン */}
                                 <div className="mt-8 pt-6 border-t flex justify-center">

--- a/apps/web/src/features/ads/server.ts
+++ b/apps/web/src/features/ads/server.ts
@@ -6,7 +6,7 @@ export {
   readActiveBannersByCategoryKeysFromR2 as findActiveBannersByCategoryKeys,
   readActiveBannersByLocationFromR2 as findActiveBannersByLocation,
 } from "./repositories/affiliate-ad-snapshot";
-export { resolveAffiliateAd, resolveAffiliateBanners } from "./services/resolve-affiliate-ad";
+export { resolveAffiliateAd, resolveAffiliateBanners, resolveAffiliateBannersByCategory } from "./services/resolve-affiliate-ad";
 export { fetchAffiliateAdAction } from "./actions/fetch-affiliate-ad";
 export { AffiliateAdSlot } from "./components/AffiliateAdSlot";
 export type { ResolvedAffiliateAd, ResolvedAffiliateBanner } from "./services/resolve-affiliate-ad";

--- a/apps/web/src/features/ads/services/resolve-affiliate-ad.ts
+++ b/apps/web/src/features/ads/services/resolve-affiliate-ad.ts
@@ -1,8 +1,8 @@
 import {
   CATEGORY_AFFILIATE_MAP,
   TAG_AFFILIATE_MAP,
+  type AffiliateCategory,
 } from "../constants/affiliate-category";
-import type { AffiliateCategory } from "../constants/affiliate-category";
 import {
   readActiveAdByCategoryFromR2 as findActiveAdByCategory,
   readActiveBannersByCategoryKeysFromR2 as findActiveBannersByCategoryKeys,

--- a/apps/web/src/features/ads/services/resolve-affiliate-ad.ts
+++ b/apps/web/src/features/ads/services/resolve-affiliate-ad.ts
@@ -2,6 +2,7 @@ import {
   CATEGORY_AFFILIATE_MAP,
   TAG_AFFILIATE_MAP,
 } from "../constants/affiliate-category";
+import type { AffiliateCategory } from "../constants/affiliate-category";
 import {
   readActiveAdByCategoryFromR2 as findActiveAdByCategory,
   readActiveBannersByCategoryKeysFromR2 as findActiveBannersByCategoryKeys,
@@ -78,4 +79,31 @@ export async function resolveAffiliateBanners(
       width: b.width ?? 300,
       height: b.height ?? 250,
     }));
+}
+
+/**
+ * すべての AffiliateCategory に対してバナーを一括解決する。
+ * category prop で affiliate-banner を宣言的に配置する際のサーバー側解決に使う。
+ */
+export async function resolveAffiliateBannersByCategory(): Promise<Partial<Record<AffiliateCategory, ResolvedAffiliateBanner>>> {
+  const allCategoryKeys = Object.keys(CATEGORY_AFFILIATE_MAP);
+  const banners = await findActiveBannersByCategoryKeys(allCategoryKeys, 100);
+
+  const result: Partial<Record<AffiliateCategory, ResolvedAffiliateBanner>> = {};
+
+  for (const b of banners) {
+    if (!b.imageUrl || !b.trackingPixelUrl || !b.categoryKey) continue;
+    const affiliateCategory = CATEGORY_AFFILIATE_MAP[b.categoryKey];
+    if (!affiliateCategory || result[affiliateCategory]) continue;
+    result[affiliateCategory] = {
+      title: b.title,
+      href: b.htmlContent,
+      imageUrl: b.imageUrl,
+      trackingPixelUrl: b.trackingPixelUrl,
+      width: b.width ?? 300,
+      height: b.height ?? 250,
+    };
+  }
+
+  return result;
 }

--- a/apps/web/src/features/blog/components/article-renderer.tsx
+++ b/apps/web/src/features/blog/components/article-renderer.tsx
@@ -7,11 +7,19 @@ interface ArticleRendererProps {
     article: Article;
     slug: string;
     relatedArticleTitles?: Record<string, string>;
+    affiliateBannersByCategory?: Record<string, {
+        href: string;
+        imageUrl: string;
+        trackingPixelUrl?: string | null;
+        width?: number | null;
+        height?: number | null;
+        title?: string;
+    }>;
 }
 
-export function ArticleRenderer({ article, slug, relatedArticleTitles }: ArticleRendererProps) {
+export function ArticleRenderer({ article, slug, relatedArticleTitles, affiliateBannersByCategory }: ArticleRendererProps) {
     if (article.format === "mdx") {
         return <MDXContent source={article.content} />;
     }
-    return <MDContent source={article.content} slug={slug} relatedArticleTitles={relatedArticleTitles} />;
+    return <MDContent source={article.content} slug={slug} relatedArticleTitles={relatedArticleTitles} affiliateBannersByCategory={affiliateBannersByCategory} />;
 }

--- a/apps/web/src/features/blog/components/md-content.tsx
+++ b/apps/web/src/features/blog/components/md-content.tsx
@@ -17,10 +17,20 @@ import { AdSenseAd, RANKING_PAGE_FOOTER } from "@/lib/google-adsense";
 import { preprocessCallouts } from "./md-preprocessor";
 import { MarkdownRankingTable } from "./tables/MarkdownRankingTable";
 
+interface AffiliateBannerData {
+    href: string;
+    imageUrl: string;
+    trackingPixelUrl?: string | null;
+    width?: number | null;
+    height?: number | null;
+    title?: string;
+}
+
 interface MDContentProps {
     source: string;
     slug?: string;
     relatedArticleTitles?: Record<string, string>;
+    affiliateBannersByCategory?: Record<string, AffiliateBannerData>;
 }
 
 interface ComponentProps {
@@ -28,7 +38,7 @@ interface ComponentProps {
     [key: string]: unknown;
 }
 
-function makeMdComponents(slug?: string): Record<string, React.ComponentType<ComponentProps>> {
+function makeMdComponents(slug?: string, affiliateBannersByCategory?: Record<string, AffiliateBannerData>): Record<string, React.ComponentType<ComponentProps>> {
     return {
         h2: ({ children, ...props }: ComponentProps) => (
             <h2
@@ -230,19 +240,37 @@ function makeMdComponents(slug?: string): Record<string, React.ComponentType<Com
             </span>
         ),
 
-        "affiliate-banner": ({ src, href, tracking, width, height, label }: ComponentProps & { src?: string; href?: string; tracking?: string; width?: string; height?: string; label?: string }) => (
-            <div className="my-8 not-prose">
-                <BannerAd
-                    href={href ?? "#"}
-                    imageUrl={src ?? ""}
-                    trackingPixelUrl={tracking}
-                    width={Number(width) || null}
-                    height={Number(height) || null}
-                    label={label ?? ""}
-                    position="article-inline"
-                />
-            </div>
-        ),
+        "affiliate-banner": ({ src, href, tracking, width, height, label, category }: ComponentProps & { src?: string; href?: string; tracking?: string; width?: string; height?: string; label?: string; category?: string }) => {
+            if (category && affiliateBannersByCategory?.[category]) {
+                const b = affiliateBannersByCategory[category];
+                return (
+                    <div className="my-8 not-prose">
+                        <BannerAd
+                            href={b.href}
+                            imageUrl={b.imageUrl}
+                            trackingPixelUrl={b.trackingPixelUrl}
+                            width={b.width ?? null}
+                            height={b.height ?? null}
+                            label={b.title ?? ""}
+                            position="article-inline"
+                        />
+                    </div>
+                );
+            }
+            return (
+                <div className="my-8 not-prose">
+                    <BannerAd
+                        href={href ?? "#"}
+                        imageUrl={src ?? ""}
+                        trackingPixelUrl={tracking}
+                        width={Number(width) || null}
+                        height={Number(height) || null}
+                        label={label ?? ""}
+                        position="article-inline"
+                    />
+                </div>
+            );
+        },
 
         "related-articles": ({ children }: ComponentProps) => (
             <div className="my-8 not-prose overflow-hidden rounded-lg border-2 border-primary/30">
@@ -297,8 +325,8 @@ function makeMdComponents(slug?: string): Record<string, React.ComponentType<Com
     };
 }
 
-export function MDContent({ source, slug, relatedArticleTitles }: MDContentProps) {
-    const mdComponents = useMemo(() => makeMdComponents(slug), [slug]);
+export function MDContent({ source, slug, relatedArticleTitles, affiliateBannersByCategory }: MDContentProps) {
+    const mdComponents = useMemo(() => makeMdComponents(slug, affiliateBannersByCategory), [slug, affiliateBannersByCategory]);
     const processed = useMemo(() => preprocessCallouts(source, relatedArticleTitles), [source, relatedArticleTitles]);
     return (
         <article className="prose prose-zinc dark:prose-invert max-w-none" suppressHydrationWarning>

--- a/apps/web/src/features/blog/components/md-content.tsx
+++ b/apps/web/src/features/blog/components/md-content.tsx
@@ -12,7 +12,7 @@ import remarkGfm from "remark-gfm";
 
 import { BannerAd } from "@/features/ads";
 
-import { AdSenseAd, RANKING_PAGE_FOOTER } from "@/lib/google-adsense";
+import { AdSenseAd, BLOG_ARTICLE_INLINE } from "@/lib/google-adsense";
 
 import { preprocessCallouts } from "./md-preprocessor";
 import { MarkdownRankingTable } from "./tables/MarkdownRankingTable";
@@ -199,10 +199,11 @@ function makeMdComponents(slug?: string, affiliateBannersByCategory?: Record<str
         ),
 
         "ad-slot": () => (
-            <div className="my-8 flex justify-center not-prose">
+            <div className="my-8 not-prose">
                 <AdSenseAd
-                    format={RANKING_PAGE_FOOTER.format}
-                    slotId={RANKING_PAGE_FOOTER.slotId}
+                    format={BLOG_ARTICLE_INLINE.format}
+                    slotId={BLOG_ARTICLE_INLINE.slotId}
+                    showLabel={false}
                 />
             </div>
         ),

--- a/apps/web/src/lib/google-adsense/components/AdSenseAd.tsx
+++ b/apps/web/src/lib/google-adsense/components/AdSenseAd.tsx
@@ -119,13 +119,14 @@ export function AdSenseAd({
     return null;
   }
 
-  const reservedMinHeight = getReservedMinHeight(format);
+  const isArticleFormat = format === "article";
+  const reservedMinHeight = isArticleFormat ? 0 : getReservedMinHeight(format);
 
   return (
     <div
       ref={adRef}
       className={`ad-container w-full flex flex-col items-center ${className}`}
-      style={{ minHeight: `${reservedMinHeight}px` }}
+      style={reservedMinHeight > 0 ? { minHeight: `${reservedMinHeight}px` } : undefined}
     >
       {showLabel && (
         <div className="text-xs text-muted-foreground text-center mb-1">
@@ -133,20 +134,32 @@ export function AdSenseAd({
         </div>
       )}
       {isVisible ? (
-        <ins
-          className="adsbygoogle"
-          style={{
-            display: "block",
-            width: "100%",
-            minHeight: `${reservedMinHeight}px`,
-          }}
-          data-ad-client={clientId}
-          data-ad-slot={slotId}
-          data-ad-format="auto"
-          data-full-width-responsive="true"
-        />
+        isArticleFormat ? (
+          // 記事内広告（fluid / in-article）: Google 推奨の属性構成
+          <ins
+            className="adsbygoogle"
+            style={{ display: "block", textAlign: "center" }}
+            data-ad-layout="in-article"
+            data-ad-format="fluid"
+            data-ad-client={clientId}
+            data-ad-slot={slotId}
+          />
+        ) : (
+          <ins
+            className="adsbygoogle"
+            style={{
+              display: "block",
+              width: "100%",
+              minHeight: `${reservedMinHeight}px`,
+            }}
+            data-ad-client={clientId}
+            data-ad-slot={slotId}
+            data-ad-format="auto"
+            data-full-width-responsive="true"
+          />
+        )
       ) : (
-        // 遅延ロード中のスペース確保（CLSの防止、最小値を広告サイズに合わせる）
+        // 遅延ロード中のスペース確保（CLSの防止）
         <div
           style={{ width: "100%", minHeight: `${reservedMinHeight}px` }}
           className="bg-gray-100"

--- a/apps/web/src/lib/google-adsense/constants.ts
+++ b/apps/web/src/lib/google-adsense/constants.ts
@@ -44,6 +44,12 @@ export const RANKING_PAGE_FOOTER: AdSlotConfig = {
   format: "rectangle",
 };
 
+/** ブログ記事内インライン広告（記事内 / fluid） */
+export const BLOG_ARTICLE_INLINE: AdSlotConfig = {
+  slotId: "5610987738",
+  format: "article",
+};
+
 /** 比較ページ: 右サイドバー */
 export const COMPARE_PAGE_SIDEBAR: AdSlotConfig = {
   slotId: "6180558947",


### PR DESCRIPTION
## Summary

- AdSense コンソールで作成した記事内専用スロット（slotId: 5610987738）を組み込み
- `article` format の `<ad-slot>` は `data-ad-format="fluid"` + `data-ad-layout="in-article"` で表示
- これまでランキングページのフッタースロットを流用していた問題を解消

## Changes

- `constants.ts`: `BLOG_ARTICLE_INLINE` 定数を追加
- `AdSenseAd.tsx`: `format === "article"` のとき in-article 専用の `<ins>` を描画（minHeight 予約なし）
- `md-content.tsx`: `<ad-slot>` コンポーネントを `BLOG_ARTICLE_INLINE` に切り替え

## Test plan

- [ ] ブログ記事ページを開き、セクション末尾に記事内広告が表示されること
- [ ] モバイルでも記事幅に合わせて fluid 表示されること
- [ ] AdSense レポートで `blog-article-inline` スロットにインプレッションが記録されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)