### PR TITLE
feat(ranking): 正規化済み R2 スナップショット事前生成（per_population / per_area）

### DIFF
--- a/.claude/skills/db/sync-snapshots/run.sh
+++ b/.claude/skills/db/sync-snapshots/run.sh
@@ -27,6 +27,7 @@ declare -a TASKS=(
   "ai-content|packages/ai-content/src/scripts/export-snapshot.ts"
   "correlation|packages/correlation/src/scripts/export-snapshot.ts"
   "ranking-values|packages/ranking/src/scripts/export-ranking-values-snapshots.ts"
+  "ranking-normalized-values|packages/ranking/src/scripts/export-ranking-normalized-values-snapshots.ts"
   "area-profile|packages/area-profile/src/scripts/export-snapshot.ts"
   "blog|apps/web/scripts/export-blog-snapshot.ts"
   "page-components|apps/web/scripts/export-page-components-snapshot.ts"

--- a/apps/web/src/features/ranking/actions/fetch-ranking-values.ts
+++ b/apps/web/src/features/ranking/actions/fetch-ranking-values.ts
@@ -3,6 +3,7 @@
 import {
   computeNormalization,
   fetchRankingValuesOnDemand,
+  readNormalizedRankingValuesFromR2,
   readRankingValuesFromR2,
   readRankingItemFromR2,
 } from "@stats47/ranking/server";
@@ -35,11 +36,19 @@ export async function fetchRankingValuesAction(
 
     // 正規化が指定されている場合
     if (normalizationType) {
-      values = await computeNormalization(
-        rankingItem,
+      // 事前計算済み R2 スナップショットを優先使用
+      const normResult = await readNormalizedRankingValuesFromR2(
+        rankingKey,
+        areaType,
         yearCode,
-        normalizationType
+        normalizationType,
       );
+      if (isOk(normResult) && normResult.data.length > 0) {
+        values = normResult.data;
+      } else {
+        // フォールバック: 実行時計算（カスタム denominatorKey 等）
+        values = await computeNormalization(rankingItem, yearCode, normalizationType);
+      }
     } else {
       // DB から取得（なければ e-Stat API からオンデマンド取得 + キャッシュ）
       const result = await readRankingValuesFromR2(rankingKey, areaType, yearCode);

--- a/apps/web/src/features/ranking/components/RankingKeyPage/RankingKeyPageClient.tsx
+++ b/apps/web/src/features/ranking/components/RankingKeyPage/RankingKeyPageClient.tsx
@@ -141,10 +141,11 @@ export function RankingKeyPageClient({
         return baseInfo;
     }, [rankingItem, normalizationType]);
 
-    const buildUrl = (year: string, area: AreaType) => {
+    const buildUrl = (year: string, area: AreaType, norm?: string) => {
         const params = new URLSearchParams();
         if (year) params.set("year", year);
         if (area !== "prefecture") params.set("areaType", area);
+        if (norm) params.set("norm", norm);
         const qs = params.toString();
         return qs ? `${pathname}?${qs}` : pathname;
     };
@@ -152,7 +153,7 @@ export function RankingKeyPageClient({
     const handleYearChange = (newYear: string) => {
         trackYearChange({ rankingKey, fromYear: currentYear, toYear: newYear });
         setCurrentYear(newYear);
-        window.history.replaceState(null, "", buildUrl(newYear, currentAreaType));
+        window.history.replaceState(null, "", buildUrl(newYear, currentAreaType, normalizationType));
         startTransition(async () => {
             const result = await fetchRankingValuesAction(
                 rankingKey,
@@ -219,7 +220,19 @@ export function RankingKeyPageClient({
                 });
             }
         } else if (urlYear && urlYear !== selectedYear) {
-            handleYearChange(urlYear);
+            // year と norm が同時に指定されている場合、両方を一度のリクエストで処理する
+            setCurrentYear(urlYear);
+            window.history.replaceState(null, "", buildUrl(urlYear, currentAreaType, urlNorm));
+            startTransition(async () => {
+                const result = await fetchRankingValuesAction(
+                    rankingKey,
+                    currentAreaType,
+                    urlYear,
+                    urlNorm,
+                    parentAreaCode,
+                );
+                if (isOk(result)) setRankingValues(result.data);
+            });
         } else if (urlNorm) {
             startTransition(async () => {
                 if (!currentYear) return;

--- a/packages/ranking/src/exporters/ranking-normalized-values-snapshot.ts
+++ b/packages/ranking/src/exporters/ranking-normalized-values-snapshot.ts
@@ -1,0 +1,220 @@
+import "server-only";
+
+import { getDrizzle, metrics, statsPrefecture } from "@stats47/database/server";
+import { logger } from "@stats47/logger/server";
+import { saveToR2 } from "@stats47/r2-storage/server";
+import { eq } from "drizzle-orm";
+
+import { WELL_KNOWN_DENOMINATORS } from "../services/compute-normalization";
+import type { RankingValue } from "../types";
+import { rankingNormalizedValuesKeyPath, type RankingValuesKeySnapshot } from "../types/snapshot";
+import { computeCalculatedValues } from "../utils/compute-calculated-values";
+import { rankByValue } from "../utils/rank-by-value";
+
+export interface ExportRankingNormalizedValuesSnapshotResult {
+  files: number;
+  skipped: number;
+  durationMs: number;
+}
+
+interface NormOption {
+  type: string;
+  unit: string;
+  scaleFactor?: number;
+  denominatorKey?: string;
+}
+
+function parseNormalizationOptions(calcConfigJson: string | null): NormOption[] {
+  if (!calcConfigJson) return [];
+  try {
+    const config = JSON.parse(calcConfigJson) as { normalizationOptions?: NormOption[] };
+    return config.normalizationOptions ?? [];
+  } catch {
+    return [];
+  }
+}
+
+async function loadValuesByYear(
+  drizzleDb: ReturnType<typeof getDrizzle>,
+  metricKey: string,
+): Promise<Map<string, RankingValue[]>> {
+  const rows = await drizzleDb
+    .select()
+    .from(statsPrefecture)
+    .where(eq(statsPrefecture.metricKey, metricKey));
+
+  const byYear = new Map<string, RankingValue[]>();
+  for (const row of rows) {
+    const yearCode = String(row.yearCode ?? "").slice(0, 4);
+    if (!yearCode) continue;
+    const arr = byYear.get(yearCode) ?? [];
+    arr.push({
+      areaType: "prefecture",
+      areaCode: row.areaCode ?? "",
+      areaName: row.areaName ?? "",
+      yearCode,
+      yearName: row.yearName ?? "",
+      metricKey,
+      value: row.value != null ? Number(row.value) : 0,
+      unit: row.unit ?? "",
+      rank: row.rank != null ? Number(row.rank) : 0,
+    });
+    byYear.set(yearCode, arr);
+  }
+  return byYear;
+}
+
+async function processNormalization(
+  drizzleDb: ReturnType<typeof getDrizzle>,
+  rankingKey: string,
+  option: NormOption,
+  dryRun: boolean,
+): Promise<boolean> {
+  const denominatorKey =
+    option.denominatorKey ?? WELL_KNOWN_DENOMINATORS[option.type]?.["prefecture"];
+
+  if (!denominatorKey) {
+    logger.warn({ rankingKey, normType: option.type }, "分母キーを特定できません。スキップ");
+    return false;
+  }
+
+  const [numeratorByYear, denominatorByYear] = await Promise.all([
+    loadValuesByYear(drizzleDb, rankingKey),
+    loadValuesByYear(drizzleDb, denominatorKey),
+  ]);
+
+  if (numeratorByYear.size === 0) return false;
+
+  // 分母の最新年度（フォールバック用）
+  const sortedDenomYears = [...denominatorByYear.keys()].sort();
+  const denomLatestYear = sortedDenomYears[sortedDenomYears.length - 1] ?? "";
+
+  const partitions: RankingValuesKeySnapshot["partitions"] = [];
+
+  for (const [yearCode, numValues] of [...numeratorByYear.entries()].sort((a, b) =>
+    b[0].localeCompare(a[0])
+  )) {
+    const denValues =
+      denominatorByYear.get(yearCode) ?? denominatorByYear.get(denomLatestYear);
+    if (!denValues || denValues.length === 0) continue;
+
+    const computed = computeCalculatedValues(numValues, denValues, {
+      type: "ratio",
+      metricKey: rankingKey,
+      unit: option.unit,
+      keyBy: "areaCode",
+      scaleFactor: option.scaleFactor ?? 1,
+    });
+
+    const ranked = rankByValue(computed) as RankingValue[];
+    if (ranked.length === 0) continue;
+
+    partitions.push({ yearCode, count: ranked.length, values: ranked });
+  }
+
+  if (partitions.length === 0) return false;
+
+  const snapshot: RankingValuesKeySnapshot = {
+    generatedAt: new Date().toISOString(),
+    rankingKey,
+    areaType: "prefecture",
+    partitions,
+  };
+
+  if (!dryRun) {
+    const path = rankingNormalizedValuesKeyPath(rankingKey, option.type);
+    await saveToR2(path, JSON.stringify(snapshot), {
+      contentType: "application/json; charset=utf-8",
+    });
+  }
+
+  return true;
+}
+
+/**
+ * normalizationOptions を持つ全 metrics に対して正規化済み values を R2 に保存する。
+ *
+ * 生成ファイル:
+ *   app/ranking/{key}/values-per-population.json
+ *   app/ranking/{key}/values-per-area.json
+ */
+export async function exportRankingNormalizedValuesSnapshots(
+  options: {
+    db?: ReturnType<typeof getDrizzle>;
+    parallelism?: number;
+    rankingKeyFilter?: string;
+    normTypeFilter?: string;
+    dryRun?: boolean;
+  } = {},
+): Promise<ExportRankingNormalizedValuesSnapshotResult> {
+  const startedAt = Date.now();
+  const drizzleDb = options.db ?? getDrizzle();
+  const parallelism = options.parallelism ?? 8;
+  const dryRun = options.dryRun ?? false;
+
+  // calculationConfigJson を持つ metrics を取得
+  const metricsRows = options.rankingKeyFilter
+    ? await drizzleDb
+        .select({ key: metrics.key, calcJson: metrics.calculationConfigJson })
+        .from(metrics)
+        .where(eq(metrics.key, options.rankingKeyFilter))
+    : await drizzleDb
+        .select({ key: metrics.key, calcJson: metrics.calculationConfigJson })
+        .from(metrics);
+
+  // normalizationOptions を持つ metric のみ抽出
+  const tasks: Array<{ rankingKey: string; option: NormOption }> = [];
+  for (const row of metricsRows) {
+    const opts = parseNormalizationOptions(row.calcJson ?? null);
+    for (const opt of opts) {
+      if (options.normTypeFilter && opt.type !== options.normTypeFilter) continue;
+      tasks.push({ rankingKey: row.key, option: opt });
+    }
+  }
+
+  logger.info(
+    { taskCount: tasks.length, dryRun, parallelism },
+    "ranking_normalized_values export を開始…",
+  );
+
+  let totalFiles = 0;
+  let totalSkipped = 0;
+
+  for (let i = 0; i < tasks.length; i += parallelism) {
+    const batch = tasks.slice(i, i + parallelism);
+    const results = await Promise.all(
+      batch.map(async ({ rankingKey, option }) => {
+        try {
+          const saved = await processNormalization(drizzleDb, rankingKey, option, dryRun);
+          return saved ? 1 : 0;
+        } catch (error) {
+          logger.error(
+            { rankingKey, normType: option.type, error: error instanceof Error ? error.message : String(error) },
+            "正規化スナップショット生成失敗。スキップ",
+          );
+          return 0;
+        }
+      }),
+    );
+
+    for (const r of results) {
+      if (r === 1) totalFiles++;
+      else totalSkipped++;
+    }
+
+    if ((i + batch.length) % 200 === 0 || i + batch.length >= tasks.length) {
+      logger.info(
+        { processed: i + batch.length, total: tasks.length, totalFiles, totalSkipped },
+        "ranking_normalized_values 進捗",
+      );
+    }
+  }
+
+  const durationMs = Date.now() - startedAt;
+  logger.info(
+    { files: totalFiles, skipped: totalSkipped, durationMs, dryRun },
+    "ranking_normalized_values snapshot を R2 に保存しました",
+  );
+
+  return { files: totalFiles, skipped: totalSkipped, durationMs };
+}

--- a/packages/ranking/src/repositories/ranking-value/index.ts
+++ b/packages/ranking/src/repositories/ranking-value/index.ts
@@ -3,6 +3,7 @@ export { getAllAvailableYears } from "./get-all-available-years";
 export { getAvailableYears } from "./get-available-years";
 export { listRankingValues } from "./list-ranking-values";
 export {
+  readNormalizedRankingValuesFromR2,
   readRankingValuesByPrefectureFromR2,
   readRankingValuesFromR2,
 } from "./read-ranking-values-from-r2";

--- a/packages/ranking/src/repositories/ranking-value/read-ranking-values-from-r2.ts
+++ b/packages/ranking/src/repositories/ranking-value/read-ranking-values-from-r2.ts
@@ -7,6 +7,7 @@ import type { AreaType } from "@stats47/types";
 
 import type { RankingValue } from "../../types";
 import {
+  rankingNormalizedValuesKeyPath,
   rankingValuesKeyPath,
   type RankingValuesKeySnapshot,
 } from "../../types/snapshot";
@@ -81,6 +82,39 @@ export async function readRankingValuesFromR2(
     logger.error(
       { rankingKey, areaType, yearCode, error: error instanceof Error ? error.message : String(error) },
       "readRankingValuesFromR2: failed",
+    );
+    return err(error instanceof Error ? error : new Error(String(error)));
+  }
+}
+
+/**
+ * 正規化済み R2 snapshot から ranking_values を取得。
+ *
+ * normType: "per_population" → app/ranking/{key}/values-per-population.json
+ * normType: "per_area"       → app/ranking/{key}/values-per-area.json
+ *
+ * ファイルが存在しない場合は ok([]) を返す（computeNormalization フォールバック用）。
+ */
+export async function readNormalizedRankingValuesFromR2(
+  rankingKey: string,
+  _areaType: AreaType,
+  yearCode: string,
+  normType: string,
+): Promise<Result<RankingValue[], Error>> {
+  try {
+    const path = rankingNormalizedValuesKeyPath(rankingKey, normType);
+    const snapshot = await fetchFromR2AsJson<RankingValuesKeySnapshot>(path);
+    if (!snapshot) return ok([]);
+
+    const normalizedYear = yearCode.slice(0, 4);
+    const partition = snapshot.partitions.find((p) => p.yearCode.slice(0, 4) === normalizedYear);
+    if (!partition) return ok([]);
+
+    return ok(partition.values);
+  } catch (error) {
+    logger.error(
+      { rankingKey, yearCode, normType, error: error instanceof Error ? error.message : String(error) },
+      "readNormalizedRankingValuesFromR2: failed",
     );
     return err(error instanceof Error ? error : new Error(String(error)));
   }

--- a/packages/ranking/src/scripts/export-ranking-normalized-values-snapshots.ts
+++ b/packages/ranking/src/scripts/export-ranking-normalized-values-snapshots.ts
@@ -1,0 +1,38 @@
+#!/usr/bin/env tsx
+/**
+ * 正規化済み ranking_values snapshot を R2 に書き出す。
+ *
+ * Usage:
+ *   npx tsx -r ./packages/ranking/src/scripts/setup-cli.js \
+ *     packages/ranking/src/scripts/export-ranking-normalized-values-snapshots.ts
+ *
+ * Options (環境変数):
+ *   PARALLELISM=8                 # 並列書き込み数 (default 8)
+ *   RANKING_KEY_FILTER=foo-bar    # 特定 ranking_key だけ更新したい場合
+ *   NORM_TYPE_FILTER=per_population  # 特定 normType だけ更新したい場合
+ */
+
+import { exportRankingNormalizedValuesSnapshots } from "../exporters/ranking-normalized-values-snapshot";
+
+async function main() {
+  const parallelism = process.env.PARALLELISM
+    ? Number(process.env.PARALLELISM)
+    : undefined;
+  const rankingKeyFilter = process.env.RANKING_KEY_FILTER || undefined;
+  const normTypeFilter = process.env.NORM_TYPE_FILTER || undefined;
+
+  console.log("ranking_normalized_values snapshot を R2 に書き出します…");
+  const result = await exportRankingNormalizedValuesSnapshots({
+    parallelism,
+    rankingKeyFilter,
+    normTypeFilter,
+  });
+  console.log(
+    `✅ ranking_normalized_values: files=${result.files} skipped=${result.skipped} duration=${result.durationMs}ms`,
+  );
+}
+
+main().catch((err) => {
+  console.error("Fatal:", err);
+  process.exit(1);
+});

--- a/packages/ranking/src/services/compute-normalization.ts
+++ b/packages/ranking/src/services/compute-normalization.ts
@@ -8,7 +8,7 @@ import { computeCalculatedValues } from "../utils/compute-calculated-values";
 import { rankByValue } from "../utils/rank-by-value";
 
 // Well-known keys mapping
-const WELL_KNOWN_DENOMINATORS: Record<string, Record<string, string>> = {
+export const WELL_KNOWN_DENOMINATORS: Record<string, Record<string, string>> = {
   per_population: {
     prefecture: "total-population",
     city: "total-population",

--- a/packages/ranking/src/types/snapshot.ts
+++ b/packages/ranking/src/types/snapshot.ts
@@ -56,6 +56,20 @@ export function rankingValuesKeyPath(
   return `app/ranking/${encodeURIComponent(rankingKey)}/values.json`;
 }
 
+/**
+ * 正規化済みランキング値スナップショットの R2 キーパスを返す。
+ *
+ * normType: "per_population" → `app/ranking/{key}/values-per-population.json`
+ * normType: "per_area"       → `app/ranking/{key}/values-per-area.json`
+ */
+export function rankingNormalizedValuesKeyPath(
+  rankingKey: string,
+  normType: string,
+): string {
+  const suffix = normType.replace(/_/g, "-");
+  return `app/ranking/${encodeURIComponent(rankingKey)}/values-${suffix}.json`;
+}
+
 /** @deprecated rankingValuesKeyPath を使用してください */
 export interface RankingValuesPartitionSnapshot {
   generatedAt: string;


### PR DESCRIPTION
## Summary

- D1 解約後に `?norm=per_population` / `?norm=per_area` でデータが表示されない問題を修正
- `computeNormalization` の D1 依存を排除し、R2 事前計算済みスナップショットを使う設計に変更
- `/sync-snapshots` に `ranking-normalized-values` タスクを追加（1,470件 × 2種 = 2,940ファイル）
- URL `?year=&norm=` 同時指定時のクロージャ不一致バグを修正

## Test plan

- [ ] `https://stats47.jp/ranking/total-population?year=2021&norm=per_population` でデータが表示されること
- [ ] NormalizationToggle 切替後も URL に `norm` パラメータが保持されること
- [ ] 型チェック: `npx tsc --noEmit -p apps/web/tsconfig.json` がパスすること

🤖 Generated with [Claude Code](https://claude.com/claude-code)