### PR TITLE
fix(blog): 画像ごとのスクロールバーを解消（overflow-x-auto → hidden）

### DIFF
--- a/apps/web/src/features/blog/components/md-content.tsx
+++ b/apps/web/src/features/blog/components/md-content.tsx
@@ -96,7 +96,7 @@ function makeMdComponents(slug?: string, affiliateBannersByCategory?: Record<str
             const isSvg = resolvedSrc.toLowerCase().endsWith(".svg");
             return (
                 <span
-                    className="block mt-2 -mx-6 sm:-mx-8 overflow-x-auto"
+                    className="block mt-2 -mx-6 sm:-mx-8 overflow-x-hidden"
                     style={{ aspectRatio: isSvg ? "16 / 9" : undefined }}
                 >
                     <Image


### PR DESCRIPTION
## Summary

- `md-content.tsx` の画像 `span` に付いていた `overflow-x-auto` を `overflow-x-hidden` に変更
- 負マージン（`-mx-6 sm:-mx-8`）でパディングを相殺しているため画像は `w-full` で収まるが、ブラウザのサブピクセル誤差で scrollWidth が 1px 超過し各画像に個別スクロールバーが出ていた
- フルブリード効果・SVG の CLS 対策は変更なし

## Test plan

- [ ] ブログ記事を開いて各画像にスクロールバーが出ないことを確認
- [ ] モバイル幅（375px）でも確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)