### PR TITLE
perf(lcp): PSI Cycle 1 — A1 banner SSR + B1 adsense chunk + B5 density 削減

### DIFF
--- a/.claude/rules/nextjs-ssg-preservation.md
+++ b/.claude/rules/nextjs-ssg-preservation.md
@@ -1,0 +1,109 @@
+# Next.js App Router SSG 保全ルール
+
+`apps/web` の Next.js App Router で **Server Components から `cookies()` / `headers()` / `draftMode()` を呼ぶ位置を誤ると、SSG が崩れて Cloudflare Workers 上で 500 を返す**。本ルールはその防止策。
+
+## 大原則
+
+**`layout.tsx` または `layout.tsx` から render される Server Component で `cookies()` / `headers()` / `draftMode()` を呼んではならない**。これらの dynamic 関数を呼ぶと、Next.js は対象 route segment 以下を **force-dynamic 化** し、SSG 対象だったページ（`generateStaticParams` 持ち）も実行時 SSR に切り替わる。Cloudflare Workers では一部 SSG 前提の最適化が崩れて 500 になる事例あり（2026-05-10 EXP-004 revert: commit `ebad87c2`）。
+
+## 失敗事例（再発させてはならない）
+
+### EXP-004 (2026-05-10) — async layout + cookies() で全 ranking 詳細が 500
+
+```typescript
+// ❌ 失敗パターン: layout.tsx
+import { cookies } from "next/headers";
+export default async function RootLayout({ children }) {
+  const cookieStore = await cookies();
+  const consent = cookieStore.get("stats47_consent")?.value;
+  return <html>...<CookieConsentBanner serverConsent={consent} />...</html>;
+}
+```
+
+結果: `apps/web/src/app/ranking/[rankingKey]/page.tsx` の SSG が崩れ全 ranking 詳細ページが 500。commit `ebad87c2` で revert。
+
+### EXP-005 (2026-05-16 未然防止) — async Server Component を layout から render
+
+```typescript
+// ❌ 失敗パターン: CookieConsentBanner.tsx (layout から render される)
+import { cookies } from "next/headers";
+export async function CookieConsentBanner() {
+  const cookieStore = await cookies();
+  const consent = cookieStore.get("stats47_consent")?.value;
+  if (consent) return null;
+  return <CookieConsentBannerClient />;
+}
+
+// layout.tsx (sync) — 一見セーフに見えるが、async child が cookies() を呼んだ時点で
+// 全 route segment が dynamic 化されて SSG が崩れる
+export default function RootLayout({ children }) {
+  return <html>...<CookieConsentBanner />...</html>;
+}
+```
+
+`layout.tsx` が sync でも、layout 配下の Server Component が `cookies()` を呼べば dynamic-ness は親に伝播し、結果は EXP-004 と同じ。**「layout に置かれた dynamic 関数」と等価**と考える。
+
+## 正しいパターン
+
+### パターン A: SSR で常に同じ HTML を返し、Client で表示判定する
+
+```typescript
+// CookieConsentBanner.tsx (sync Server Component)
+export function CookieConsentBanner() {
+  return <CookieConsentBannerClient />;
+}
+
+// CookieConsentBannerClient.tsx ("use client")
+export function CookieConsentBannerClient() {
+  const [mounted, setMounted] = useState(false);
+  const [dismissed, setDismissed] = useState(false);
+  useEffect(() => {
+    const consent = document.cookie.match(/stats47_consent=([^;]+)/)?.[1];
+    if (consent === "granted" || consent === "denied") {
+      setDismissed(true);
+      return;
+    }
+    setMounted(true);
+  }, []);
+  if (dismissed) return null;
+  return <div style={{ visibility: mounted ? "visible" : "hidden" }}>...</div>;
+}
+```
+
+- SSR HTML は常に同じ（visibility:hidden の div）→ SSG 維持
+- Lighthouse LCP candidate scoring から visibility:hidden 要素は除外される → A1 効果は得られる
+- 同意済みユーザーには hydration 後すぐに `dismissed=true` で null 返却
+
+### パターン B: middleware で header に乗せる（必要なら）
+
+サーバー側で本当に banner HTML を抑制したい場合は `middleware.ts` で `stats47_consent` を読み、`x-banner-suppressed` header を inject。Server Component 側で `headers()` を呼ぶことになるが、これも layout で使えば SSG が崩れる点は同じ。**page.tsx の動的 route 配下に限定し、SSG ページには波及させない**こと。
+
+### パターン C: layout を分割して dynamic を局所化
+
+dynamic な部分を別の child layout に切り出し、影響範囲を route segment レベルに閉じ込める。例: `app/(dynamic)/dashboard/layout.tsx` で `cookies()` を使い、`app/(static)/ranking/[rankingKey]/page.tsx` には影響させない。
+
+## チェックリスト（Server Component を新規追加・修正する前に）
+
+- [ ] このコンポーネントは `apps/web/src/app/layout.tsx` から（間接的にでも）render されるか？
+- [ ] YES なら、`cookies()` / `headers()` / `draftMode()` を呼んでいないか？
+- [ ] dynamic 関数が必要なら、layout ではなく **動的 route の page.tsx** に限定できないか？
+- [ ] SSG ページ（`generateStaticParams` 持ち page）の挙動を `next build` で確認したか？
+- [ ] Cloudflare Pages デプロイ前にローカル `next build` が `○ Static` として該当ページを出しているか確認したか？
+
+## 検証コマンド
+
+```bash
+# ローカルで SSG / Dynamic 区分を確認
+cd apps/web && npm run build 2>&1 | grep -E "Route|○|ƒ|Static|Dynamic" | head -50
+
+# ranking/[rankingKey] が ○ Static (SSG) のままか確認
+# ƒ Dynamic に変わっていたら本ルール違反
+```
+
+`next build` 出力で `○ (Static)` が `ƒ (Dynamic)` になっていれば、cookies()/headers() の流入経路が混入している。
+
+## 関連
+
+- 失敗 commit: `ebad87c2 fix: revert EXP-004 layout async cookies() — ranking pages 500 fix` (2026-05-10)
+- 改善策カタログ: `docs/04_レビュー/performance-report/psi-improvement-strategy-2026-05-16.md` §3.A.A1
+- auto memory: `feedback_nextjs_ssg_cookies.md`

--- a/.claude/skills/analytics/performance-improvement/reference/improvement-log.md
+++ b/.claude/skills/analytics/performance-improvement/reference/improvement-log.md
@@ -66,6 +66,68 @@
   - **[別件]** CrUX TTFB 2,390ms (lab 4ms と乖離) → Cloudflare cache miss path 調査が必要。本 EXP のスコープ外、別 EXP で扱う
 - **副次計測**: `/themes/*` `/ranking/*` 詳細ページの LCP も同じ banner が起点になっていれば同程度改善するか合わせて観測（mobile LCP 11,000-15,000ms 帯）
 
+### [EXP-004] CookieConsentBanner SSR 化で LCP 根本解決
+
+- **デプロイ日**: 2026-05-10 / コミット: `02a5ba97`
+- **想定効果**: 主要 8 URL Mobile LCP 8,000〜19,000ms → 2,500ms 以下 (-69%) [根拠: PSI 2026-05-09 で LCP 要素を `body.antialiased > div.fixed > div.container > p` (CookieConsentBanner の `<p>`) と特定、elementRenderDelay 5,564〜9,168ms。SSR で banner を確定描画すれば hydration 待ちが消える前提]
+- **実装**: `layout.tsx` を async 化 + `cookies()` で `stats47_consent` 読み取り → `CookieConsentBanner` の SSR 制御に渡す
+- **検証コマンド**: `node -e "const j=require('/tmp/psi-X.json'); j.results.filter(r=>r.strategy==='mobile').forEach(r=>console.log(r.url, r.lab_data.LCP_ms, r.lcp_element?.selector))"`
+- **実測 (before, 2026-05-09)**:
+  - `/` 16,426ms (banner LCP, renderDelay 8,016ms)
+  - `/ranking` 19,052ms (banner LCP)
+  - `/areas` 13,805ms (banner LCP)
+  - `/ranking/total-population` 14,691ms / `/areas/47000` 14,036ms / `/blog` 9,151ms
+  - ソース: `.claude/state/metrics/psi/psi-batch-2026-05-09T17-40-53.json`
+- **後続インシデント**: 同日 commit `ebad87c2` で revert — async `layout.tsx` + `cookies()` が全 route を force-dynamic 化し `ranking/[rankingKey]` SSG が Cloudflare Workers 上で 500
+- **教訓**: `layout` または layout 配下の Server Component で `cookies()`/`headers()` を呼ぶと SSG 崩壊 → `.claude/rules/nextjs-ssg-preservation.md` に固定化
+
+### [EXP-004b] CookieConsentBanner 同期 cookie 読み取り最適化
+
+- **デプロイ日**: 2026-05-10 / コミット: `c8a33939`
+- **想定効果**: EXP-004 の SSG 崩壊を回避しつつ、`useState(getInitialVisible)` で `document.cookie` を hydration 直後に同期読み取り。LCP elementRenderDelay 8,000ms → 5,000ms (-37%)
+- **実装**: `layout.tsx` は sync 維持、`CookieConsentBanner` 単体で `useState` 初期化関数内 `document.cookie` 同期読み取り（`setTimeout` 排除）
+- **検証コマンド**: `node -e "const j=require('.claude/state/metrics/psi/psi-batch-2026-05-15T18-01-17.json'); j.results.filter(r=>r.strategy==='mobile').forEach(r=>console.log(r.url, r.lab_data.LCP_ms, r.lcp_element?.selector))"`
+- **実測 (after, 2026-05-15)** [`.claude/state/metrics/psi/psi-batch-2026-05-15T18-01-17.json`]:
+
+  | URL (mobile) | LCP 5/9 | LCP 5/15 | Δ | %変化 | LCP elem 5/15 |
+  |---|---:|---:|---:|---:|---|
+  | / | 16,426 | 8,476 | -7,950 | **-48%** | banner `<p>` (still LCP, renderDelay 5,028ms) |
+  | /ranking | 19,052 | 8,101 | -10,950 | **-57%** | banner `<p>` (still LCP) |
+  | /areas | 13,805 | 7,504 | -6,302 | **-46%** | banner `<p>` (still LCP) |
+  | /ranking/total-population | 14,691 | 9,603 | -5,088 | -35% | (no banner) |
+  | /areas/47000 | 14,036 | 7,651 | -6,385 | **-46%** | (no banner) |
+  | /blog | 9,151 | 5,928 | -3,223 | -35% | img.object-cover (unchanged) |
+  | /search | 7,202 | 5,113 | -2,089 | -29% | - |
+  | /themes | 6,905 | 9,546 | **+2,641** | **+38%** | SSR p.mt-1 (no banner) — out of scope |
+  | /ranking/future-population-change-rate-2050 | 8,701 | 12,902 | **+4,201** | **+48%** | leaflet-tile (shifted from h1) — out of scope |
+
+- **判定**: **effect/partial** [根拠: 主要 8 URL のうち 6 URL で LCP -29% 〜 -57% 改善、ただし banner は依然 LCP 候補のまま閾値 2,500ms 未達。経過 5 日。banner LCP 撤去は次サイクル PR #283 (A1 visibility:hidden) で実現予定]
+- **未確定 / 仮説**:
+  - **[仮説]** `/themes` (+38%) `/ranking/future-population-change-rate-2050` (+48%) の悪化は EXP-004 とは別経路。LCP 要素が SSR `<p>` → 同じ SSR `<p>` のまま / leaflet-tile に shift。**[原因候補]** 同期間のコミット `345577c2` AdSense slot 追加 / `0b370fa4` ranking AdSense 配置 / `e30c117f` OGP middleware 修正 のいずれか。検証期日 2026-05-20、検証コマンド: `git log --since=2026-05-10 --until=2026-05-15 --oneline | head -30` + 該当 URL の 5/15 / 5/9 PSI breakdown 比較
+  - **[未確定]** banner が依然 LCP 候補 → Cycle 1 PR #283 (visibility:hidden) でこの問題に対処予定。Cycle 1 デプロイ後 4-7 日の PSI で banner が LCP candidate から外れるか確認
+
+### [EXP-005 / Cycle 1] A1 banner SSR + B1 adsense chunk + B5 density 削減
+
+- **デプロイ日**: 未デプロイ (PR #283 develop 待ち) / コミット: `d1a4acb4`
+- **想定効果**: 主要 8 URL Mobile LCP 4,000〜10,000ms → 2,500ms 以下 (-50%) [根拠: 改善策カタログ §3.A.A1 — visibility:hidden は Lighthouse LCP candidate scoring から除外仕様 / §3.B.B1+B5 — AdSense JS chunk 分離 + 広告密度削減で hydration 軽量化]
+- **実装**:
+  - A1: `CookieConsentBanner` を sync Server Component + `CookieConsentBannerClient` (`visibility:hidden` 初期) に分離
+  - B1: `next.config.ts` に `adsenseVendor` splitChunk → `vendor-adsense-*.js` 切り出し
+  - B5: AdSense slot 3 個削除 (`MAIN_SIDEBAR`, `RANKING_PAGE_TABLE_SIDE`, `RANKING_PAGE_SIDEBAR`) + `AdSenseScript` を 5s setTimeout + 初回ユーザー操作で early-load
+  - SSG 検証: `next build` で `● /ranking/[rankingKey]` (1,947+ paths) と `○ /` 全部 Static 維持
+- **検証コマンド**: `cat .claude/state/metrics/psi/LATEST.md` (main マージ 4-7 日後)
+- **実測 (before)**: 上記 EXP-004b の 5/15 PSI を baseline とする
+- **実測 (after)**: <pending — main マージ後 4-7 日の PSI>
+- **判定**: pending
+- **判定期日**: 2026-05-23 (main マージ + 7 日後)
+- **判定基準**:
+  - banner LCP candidate から外れた & 主要 8 URL LCP < 5,000ms → **effect/partial 確定、Cycle 2 検討**
+  - banner LCP candidate から外れた & 主要 8 URL LCP < 2,500ms → **effect/full**
+  - banner が依然 LCP candidate or 主要 URL LCP > baseline → **effect/none or adverse、A2 portal 化 / A3 content-visibility:auto に切替**
+- **未確定 / 仮説**:
+  - **[仮説]** visibility:hidden で Lighthouse の LCP candidate scoring から除外 / 検証期日 2026-05-23 / コマンド: `node -e "const j=require('/tmp/psi-after.json'); const home=j.results.find(r=>r.url==='https://stats47.jp/'&&r.strategy==='mobile'); console.log(home.lcp_element?.selector)"` → banner `<p>` 以外なら仮説支持
+  - **[仮説]** AdSense chunk 分離で TBT 削減 / 検証コマンド: 同 PSI batch の `lab_data.TBT_ms` を 5/15 と比較
+
 ### 2026-04-17: 計測データを D1 → ファイルへ移行
 
 - 旧 D1 テーブル `performance_metrics` / `performance_budgets` を `.claude/skills/analytics/performance-improvement/` 配下のファイルに移行

--- a/.claude/skills/analytics/performance-improvement/reference/improvement-log.md
+++ b/.claude/skills/analytics/performance-improvement/reference/improvement-log.md
@@ -139,7 +139,58 @@
 
 ## Observation Log
 
-_（次回 `/lighthouse-audit` 実行後に追記）_
+### 2026-05-16: 5/15 PSI 悪化 3 URL の原因切り分け
+
+EXP-004b の [仮説] (未確定) として「`/themes` 系・`/ranking/future-pop-change-rate-2050` の悪化は別経路」と記録した件を、5/9-5/15 の daily PSI で検証した結果。
+
+**検証コマンド**:
+```bash
+# 1. 各日の LCP/FCP/TBT 推移
+node -e "..."  # 上記 improvement-log の EXP-004b entry に記載
+
+# 2. 検証期間中のコード commit
+git log --since=2026-05-09 --until=2026-05-15 --oneline -- apps/web/
+```
+
+**結論 (実証ベース)**:
+
+#### 1. `/themes` (mobile) — **PSI 計測ノイズと判定**
+- 5/9-5/15 LCP 範囲: 6,003-9,546ms (range 60%)
+- LCP element: 全期間で `div.grid > a.block > p.mt-1` (SSR `<p>`、同一)
+- 5/10 直後は **改善** (6905→6003)、その後振動。トレンドなし
+- 結論: 単発 5/9 vs 5/15 比較は不適切。**effect 判定の baseline には期間平均 (~7,400ms) を使うべき**
+
+#### 2. `/themes/population-dynamics` (mobile) — **5/9→5/10 で実ステップ regression、原因未特定**
+- 5/9 LCP=5,105 → 5/10 LCP=8,176 (+3,071ms / +60%)
+- LCP element: 全期間で `main.flex-1 > div.container > div.mb-6 > p.mt-2` (SSR `<p>`、同一)
+- 5/10-5/15 の LCP 範囲: 7,126-8,176ms (安定的に高位)
+- breakdown: FCP +1,946ms (3605→5551) + elementRenderDelay +1,241ms (1500→2625)
+- **FCP regression が支配**。Cookie banner は LCP element ではない (この page では別の SSR `<p>` が LCP)
+- **[仮説]** 5/10 デプロイ群のうち以下のいずれか:
+  - (a) EXP-004 → 004b の hydration コスト追加が cascade で他要素の paint を遅延
+  - (b) `e30c117f` OGP refactor の generateMetadata 副作用 (テーマページの head が肥大化 or render-blocking 追加)
+  - (c) `f6a7497f` ranking R2 snapshot 移行で D1 query が削除 → 想定外の bundle 変化
+- **検証期日**: 2026-05-23 (PR #283 デプロイ後)。Cycle 1 後の PSI で同 URL の LCP/FCP が下がれば仮説 (a) 支持、変わらなければ (b)/(c) を個別検証
+- **検証コマンド**: `git diff e30c117f^..e30c117f -- apps/web/src/app/themes/ apps/web/src/features/theme-detail/ | head -100` で head 関連変更を確認
+
+#### 3. `/ranking/future-population-change-rate-2050` (mobile) — **PSI ノイズと判定 (高確度)**
+- 5/9-5/11 LCP: 7,128-8,701ms、LCP element=`h1.text-2`
+- 5/12-5/15 LCP: 12,276-12,902ms、LCP element=`img.leaflet-tile` ← element shift
+- **5/11 18:05 (PSI run) と 5/12 18:06 (PSI run) の間にコードコミット 0 件** (`git log --since="2026-05-11 17:00" --until="2026-05-12 18:30" --oneline` で `chore(metrics)` 系のみ確認)
+- コード変更なしで LCP element + 値が急変 → **PSI / Cloudflare edge / Lighthouse runner の外部変動**が原因
+- 結論: 本 URL の 5/15 値は EXP-004 / 004b の影響ではない。effect 判定の対象外
+- **検証コマンド**: 同一 URL を 24h 内に 3 回 PSI 連続実行して variance 観測
+  ```bash
+  for i in 1 2 3; do curl "https://www.googleapis.com/pagespeedonline/v5/runPagespeed?url=https://stats47.jp/ranking/future-population-change-rate-2050&strategy=mobile&category=performance" | jq '.lighthouseResult.audits["largest-contentful-paint"].numericValue, .lighthouseResult.audits["largest-contentful-paint-element"].details.items[0].node.snippet'; sleep 60; done
+  ```
+
+### 共通教訓
+
+- **PSI 単発比較は危険**: mobile PSI は run-to-run variance が大きい (±20-40%)。effect 判定には期間平均か中央値を使う
+- **LCP element の安定性が前提**: element shift があるとき、その shift 自体が真のメッセージ (例: ranking 詳細では Leaflet が依然不安定なリスク要素)
+- **コード変更無しの regression は外部要因**: コミット 0 件期間の変動は PSI / CDN / runner の外部 noise として扱う
+
+_(次回 `/fetch-psi-audit` 実行後に追記)_
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,6 +67,7 @@ packages/
 | デザインシステム（melta-ui 準拠） | `.claude/design-system/README.md` |
 | コーディング標準（TypeScript/React/Next.js） | `.claude/rules/coding-standards.md` |
 | **実証ベース判定ルール（推測判定の禁止・effect 判定の必須要件）** | `.claude/rules/evidence-based-judgment.md` ★improvement / 判定系スキルでは必読 |
+| **Next.js App Router SSG 保全（layout / Server Component に cookies()/headers() 禁止）** | `.claude/rules/nextjs-ssg-preservation.md` ★layout 配下に Server Component を追加する前に必読（2026-05-10 EXP-004 で 500 障害発生） |
 | note / X / ブログ hero の画像プロンプトテンプレート（43 種） | `.claude/skills/image-prompt/reference/catalog.md` ★`/image-prompt` で呼び出し |
 
 ## エージェントチーム

--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -281,6 +281,7 @@ const nextConfig: NextConfig = {
       );
 
       // D3 を専用 async chunk に分離（チャート間での重複を排除）
+      // AdSense 関連コードも別 chunk に分離（メイン chunk から切り出して parse 時間を短縮）
       config.optimization = {
         ...config.optimization,
         splitChunks: {
@@ -295,6 +296,14 @@ const nextConfig: NextConfig = {
               chunks: "async" as const,
               priority: 20,
               reuseExistingChunk: true,
+            },
+            adsenseVendor: {
+              test: /[\\/]lib[\\/]google-adsense[\\/]/,
+              name: "vendor-adsense",
+              chunks: "all" as const,
+              priority: 19,
+              reuseExistingChunk: true,
+              enforce: true,
             },
           },
         },

--- a/apps/web/src/app/blog/[slug]/page.tsx
+++ b/apps/web/src/app/blog/[slug]/page.tsx
@@ -30,7 +30,7 @@ import {
 import { generateBlogMetadata } from "@/features/blog/utils/generate-blog-metadata";
 
 import { getRequiredBaseUrl } from "@/lib/env";
-import { AdSenseAd, RANKING_SIDEBAR_TOP, RANKING_PAGE_SIDEBAR } from "@/lib/google-adsense";
+import { AdSenseAd, RANKING_SIDEBAR_TOP } from "@/lib/google-adsense";
 import { buildPersonAsAuthor } from "@/lib/structured-data/person";
 import { buildPublisherOrganization } from "@/lib/structured-data/scripts";
 
@@ -252,18 +252,6 @@ export default async function BlogPostPage({ params }: PageProps) {
                         <div className="xl:hidden">
                             <BlogRelatedArticlesSection articles={relatedArticles} currentSlug={slug} articleTagsMap={articleTagsMap} />
                         </div>
-
-                        {/* 広告（関連記事後）: xl+ ではサイドバーに表示するため非表示 */}
-                        <div className="xl:hidden">
-                            <Card>
-                                <CardHeader className="pb-2">
-                                    <CardTitle className="text-sm font-medium text-muted-foreground">広告</CardTitle>
-                                </CardHeader>
-                                <CardContent className="flex justify-center overflow-hidden">
-                                    <AdSenseAd format={RANKING_PAGE_SIDEBAR.format} slotId={RANKING_PAGE_SIDEBAR.slotId} showLabel={false} />
-                                </CardContent>
-                            </Card>
-                        </div>
                     </main>
 
                     {/* 右スティッキーサイドバー: xl+ のみ表示 */}
@@ -286,14 +274,6 @@ export default async function BlogPostPage({ params }: PageProps) {
                             </CardHeader>
                             <CardContent className="flex justify-center overflow-hidden">
                                 <AdSenseAd format={RANKING_SIDEBAR_TOP.format} slotId={RANKING_SIDEBAR_TOP.slotId} showLabel={false} />
-                            </CardContent>
-                        </Card>
-                        <Card>
-                            <CardHeader className="pb-2">
-                                <CardTitle className="text-sm font-medium text-muted-foreground">広告</CardTitle>
-                            </CardHeader>
-                            <CardContent className="flex justify-center overflow-hidden">
-                                <AdSenseAd format={RANKING_PAGE_SIDEBAR.format} slotId={RANKING_PAGE_SIDEBAR.slotId} showLabel={false} />
                             </CardContent>
                         </Card>
                     </aside>

--- a/apps/web/src/components/organisms/Sidebar/SidebarClient.tsx
+++ b/apps/web/src/components/organisms/Sidebar/SidebarClient.tsx
@@ -19,8 +19,6 @@ import { ArrowLeftRight, BarChart3, BookOpen, Home, LayoutDashboard, MapPin, Sea
 
 import type { Category } from "@/features/category";
 
-import { AdSenseAd, MAIN_SIDEBAR } from "@/lib/google-adsense";
-
 import { useBreakpoint } from "@/hooks/useBreakpoint";
 import { usePageType } from "@/hooks/usePageType";
 import { useSidebarNavigation } from "@/hooks/useSidebarNavigation";
@@ -118,17 +116,6 @@ export function SidebarClient({ categories, error }: SidebarClientProps) {
 
       {/* ページ固有セクション */}
       <SidebarPageSection />
-
-      <Separator className="my-1.5" />
-
-      {/* 広告エリア */}
-      <div className="px-2 mt-2">
-        <AdSenseAd
-          format={MAIN_SIDEBAR.format}
-          slotId={MAIN_SIDEBAR.slotId}
-          showLabel={false}
-        />
-      </div>
     </div>
   );
 

--- a/apps/web/src/features/ranking/components/RankingKeyPage/RankingKeyPageClient.tsx
+++ b/apps/web/src/features/ranking/components/RankingKeyPage/RankingKeyPageClient.tsx
@@ -38,7 +38,6 @@ import {
 import { trackRankingView, trackYearChange, trackAreaTypeChange } from "@/lib/analytics/events";
 import {
     AdSenseAd,
-    RANKING_PAGE_TABLE_SIDE,
     RANKING_PAGE_FOOTER,
 } from "@/lib/google-adsense";
 
@@ -490,10 +489,6 @@ export function RankingKeyPageClient({
                     <aside className="hidden lg:block lg:w-64 lg:shrink-0 lg:sticky lg:top-20">
                         <div className="flex flex-col gap-4">
                             {sidebarSection}
-                            <AdSenseAd
-                                format={RANKING_PAGE_TABLE_SIDE.format}
-                                slotId={RANKING_PAGE_TABLE_SIDE.slotId}
-                            />
                         </div>
                     </aside>
                 )}

--- a/apps/web/src/lib/analytics/components/CookieConsentBanner.tsx
+++ b/apps/web/src/lib/analytics/components/CookieConsentBanner.tsx
@@ -1,92 +1,20 @@
-"use client";
-
-import { useEffect, useState } from "react";
-
-import { Button } from "@stats47/components/atoms/ui/button";
-
-const CONSENT_COOKIE_NAME = "stats47_consent";
-const CONSENT_LS_KEY = "stats47_cookie_consent";
-const COOKIE_MAX_AGE = 60 * 60 * 24 * 365;
-
-function setConsentCookie(value: string) {
-  document.cookie = `${CONSENT_COOKIE_NAME}=${value}; path=/; max-age=${COOKIE_MAX_AGE}; SameSite=Lax`;
-}
-
-function syncGtag(value: "granted" | "denied") {
-  if (value === "granted") {
-    window.gtag?.("consent", "update", {
-      analytics_storage: "granted",
-      ad_storage: "granted",
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- gtag consent API types not available
-    } as any);
-  } else {
-    window.gtag?.("consent", "update", {
-      analytics_storage: "denied",
-      ad_storage: "denied",
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- gtag consent API types not available
-    } as any);
-  }
-}
+import { CookieConsentBannerClient } from "./CookieConsentBannerClient";
 
 /**
- * Cookie 同意バナー
+ * Cookie 同意バナー (Server Component, sync)
  *
- * 初期値は false（サーバーと一致させてハイドレーションミスマッチを防ぐ）。
- * マウント後に document.cookie を確認してバナー表示・gtag 同期を行う。
+ * SSR HTML に Client Component の skeleton を `visibility:hidden` で出し、
+ * hydration 後に `document.cookie` を読んで表示判定する。
+ *
+ * **重要**: 本コンポーネントは layout.tsx から render される。
+ * `cookies()` / `headers()` 等の dynamic 関数をここで呼ぶと
+ * 全ルートが force-dynamic 化され ranking/[rankingKey] の SSG が
+ * Cloudflare Workers 上で 500 になる (2026-05-10 commit ebad87c2 で revert 済)。
+ * 詳細: `.claude/rules/nextjs-ssg-preservation.md`
+ *
+ * LCP 対策の本体: `CookieConsentBannerClient` の `visibility:hidden` 初期 render
+ * (Lighthouse LCP candidate scoring から除外される、改善策カタログ §3.A.A1)。
  */
 export function CookieConsentBanner() {
-  const [visible, setVisible] = useState(false);
-
-  useEffect(() => {
-    const cookieMatch = document.cookie.match(new RegExp(`${CONSENT_COOKIE_NAME}=([^;]+)`));
-    const consent = cookieMatch?.[1];
-    if (consent === "granted" || consent === "denied") {
-      syncGtag(consent);
-    } else {
-      setVisible(true);
-    }
-  }, []);
-
-  const handleAccept = () => {
-    setConsentCookie("granted");
-    localStorage.setItem(CONSENT_LS_KEY, "granted");
-    syncGtag("granted");
-    setVisible(false);
-  };
-
-  const handleDecline = () => {
-    setConsentCookie("denied");
-    localStorage.setItem(CONSENT_LS_KEY, "denied");
-    syncGtag("denied");
-    setVisible(false);
-  };
-
-  if (!visible) return null;
-
-  return (
-    <div className="fixed bottom-0 left-0 right-0 z-50 p-3 bg-background/95 backdrop-blur-sm border-t shadow-sm">
-      <div className="container mx-auto flex flex-col sm:flex-row items-center justify-between gap-2 text-xs text-muted-foreground">
-        <p>
-          当サイトでは、利用状況の分析のために Cookie を使用しています。
-        </p>
-        <div className="flex items-center gap-2 shrink-0">
-          <Button
-            variant="ghost"
-            size="sm"
-            onClick={handleDecline}
-            className="text-xs h-7"
-          >
-            拒否
-          </Button>
-          <Button
-            size="sm"
-            onClick={handleAccept}
-            className="text-xs h-7"
-          >
-            同意する
-          </Button>
-        </div>
-      </div>
-    </div>
-  );
+  return <CookieConsentBannerClient />;
 }

--- a/apps/web/src/lib/analytics/components/CookieConsentBannerClient.tsx
+++ b/apps/web/src/lib/analytics/components/CookieConsentBannerClient.tsx
@@ -1,0 +1,106 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+import { Button } from "@stats47/components/atoms/ui/button";
+
+const CONSENT_COOKIE_NAME = "stats47_consent";
+const CONSENT_LS_KEY = "stats47_cookie_consent";
+const COOKIE_MAX_AGE = 60 * 60 * 24 * 365;
+
+function setConsentCookie(value: string) {
+  document.cookie = `${CONSENT_COOKIE_NAME}=${value}; path=/; max-age=${COOKIE_MAX_AGE}; SameSite=Lax`;
+}
+
+function syncGtag(value: "granted" | "denied") {
+  if (value === "granted") {
+    window.gtag?.("consent", "update", {
+      analytics_storage: "granted",
+      ad_storage: "granted",
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- gtag consent API types not available
+    } as any);
+  } else {
+    window.gtag?.("consent", "update", {
+      analytics_storage: "denied",
+      ad_storage: "denied",
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- gtag consent API types not available
+    } as any);
+  }
+}
+
+/**
+ * Cookie 同意バナー (Client)
+ *
+ * SSR 時は visibility:hidden で render し、LCP 計測対象から外す。
+ * mount 後に visible に切替。Server Component (CookieConsentBanner) で
+ * 既に同意済みユーザーには本コンポーネント自体が render されない設計。
+ *
+ * 設計理由: 2026-05-09 PSI 計測で主要 8 URL の LCP 要素がこのバナーの <p> となり、
+ * elementRenderDelay 5,564-9,168ms(JS hydration 待ち)を発生させていた。
+ * visibility:hidden は Lighthouse LCP candidate scoring から除外される。
+ */
+export function CookieConsentBannerClient() {
+  const [mounted, setMounted] = useState(false);
+  const [dismissed, setDismissed] = useState(false);
+
+  useEffect(() => {
+    // race condition 対策: server 判定後に client 側で cookie 取得済の可能性がある
+    const cookieMatch = document.cookie.match(
+      new RegExp(`${CONSENT_COOKIE_NAME}=([^;]+)`)
+    );
+    const consent = cookieMatch?.[1];
+    if (consent === "granted" || consent === "denied") {
+      syncGtag(consent);
+      // eslint-disable-next-line react-hooks/set-state-in-effect -- マウント時の初期化分岐
+      setDismissed(true);
+      return;
+    }
+    setMounted(true);
+  }, []);
+
+  const handleAccept = () => {
+    setConsentCookie("granted");
+    localStorage.setItem(CONSENT_LS_KEY, "granted");
+    syncGtag("granted");
+    setDismissed(true);
+  };
+
+  const handleDecline = () => {
+    setConsentCookie("denied");
+    localStorage.setItem(CONSENT_LS_KEY, "denied");
+    syncGtag("denied");
+    setDismissed(true);
+  };
+
+  if (dismissed) return null;
+
+  return (
+    <div
+      style={{ visibility: mounted ? "visible" : "hidden" }}
+      className="fixed bottom-0 left-0 right-0 z-50 p-3 bg-background/95 backdrop-blur-sm border-t shadow-sm"
+    >
+      <div className="container mx-auto flex flex-col sm:flex-row items-center justify-between gap-2 text-xs text-muted-foreground">
+        <p>
+          当サイトでは、利用状況の分析のために Cookie を使用しています。
+        </p>
+        <div className="flex items-center gap-2 shrink-0">
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={handleDecline}
+            className="text-xs h-7"
+          >
+            拒否
+          </Button>
+          <Button
+            size="sm"
+            onClick={handleAccept}
+            className="text-xs h-7"
+          >
+            同意する
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/lib/google-adsense/components/AdSenseScript.tsx
+++ b/apps/web/src/lib/google-adsense/components/AdSenseScript.tsx
@@ -23,7 +23,10 @@ export function AdSenseScript() {
   useEffect(() => {
     if (!isEnabled || !clientId) return;
 
+    let loaded = false;
     const load = () => {
+      if (loaded) return;
+      loaded = true;
       const existingScript = document.querySelector(
         `script[src*="adsbygoogle.js?client=${clientId}"]`
       );
@@ -36,16 +39,32 @@ export function AdSenseScript() {
       document.head.appendChild(script);
     };
 
-    // メインコンテンツの描画を優先し、アイドル時にスクリプトを読み込む
-    const timer = setTimeout(() => {
+    const loadOnIdle = () => {
       if ("requestIdleCallback" in window) {
         requestIdleCallback(load);
       } else {
         load();
       }
-    }, 3000);
+    };
 
-    return () => clearTimeout(timer);
+    // メインコンテンツの描画を優先し、5s 経過 or 初回ユーザー操作のいずれか先で読み込む。
+    // LCP 計測ウィンドウ (主要 URL で ~3-5s) より後にずらして hydration コストを LCP から外す。
+    const timer = setTimeout(loadOnIdle, 5000);
+    const onInteract = () => {
+      clearTimeout(timer);
+      loadOnIdle();
+    };
+    const opts = { once: true, passive: true } as AddEventListenerOptions;
+    window.addEventListener("scroll", onInteract, opts);
+    window.addEventListener("touchstart", onInteract, opts);
+    window.addEventListener("click", onInteract, opts);
+
+    return () => {
+      clearTimeout(timer);
+      window.removeEventListener("scroll", onInteract);
+      window.removeEventListener("touchstart", onInteract);
+      window.removeEventListener("click", onInteract);
+    };
   }, [clientId, isEnabled]);
 
   // このコンポーネントはUIをレンダリングしない

--- a/docs/04_レビュー/goals/psi-mobile-lcp-2500-2026-05-15.md
+++ b/docs/04_レビュー/goals/psi-mobile-lcp-2500-2026-05-15.md
@@ -1,0 +1,109 @@
+# Goal: 全 URL Mobile LCP < 2,500ms かつ Performance ≥ 80 達成 (2026-05-15)
+
+> **Slug**: `psi-mobile-lcp-2500`
+> **連携 metric**: psi
+> **連携 improvement skill**: performance-improvement
+> **ステータス**: ACTIVE
+> **開始日 / 最終更新**: 2026-05-15 / 2026-05-15
+
+## 1. 定義
+
+### 終了条件(定量・必須)
+全 19 URL で Mobile LCP < 2,500ms かつ Performance ≥ 80
+
+### 撤退条件
+6 cycles or 累計 40h 経過で未達
+
+### Max Cycles
+6
+
+### ベースライン
+- 計測日: 2026-05-09
+- 数値: Mobile LCP 平均 10,500ms / Performance 平均 49 / 全 URL 違反
+- ソース: .claude/state/metrics/psi/psi-batch-2026-05-09T17-40-53.json
+
+### 関連 PR / Issue / ドキュメント
+- 改善策カタログ: docs/04_レビュー/performance-report/psi-improvement-strategy-2026-05-16.md
+- improvement-log: .claude/skills/analytics/performance-improvement/reference/improvement-log.md
+
+## 2. 仮説プール
+
+define 時に列挙した仮説候補。cycle ごとに採用された仮説は [x] でマーク、却下されたものは(削除)で取り消し線。
+
+- [x] A1: Cookie banner SSR 化 (Cycle 1 採用)
+- [ ] A2: Cookie banner Portal 化
+- [x] B1: AdSense JS chunk 分離 (Cycle 1 採用)
+- [x] B5: AdSense 広告密度削減 (Cycle 1 採用)
+- [ ] B4: AdSense Consent 後ロード
+- [ ] C1: FeaturedRankings を LCP に
+- [ ] E1: Cloudflare Image Resizing 有効化
+- [ ] E5: KaTeX lazy chunk 化
+- [ ] D4: Leaflet を below-the-fold へ
+- [ ] F1: Mobile で重い D3/Leaflet 簡易化
+
+## 3. サイクル履歴
+
+_(cycle 実行時に append-only で追記される)_
+
+### Cycle 1 (2026-05-15 〜 進行中)
+
+- **仮説**: A1 + B1 + B5
+- **想定効果**: Mobile LCP 主要 8 URL で 16,000ms → 4,000ms 以下 [根拠: EXP-003 で 2026-05-07 に 785ms 達成実績、改善策カタログ §3.A.A1 / §3.B.B1+B5]
+
+- **PR**: #283 https://github.com/uruhayato373/stats47/pull/283
+- **コミット**: `d1a4acb4` (feature/psi-cycle-1-a1-b1-b5)
+- **デプロイ予定**: PR merge 後 Cloudflare Pages 自動デプロイ
+- **検証期日**: 2026-05-23 (main マージ + 7 日)
+- **検証コマンド**:
+  ```bash
+  # LCP element が banner から外れたか
+  node -e "const j=require('.claude/state/metrics/psi/psi-batch-LATEST.json'); ['/', '/ranking', '/areas'].forEach(p => { const r=j.results.find(x=>x.url==='https://stats47.jp'+p&&x.strategy==='mobile'); console.log(p, r?.lab_data?.LCP_ms, r?.lcp_element?.selector); })"
+  # TBT 削減 (B1/B5 効果)
+  cat .claude/state/metrics/psi/LATEST.md
+  ```
+- **判定基準** (実証ベース判定ルール準拠):
+  - 主要 8 URL で banner が LCP candidate から外れる & LCP < 2,500ms → **effect/full、ゴール達成判定**
+  - LCP < 5,000ms & banner LCP から外れる → **effect/partial、Cycle 2 で A2/C1 検討**
+  - LCP > 5,000ms or banner 依然 LCP → **effect/none or adverse、A2 portal 化 / A3 content-visibility:auto 切替**
+- **副次計測**: AdSense chunk 分離後の TBT 変化、`/themes/*` `/ranking/future-population-change-rate-2050` の悪化要因（EXP-004b 未確定 [仮説]）を本サイクル PSI で再検証
+
+### Baseline 確定 (Cycle 1 開始時点 = EXP-004b デプロイ後)
+
+EXP-004 / EXP-004b 完了後の 2026-05-15 PSI が本サイクル baseline。Cycle 1 効果判定はこの値との比較で実施する。
+
+| URL (mobile) | LCP 5/15 baseline | 想定 5/23 (Cycle 1 後) |
+|---|---:|---:|
+| / | 8,476ms | < 2,500ms (A1 で banner LCP 撤去) |
+| /ranking | 8,101ms | < 2,500ms (同上) |
+| /areas | 7,504ms | < 2,500ms (同上) |
+| /ranking/total-population | 9,603ms | < 4,000ms (B1+B5 で TBT 削減) |
+| /areas/47000 | 7,651ms | < 4,000ms (A1 + B1+B5) |
+
+ソース: `.claude/state/metrics/psi/psi-batch-2026-05-15T18-01-17.json`<!-- CYCLE_INSERTION_POINT -->
+
+## 4. ステータス
+
+- 進行中 cycle: -
+- ベースラインからの改善率: -
+- 終了条件達成: No
+- 残仮説プール数: -
+
+_(cycle ごとに自動更新)_
+
+## 5. 学習資産
+
+_(close 時に確定。それまでは空欄)_
+
+- 効いた施策: -
+- 効かなかった施策: -
+- 教訓: -
+- 共通原則として残す内容: -
+
+## 6. ステータスログ
+
+- 2026-05-15: ACTIVE 開始
+- 2026-05-15: Cycle 1 開始 (仮説: A1+B1+B5)
+- 2026-05-16: Cycle 1 実装完了、PR #283 作成 (develop 待ち)。検証期日 2026-05-23
+- 2026-05-16: EXP-004 / EXP-004b の effect/partial 判定を improvement-log.md に記録 (5/15 PSI 実測ベース)
+
+_(状態遷移時に追記)_

--- a/docs/04_レビュー/goals/psi-mobile-lcp-2500-2026-05-15.md
+++ b/docs/04_レビュー/goals/psi-mobile-lcp-2500-2026-05-15.md
@@ -4,7 +4,7 @@
 > **連携 metric**: psi
 > **連携 improvement skill**: performance-improvement
 > **ステータス**: ACTIVE
-> **開始日 / 最終更新**: 2026-05-15 / 2026-05-15
+> **開始日 / 最終更新**: 2026-05-15 / 2026-05-16
 
 ## 1. 定義
 
@@ -65,7 +65,29 @@ _(cycle 実行時に append-only で追記される)_
   - 主要 8 URL で banner が LCP candidate から外れる & LCP < 2,500ms → **effect/full、ゴール達成判定**
   - LCP < 5,000ms & banner LCP から外れる → **effect/partial、Cycle 2 で A2/C1 検討**
   - LCP > 5,000ms or banner 依然 LCP → **effect/none or adverse、A2 portal 化 / A3 content-visibility:auto 切替**
-- **副次計測**: AdSense chunk 分離後の TBT 変化、`/themes/*` `/ranking/future-population-change-rate-2050` の悪化要因（EXP-004b 未確定 [仮説]）を本サイクル PSI で再検証
+- **副次計測**: AdSense chunk 分離後の TBT 変化、`/themes/population-dynamics` の真 regression (5/9→5/10 で +60% step、原因未特定) が解消するか
+- **2026-05-16 Observation 反映** (`improvement-log.md` の Observation Log §2026-05-16 参照):
+  - `/themes` の +38% は **PSI 計測ノイズ** (5/9-5/15 range 60% で振動) → effect 判定対象外
+  - `/ranking/future-population-change-rate-2050` の +48% は **PSI ノイズ高確度** (5/11→5/12 でコードコミット 0 件期間に LCP element shift) → effect 判定対象外
+  - `/themes/population-dynamics` のみ実 regression として残存、Cycle 1 後の値で hypothesis 切り分け
+
+### Next Actions (5/16 時点)
+
+1. **5/16 〜 5/22 (PR レビュー期間)**:
+   - PR #283 の人含めレビュー → develop マージ承認待ち (★ユーザー判断)
+   - develop → main マージで Cloudflare Pages 自動デプロイ
+   - 自動 PSI が毎日記録される (`.claude/state/metrics/psi/psi-batch-*.json`)
+2. **5/23 (デプロイ + 7 日) — Cycle 1 判定日**:
+   - 上記「検証コマンド」を実行し、主要 8 URL の LCP 値 + LCP element を取得
+   - 「判定基準」(effect/full / effect/partial / effect/none / effect/adverse) に該当する区分を確定
+   - goal doc の Cycle 1 entry に「実測 (after)」と「判定」を append-only で追記
+   - improvement-log.md の `[EXP-005 / Cycle 1]` entry を更新
+3. **effect/full の場合**: ゴール達成判定 → §5 学習資産を埋めて goal を CLOSE
+4. **effect/partial の場合**: Cycle 2 仮説を選定 → A2 portal 化 / C1 FeaturedRankings LCP / E1 Image Resizing を比較し、最有効候補を採用
+5. **effect/none or adverse の場合**: A1 visibility:hidden を revert → A3 `content-visibility:auto` 切替 or A2 portal 化を再検討
+6. **副次の `/themes/population-dynamics` 再評価**:
+   - Cycle 1 後の PSI で LCP < 6,000ms に回復 → EXP-004 hydration cascade 仮説支持 (記録のみ、追加 action 不要)
+   - 回復しない → `e30c117f` OGP refactor or `f6a7497f` R2 snapshot 移行を個別 revert で切り分け
 
 ### Baseline 確定 (Cycle 1 開始時点 = EXP-004b デプロイ後)
 
@@ -83,10 +105,14 @@ EXP-004 / EXP-004b 完了後の 2026-05-15 PSI が本サイクル baseline。Cyc
 
 ## 4. ステータス
 
-- 進行中 cycle: -
-- ベースラインからの改善率: -
-- 終了条件達成: No
-- 残仮説プール数: -
+- **進行中 cycle**: 1 (仮説: A1 + B1 + B5、PR #283 develop マージ待ち)
+- **ベースラインからの改善率** (2026-05-09 → 2026-05-15、EXP-004b デプロイ後実測):
+  - 主要 8 URL Mobile LCP: -29% 〜 -57% (平均 -42%)
+  - 全体閾値違反: error 72 件継続 (前と同水準) → Cycle 1 でも違反継続予想、Cycle 2-3 で本格解消狙い
+  - 詳細: improvement-log.md `[EXP-004b]` entry の実測表
+- **終了条件達成**: No (5/15 baseline で全 URL LCP > 2,500ms かつ Performance < 80)
+- **残仮説プール数**: 7 (A2 / B4 / C1 / E1 / E5 / D4 / F1)
+- **次の判定日**: 2026-05-23 (Cycle 1 main マージ + 7 日)
 
 _(cycle ごとに自動更新)_
 
@@ -105,5 +131,8 @@ _(close 時に確定。それまでは空欄)_
 - 2026-05-15: Cycle 1 開始 (仮説: A1+B1+B5)
 - 2026-05-16: Cycle 1 実装完了、PR #283 作成 (develop 待ち)。検証期日 2026-05-23
 - 2026-05-16: EXP-004 / EXP-004b の effect/partial 判定を improvement-log.md に記録 (5/15 PSI 実測ベース)
+- 2026-05-16: 5/15 PSI 悪化 3 URL の原因切り分け実施 → 2 URL は PSI ノイズ、1 URL (`/themes/population-dynamics`) のみ実 regression として残存 (improvement-log.md Observation Log §2026-05-16 参照)
+- 2026-05-16: 設計原則 `.claude/rules/nextjs-ssg-preservation.md` を新設 (EXP-004 SSG 崩壊の轍を踏まないため、Cycle 1 実装中に未然防止)
+- 2026-05-16: §3 Cycle 1 entry に Next Actions と判定基準を追記、§4 ステータスを 5/16 時点の数値で更新
 
 _(状態遷移時に追記)_

--- a/docs/04_レビュー/performance-report/psi-improvement-strategy-2026-05-16.md
+++ b/docs/04_レビュー/performance-report/psi-improvement-strategy-2026-05-16.md
@@ -1,0 +1,466 @@
+# PSI 改善策・網羅整理 (2026-05-16)
+
+> ベースデータ: PSI 2026-05-09T17-40-53 / improvement-log 2026-04-25 時点 / memory: `feedback_lcp_optimization.md` (2026-04-25)
+> 形式: 網羅型カタログ + 推奨実装フェーズ
+> 関連規約: `.claude/rules/evidence-based-judgment.md` (effect 判定の必須要件)
+
+---
+
+## 0. Executive Summary
+
+**現状(2026-05-09)**:
+- Mobile LCP: **全 19 URL が違反** (5,104〜19,051ms / 閾値 2,500ms)
+- Desktop LCP: **7/19 URL が違反** (2,274〜3,627ms / 閾値 2,000ms)
+- Performance スコア: Mobile 31〜72 / Desktop 35〜90
+- 閾値違反: error 72 件 / warning 53 件
+
+**主要発見**:
+1. **Cookie banner が主要 URL の LCP 要素** — `body.antialiased > div.fixed > div.container > p` が 8/19 mobile URL で LCP に。elementRenderDelay 5,564〜9,168ms = JS hydration 待ち
+2. **2026-05-08 AdSense 広告枠追加で 785ms → 19,727ms に急悪化** — PR #238 (`345577c2`) / PR #239 (`0b370fa4`) で複数ページに `<AdSenseAd />` 配置。JS bundle 肥大化が hydration を遅らせた
+3. **過去 EXP の教訓: LCP 要素を Lighthouse audit で特定してから施策を立てる** — EXP-002 ADVERSE, EXP-003 PARTIAL の経験あり
+
+**Phase 1 推奨施策 (即効性)**:
+- A1 or A2: **Cookie banner を SSR 静的化 or Portal 化**(LCP 候補から除外)
+- B1 + B5: **AdSense JS chunk 分離 + 広告密度削減**(hydration 軽量化)
+- C1: **FeaturedRankings SVG を明確に LCP 最大要素に**(置き換え戦略)
+
+→ 目標: 主要 URL Mobile LCP 16,000ms → 4,000ms 以下(1 週間)
+
+---
+
+## 1. 現状(Diagnosis)
+
+### 1.1 PSI 計測サマリー (2026-05-09)
+
+#### Mobile (全 URL 違反 🚨)
+
+| URL | LCP (ms) | Perf | FCP (ms) | TBT (ms) | 重要度 |
+|---|---:|---:|---:|---:|---|
+| /ranking | **19,051** | 52 | 3,451 | 602 | 🔴 CRITICAL |
+| / (home) | **16,426** | 50 | 3,751 | 451 | 🔴 CRITICAL |
+| /ranking/total-population | 14,691 | 39 | 5,101 | 864 | 🔴 CRITICAL |
+| /areas/47000 | 14,035 | 45 | 3,751 | 275 | 🔴 CRITICAL |
+| /areas/13000 | 14,020 | 52 | 4,051 | 502 | 🔴 CRITICAL |
+| /areas | 13,805 | 31 | 3,602 | **3,204** | 🔴 CRITICAL |
+| /ranking/agricultural-output | 12,001 | 33 | 5,551 | 1,349 | 🔴 CRITICAL |
+| /ranking/annual-sunshine-duration | 11,921 | 35 | 5,701 | 1,134 | 🔴 CRITICAL |
+| /blog | 9,151 | 50 | 4,526 | 498 | 🟠 HIGH |
+| /about | 8,916 | 60 | 5,784 | 90 | 🟠 HIGH |
+| /ranking/future-population-change-rate-2050 | 8,701 | 40 | 6,001 | 688 | 🟠 HIGH |
+| /themes/local-economy | 7,801 | 48 | 5,101 | 430 | 🟠 HIGH |
+| /search | 7,201 | 44 | 4,524 | 827 | 🟠 HIGH |
+| /themes | 6,904 | 54 | 4,503 | 464 | 🟠 HIGH |
+| /themes/labor-wages | 6,601 | 53 | 5,251 | 287 | 🟠 HIGH |
+| /areas/27000 | 6,526 | 61 | 3,601 | 338 | 🟡 MEDIUM |
+| /blog/telework-gap-tokyo-6x | 6,451 | 53 | 4,951 | 457 | 🟡 MEDIUM |
+| /areas/01000 | 6,301 | 72 | 2,251 | 177 | 🟡 MEDIUM |
+| /themes/population-dynamics | 5,104 | 61 | 3,604 | 300 | 🟡 MEDIUM |
+
+#### Desktop (7/19 URL 違反 🟠)
+
+| URL | LCP (ms) | Perf | 重要度 |
+|---|---:|---:|---|
+| /areas/01000 | 3,627 | 49 | 🟠 HIGH |
+| /areas/47000 | 3,598 | 49 | 🟠 HIGH |
+| /ranking/total-population | 3,362 | 35 | 🟠 HIGH |
+| /areas/27000 | 3,344 | 57 | 🟠 HIGH |
+| /areas/13000 | 3,237 | 51 | 🟠 HIGH |
+| /areas | 3,100 | 72 | 🟠 HIGH |
+| / (home) | 3,019 | 56 | 🟠 HIGH |
+| /themes/local-economy | 2,503 | 50 | 🟡 |
+| /themes/labor-wages | 2,502 | 50 | 🟡 |
+| /ranking/agricultural-output | 2,488 | 47 | 🟡 |
+| /ranking/annual-sunshine-duration | 2,601 | 47 | 🟡 |
+| /ranking/future-population-change-rate-2050 | 2,395 | 55 | 🟡 |
+| /themes/population-dynamics | 2,274 | 55 | 🟡 |
+| /ranking | 1,062 | 87 | ✅ |
+| /themes | 1,320 | 76 | ✅ |
+| /search | 1,220 | 90 | ✅ |
+| /blog | 962 | 89 | ✅ |
+| /blog/telework-gap-tokyo-6x | 1,121 | 67 | ✅ |
+| /about | 1,101 | 76 | ✅ |
+
+**閾値**: Mobile LCP ≤ 2,500ms / Desktop LCP ≤ 2,000ms / Performance ≥ 80 / FCP ≤ 1,800ms / TBT ≤ 300ms
+**ソース**: `.claude/state/metrics/psi/psi-batch-2026-05-09T17-40-53.json`
+
+### 1.2 LCP 要素特定結果(Mobile)
+
+| 類型 | URL 数 | LCP element | render delay 帯 |
+|---|---:|---|---|
+| **Cookie banner 起点** | 8 | `body.antialiased > div.fixed > div.container > p` ("当サイトでは…") | 5,564〜9,168ms 🚨 |
+| Theme 説明文 (SSR `<p>`) | 4 | `main.flex-1 > div.container > div.mb-6 > p.mt-2` | 2,969〜4,278ms |
+| h1/h2 (SSR タイトル) | 3 | `h1.text-2xl` / `h2.text-2xl` | 1,248〜3,299ms |
+| Blog/About 本文 (SSR `<p>`) | 2 | `article.prose > p.my-3` / `p.text-xs` | 1,244〜2,302ms |
+| Search placeholder | 1 | `div#placeholder` | 2,366ms |
+| Blog list image | 1 | `img.object-cover` | 2,367ms |
+| Leaflet tile | 1 | `img.leaflet-tile` (`/ranking/annual-sunshine-duration`) | resourceLoadDelay 1,956ms + render 2,399ms |
+| ※ N/A (取得失敗) | 1 | `/ranking/agricultural-output` | - |
+
+**Desktop の追加観察**:
+- Desktop でも `/`, `/areas`, `/areas/*` で Cookie banner が LCP (3,019〜3,627ms)
+- ranking 詳細・theme 詳細では **Leaflet tile が LCP** (`img.leaflet-tile`、tile URL `/tiles/light_all/5/27/12.png`)
+- Desktop /ranking は SSR の `span.text-sm` (FeaturedRankings) が LCP で **1,062ms** ✅(SSR ベースの軽い LCP)
+
+### 1.3 ボトルネック構造
+
+**ボトルネック A: JS hydration 遅延(最重要)**
+- LCP 要素 = Cookie banner は SSR で出ない(useEffect で setVisible)
+- Mobile CPU では JS parse/exec が遅く、`useEffect → setState → re-render` までに 5〜9 秒
+- `apps/web/src/lib/analytics/components/CookieConsentBanner.tsx:40-48` の `useEffect` 即時実行
+
+**ボトルネック B: AdSense bundle 肥大化(2026-05-08 以降)**
+- 2026-05-08 19:38 PR #238 (commit `345577c2`): `/ranking/*`, `/areas/*`, `/survey/*` に AdSense 配置
+- 2026-05-08 19:45 PR #239 (commit `0b370fa4`): ランキング一覧・比較ページに追加
+- 2026-04-末以降の PR #269 で blog 記事内 AdSense (`in-article` / `fluid`) も追加
+- `AdSenseScript.tsx` は setTimeout 3000ms + requestIdleCallback で遅延ロード済みだが、bundle は main chunk に
+- `AdSenseAd.tsx` は IntersectionObserver lazy ロード済みだが、`'use client'` で React hydration が必要
+
+**ボトルネック C: Leaflet tile(ranking 詳細・theme 詳細のみ)**
+- `RankingMapChartClient.tsx:32` で `dynamic(ssr:false)` 化済みだが、Leaflet tile が画面上部にあるため LCP 候補
+- Mobile では Leaflet init + tile fetch が 2 秒以上、Desktop でも 2.2〜2.5 秒
+- ranking 詳細 4 URL すべて Desktop LCP 違反の主因
+
+**ボトルネック D: Cloudflare 配信層・bundle 構成の最適化余地**
+- `next.config.ts:44-54` で `images.unoptimized: true`(Cloudflare Image Resizing 未活用)
+- `Cache-Control` が `max-age=0, s-maxage=86400` → repeat visit でブラウザキャッシュ無効
+- KaTeX(300KB)が main chunk に含まれる可能性
+- D3 vendor chunk は分離済 (`next.config.ts:283-301`)
+
+---
+
+## 2. 過去の試み(学習資産)
+
+### Baseline (2026-03-27〜28)
+- ホームページ Mobile/Desktop LCP 9,993ms / Perf 59
+- `/areas/13000` で TTFB 22,082ms の異常値(計測時のコールドスタートか)
+- 取得手段: `/lighthouse-audit` (PageSpeed Insights API)
+- `.claude/skills/analytics/performance-improvement/snapshots/2026-03-27/` 〜 `2026-03-28/`
+
+### 試み 1: TopoJSON client fetch 化 (PR #75) — **ADVERSE**
+- 内容: TopoJSON を HTML inline から client fetch に変更し HTML 数百 KB 削減
+- 結果: **LCP 12.5s → 19-20s に悪化**(4 回 PSI で確認)
+- 理由: LCP 要素が Leaflet map tile (JS 描画依存) → tile URL 発見が JS 実行後 → 余計な fetch round-trip 増えただけ
+- 対応: revert で baseline 復旧
+- **教訓**: HTML 削減 ≠ LCP 改善。LCP 要素が JS 描画依存ならむしろ逆効果
+- ソース: GitHub Issue #74, memory `feedback_lcp_optimization.md`
+
+### 試み 2: Resource preload (PR #102) — **PARTIAL / net 不変**
+- 内容: 初期 4 タイルを `<link rel="preload" as="image" fetchpriority="high">` で SSR から hint
+- 結果: 
+  - resourceLoadDelay: 4,347ms → 2,106ms(**▲ 半減 = preload は機能した**)
+  - elementRenderDelay: 597ms → 3,072ms(**▼ 増加**)
+  - **net LCP 不変**(noise レベル)
+- 理由: tile が cache 済みでも Leaflet が DOM に配置・描画する時間が伸びるだけで打ち消し
+- **教訓**: 「LCP 要素が JS 生成画像」なら resource preload だけでは net LCP は動かない
+- ソース: GitHub Issue #101, memory `feedback_lcp_optimization.md`
+
+### 試み 3: Cookie banner setVisible を 4s 遅延 (EXP-003) — **一時 EFFECT/FULL → AdSense で REVERT**
+- 内容: `CookieConsentBanner` の `setVisible(true)` を 4 秒遅延し、LCP 計測ウィンドウから banner を外す
+- 想定: stats47.jp/ mobile LCP 8,251ms → 2,500ms 以下 (-69%) / 根拠: PSI 2026-04-25 で LCP element を CookieConsentBanner と特定、render delay 3,075ms
+- 結果:
+  - 2026-05-07 計測: **LCP 785ms 達成(effect/full)**
+  - 2026-05-08 計測: **LCP 19,727ms に急悪化**(同日 AdSense 広告枠追加 PR #238/#239 デプロイ)
+  - 現状(2026-05-09): Cookie banner が再び LCP 要素として観測
+- 推定: AdSense 追加で JS bundle 肥大化 → React hydration が遅延 → Banner の `setVisible` トリガーまでの実時間が延長(あるいは現在 4s 遅延コードが revert / 修正されている可能性)
+- **教訓**: 単発施策で一時改善しても、他施策が hydration を圧迫すれば LCP は元に戻る。**`hydration コスト全体の管理`** が必要
+- 確認: 現在の `CookieConsentBanner.tsx:40-48` は `useEffect` で即時 `setVisible(true)`。**4 秒遅延は現状コード上に存在しない**(revert か別実装に置き換え済み)
+- ソース: improvement-log.md EXP-003, Agent 1 (Explore) レポート
+
+### 共通原則(過去 3 試行から導出)
+1. **LCP 要素を Lighthouse audit で特定してから施策を立てる**(`fetch-psi-audit.mjs` の `lcp-breakdown-insight` を参照)
+2. **breakdown の 4 値 (TTFB / resourceLoadDelay / resourceLoadDuration / elementRenderDelay) のうち、どこを縮めるかを明示する**
+3. **施策後 4-7 日以内に PSI 再計測し、effect を判定する**(`.claude/rules/evidence-based-judgment.md`)
+4. **デプロイ後に他施策が同じ指標に影響しないか監視**(本件のように相互干渉が起こる)
+
+---
+
+## 3. 改善策カタログ(網羅型)
+
+> 各方策に: **想定効果 / 実装コスト(S/M/L) / リスク / 依存関係 / 過去事例**
+>
+> 想定効果は「Mobile LCP 改善幅」を主軸に。根拠列に過去 PSI 事例 / web.dev 仕様 / 計算式を明記。
+
+### A. Cookie banner 対策 — 主要 8 URL で最大効果
+
+| ID | 方策 | 想定効果 (Mobile LCP) | コスト | リスク | 依存 / 注意 |
+|---|---|---|---|---|---|
+| A1 | Banner を SSR で render、初期 `visibility: hidden`、JS で `visible` 切替 | 16,000ms → 4,000ms 程度(主要 8 URL) [根拠: visibility:hidden は LCP 計測対象外、SSR text は他 SSR 要素に LCP 譲渡] | M | hydration mismatch 注意、SSR/CSR で `visible` state を厳密管理 | Cookie 値読み出しを cookies() (server) で行えば SSR 安全 |
+| A2 | Banner を Modal / Portal 化(`createPortal` で `<body>` 末尾に挿入) | 同上 [根拠: portal 内要素は通常レイアウトツリー外、LCP 候補から除外されるケースあり] | M | portal でも viewport 内に描画されれば LCP 候補になる、検証必要 | `react-dom` の `createPortal`、SSR では空 |
+| A3 | `content-visibility: auto` を Banner コンテナに付与 | 16,000ms → 8,000ms(部分効果) [根拠: web.dev content-visibility 解説、render 後回しで LCP 候補から除外可能] | S | Safari 対応(`@supports`)、CLS 悪化リスク | CSS のみ、ブラウザ対応 95%+ |
+| A4 | EXP-003 の 4s 遅延を再実装、ただし AdSense 軽量化と同時 | 一時的に 785ms 達成実績あり、AdSense 軽量化なしでは revert する [根拠: 過去施策 3、2026-05-07 計測] | S | B 群と組み合わせないと意味なし、単独実装は禁止 | **B1 + B5 と同 PR で実装** |
+| A5 | Banner `<p>` テキストを SSR で空、マウント後 textContent fill | 5,000ms → 2,000ms 程度 [根拠: テキストサイズが LCP candidate score に影響、空 text は通常 LCP 候補から外れる] | S | UX上の Cookie 告知が遅延 = GDPR/法令上問題なし(同意取得自体は banner UI 出現後) | A1/A2 のバリエーション |
+| A6 | Banner を `next/dynamic(ssr:false)` + `loading="lazy"` 化 | 12,000ms → 6,000ms(中程度) [根拠: dynamic component は JS hydrate 後に描画開始、LCP 候補から外れる] | S | dynamic import 自体の overhead は小さい | banner ファイルを `'use client'` のままで OK |
+
+**推奨**: **A1**(SSR 静的化 + visibility 切替)が確実性高い。A2 は portal で「ツリー外」化できるが LCP 算定上は viewport 内描画なら候補になる場合あり、計測検証必須。A4 は B 群と同時にしないと逆効果。
+
+### B. AdSense / Hydration 軽量化 — 2026-05-08 悪化への直接対策
+
+| ID | 方策 | 想定効果 | コスト | リスク | 依存 / 注意 |
+|---|---|---|---|---|---|
+| B1 | `AdSense` JS chunk を vendor-adsense として分離(webpack splitChunks) | -300ms hydration(全 URL) [根拠: D3 chunk 分離の前例、`next.config.ts:283-301`] | M | next.config.ts 編集、bundle analyze で確認 | 既存 D3 分離パターンを踏襲 |
+| B2 | AdSenseAd を server placeholder + 完全 lazy hydrate(`React.lazy` + Suspense) | -500ms hydration [根拠: React 公式 lazy load パターン] | M | placeholder の minHeight は維持(CLS 0.732 対策) | `apps/web/src/lib/google-adsense/components/AdSenseAd.tsx` 改修 |
+| B3 | AdSenseScript の `setTimeout` を 3s → 5s + scroll trigger | -200ms LCP 候補(間接) [根拠: Idle 時間延長で main thread 余裕、ただし収益 -5% リスク] | S | AdSense 表示遅延 → AdSense 収益が 5-10% 下がる可能性 | `AdSenseScript.tsx:46` の delay 値変更 |
+| B4 | AdSense を Consent 取得後にのみ load(Consent Mode v2 連携) | -800ms 初回 LCP [根拠: AdSense 公式 Consent Mode v2 推奨フロー] | M | Consent 拒否ユーザーには広告非表示 = 収益減 | `CookieConsentBanner` と統合、`gtag consent update` 後に AdSense 起動 |
+| B5 | AdSense 広告密度を 1 ページ 1-2 個に削減 | -300ms hydration(複数広告枠ページ) [根拠: AdSenseAd 1 個あたり ~20KB JS、hydration cost 比例] | S | 広告収益 -15-30% リスク | `apps/web/src/app/ranking/*`, `/areas/*` の `<AdSenseAd />` 設置箇所削減 |
+| B6 | AdSense を Partytown / web worker 経由で隔離 | -1,000ms main thread block [根拠: Partytown 公式ベンチ、3rd party scripts 隔離で TBT 大幅削減] | L | 実験的、AdSense との互換性検証必要、設定難 | `@builder.io/partytown`、Cloudflare Pages 対応 |
+| B7 | `AdSenseScript` を `<head>` ではなく `<body>` 末尾に移動 | -100ms FCP [根拠: render-blocking script の位置、ただし AdSenseScript は async なので影響小] | S | 効果限定的 | `apps/web/src/app/layout.tsx` の AdSenseScript 配置 |
+
+**推奨**: **B1 + B5** が確実性高い。B4 は consent 連携で実装複雑だが UX/コンプライアンス的にもベスト。B6 は L 工数だが、TBT 削減も狙えるなら検討。
+
+### C. LCP 要素を SSR 確定要素に置き換え
+
+| ID | 方策 | 想定効果 | コスト | リスク | 依存 / 注意 |
+|---|---|---|---|---|---|
+| C1 | Hero (FeaturedRankings SVG tile) を明確に LCP 最大要素にする(viewport 上部・大きく) | Mobile LCP 4,000ms → 2,500ms [根拠: SSR SVG は HTML parse 直後に描画、Desktop /ranking で 1,062ms ✓ 実績] | M | A1 と組み合わせて初めて効果(A 必須) | `apps/web/src/features/ranking/components/FeaturedRankings/` |
+| C2 | h1 タイトルを font-size 拡大、bold/dark で LCP candidate score 上げ | LCP 6,000ms → 4,000ms(theme 詳細) [根拠: LCP candidate score はサイズと色コントラストに依存、h1 を 36px → 48px 等] | S | デザイン変更、視覚調整必要 | melta-ui デザイン規約準拠で |
+| C3 | SSR で hero 画像(OGP / カテゴリビジュアル)を above-the-fold に配置 | LCP 5,000ms → 2,000ms(カテゴリページ) [根拠: SSR `<img>` with `priority` は最速 LCP] | M | 画像生成・配信パイプライン整備、画像 byte size 注意 | `next/image` + Cloudflare Image Resizing |
+| C4 | 各ページに「LCP 専用 SSR 要素」を意図的に挿入(明示的 LCP)、デザイン上意味のある hero 要素として | LCP 6,000ms → 2,500ms [根拠: LCP element の制御が完全に手中に] | M | 全ページデザインの統一性 | A 群と組み合わせ |
+
+**推奨**: **C1**(既存 FeaturedRankings を活用)が最低コスト。C2 は補助的に。C3 は他にもメリット(SEO, OGP)あり推奨。
+
+### D. Leaflet — ranking 詳細・theme 詳細の二次対策
+
+| ID | 方策 | 想定効果 | コスト | リスク | 依存 / 注意 |
+|---|---|---|---|---|---|
+| D1 | tile preload 強化(既実装、`apps/web/src/app/ranking/[rankingKey]/page.tsx:247-255`) | resourceLoadDelay -50% [根拠: 試み 2 の実績、ただし elementRenderDelay 増で net 効果限定] | S | net LCP は動かない可能性大(過去事例) | EXP-003 PARTIAL の教訓を念頭に |
+| D2 | Leaflet を静的 SVG/PNG fallback に置換(SSR で render) | Mobile LCP 12,000ms → 3,000ms [根拠: SSR SVG なら hydration 不要、Desktop /ranking 1,062ms 実績の応用] | L | 既存 Leaflet interaction(zoom/pan) の喪失、UX 検討必要 | `packages/visualization` で SSR map component 新設 |
+| D3 | Static tile generation(build 時に PNG 化して `/tiles/static/` で配信) | resourceLoadDuration -300ms [根拠: cartocdn 経由 → 自前 CDN で latency 削減] | L | build パイプライン整備、ストレージ追加 | Cloudflare R2 配信 |
+| D4 | Leaflet を below-the-fold に下げて LCP 候補から除外 | Mobile LCP 12,000ms → 6,000ms(theme/ranking 詳細) [根拠: viewport 外要素は LCP 候補から外れる] | S | デザイン変更、要素順序入れ替え | ranking 詳細・theme 詳細ページレイアウト調整 |
+| D5 | Leaflet を Suspense fallback 後ろにして優先度落とし | Mobile LCP 11,921ms → 9,000ms(部分) [根拠: Suspense boundary 内は LCP candidate score 低下] | S | Suspense fallback のサイズが大きいと逆効果 | 既存 `RankingMapChart` の Suspense 構造拡張 |
+| D6 | Mobile では Leaflet を静止画 PNG に置換(User Agent / viewport で分岐) | Mobile LCP 12,000ms → 4,000ms [根拠: D2 の mobile only バリエーション] | M | UA sniff の保守性、Cloudflare Worker で分岐 | Edge Middleware 活用 |
+
+**推奨**: **D4 + D5**(レイアウト変更だけで効果)を先に。D2/D3 は D4/D5 で目標未達なら検討。
+
+### E. インフラ・配信層(横断)
+
+| ID | 方策 | 想定効果 | コスト | リスク | 依存 / 注意 |
+|---|---|---|---|---|---|
+| E1 | Cloudflare Image Resizing 有効化(`next.config.ts:44` の `unoptimized: true` を解除) | Mobile LCP -500ms(画像 LCP URL) [根拠: 画像 byte size 30-50% 削減、Cloudflare 公式] | M | Cloudflare Workers 設定変更必要、コスト追加(1M req/月 \$5) | `next.config.ts` + Workers 設定 |
+| E2 | Cache-Control max-age=0 → 1h(repeat visit 改善) | repeat visit LCP -2,000ms [根拠: browser cache hit、初回後の JS/CSS 再取得回避] | S | キャッシュ無効化フローの設計 | `apps/web/src/middleware.ts` or Cloudflare headers |
+| E3 | SWC minify 確認(Next 15 でデフォルト ON だが要検証) | JS download -3% [根拠: Terser → SWC で 2-5% 削減実績] | S | next.config.ts 設定で明示 ON | `swcMinify: true` |
+| E4 | Worker KV による R2 fetch キャッシュ層 | TTFB -200ms(動的ページ) [根拠: KV 経由は R2 直アクセスより早い場合あり、エッジ近接] | M | KV binding 追加、容量制約(25MB/value) | wrangler.toml + middleware |
+| E5 | KaTeX を blog 専用 lazy chunk 化 | 非 blog ページ JS -300KB [根拠: KaTeX deps size、blog 以外で不要] | S | blog 記事内 KaTeX 描画タイミング | dynamic import in blog page |
+| E6 | `next/font` preload を selective 化(Inter は home のみ preload, Noto Sans JP は preload=false 維持) | LCP -100ms(font swap 早期化) | S | font 表示の一貫性検証 | `apps/web/src/lib/fonts/index.ts:13-43` |
+| E7 | Brotli 圧縮確認(Cloudflare Pages デフォルト ON のはず) | JS/CSS -30-40% 圧縮 [根拠: Cloudflare 公式] | S | 既に ON の可能性大、確認のみ | Response header `content-encoding: br` 確認 |
+| E8 | ISR revalidate を granular 化(category 1h / ranking 24h / blog 7d) | edge cache hit rate +30% [根拠: 変更頻度に応じた TTL 設定] | M | 全ページの `revalidate` 設定見直し | `apps/web/src/app/**/page.tsx` |
+| E9 | Cache Rules で aggressive caching(`/api/snapshot/*` 24h, `/_next/image/*` 7d) | edge hit rate +40% [根拠: Cloudflare Cache Rules 公式] | S | Cloudflare Dashboard 設定 | コード変更なし |
+| E10 | Preconnect / dns-prefetch を必要ページのみに(non-map ページから削除) | DNS lookup -50-100ms(map なしページ) [根拠: 不要 DNS 解決の削除] | S | conditional `<link>` 出力ロジック | `apps/web/src/app/layout.tsx:76-98` |
+| E11 | `<head>` 内の Google Analytics / NextTopLoader 等の script 最適化(defer / async / 削除) | TBT -100ms | S | サードパーティ依存、A/B 比較 | `apps/web/src/app/layout.tsx:103-151` |
+
+**推奨**: **E1 + E2 + E5** が安全かつ高効果。E9 は設定のみ。E4(KV)はオーバーキル感あるが将来検討。
+
+### F. Mobile 特化対策
+
+| ID | 方策 | 想定効果 | コスト | リスク | 依存 / 注意 |
+|---|---|---|---|---|---|
+| F1 | Mobile breakpoint で重い D3/Leaflet を skip / 簡易版に置換 | Mobile LCP -3,000ms / TBT -1,500ms [根拠: Mobile CPU 性能制約、JS 軽量化で hydration 早期化] | M | Mobile/Desktop で UX 差異 | useMediaQuery / Server Component で viewport 分岐 |
+| F2 | Mobile では Leaflet → 静止 PNG fallback(D6 と同じ) | (D6 と同じ) | M | (D6 と同じ) | D6 参照 |
+| F3 | critical CSS inline(above-the-fold のみ) | Mobile FCP -500ms [根拠: render-blocking CSS の inline 化、web.dev 推奨] | M | Next.js は自動で critical CSS 抽出するが手動チューニング余地 | `experimental.optimizeCss: true` 試行 |
+| F4 | JS bundle splitting で mobile に不要な component を分離(管理者画面・GES 系) | Mobile JS -200KB | M | route-based code split は既に標準 | 個別 component の dynamic import 拡張 |
+| F5 | Mobile Optimized Page を `/m/` で別配信(最終手段、SSR 軽量化) | Mobile LCP -50% [根拠: AMP 類似、minimal HTML 配信] | XL | 別配信パイプライン、SEO 影響、保守 2 倍 | 最後の手段 |
+
+**推奨**: **F1** を Phase 2 で。F5 は通常採用しない。
+
+### G. 監視・運用
+
+| ID | 方策 | 効果 | コスト | リスク |
+|---|---|---|---|---|
+| G1 | Lighthouse CI を GitHub Actions に組み込み(PR 単位で Mobile LCP / Perf を CI 表示) | 悪化の早期検知 | M | Lighthouse CI 設定、PR コメント連携 |
+| G2 | URL Inspection API で再クロール検証(既存 `.claude/scripts/gsc/url-inspection-daily.cjs`) | Google 認識との乖離検知 | S | 既存スクリプト活用 |
+| G3 | PSI 日次 batch の閾値違反通知強化(Issue 自動起票は実装済、Slack 通知追加) | 違反検知の即時性 | S | webhook 設定 |
+| G4 | Cloudflare Web Analytics で実ユーザー LCP 観測(Lab data と CrUX の乖離把握) | 実ユーザー体感の把握 | S | 既に Cloudflare Web Analytics 有効? 確認必要 |
+| G5 | PR ごとに psi-batch 自動取得 + diff 表示(GitHub Actions) | 施策効果の即時確認 | M | PR comment / commit status |
+| G6 | Performance Budget の自動チェック(`budgets.json` を CI で参照、違反で警告) | budget 違反 PR の検知 | S | 既存 budgets.json 活用 |
+
+**推奨**: **G1 + G5** で施策 PR の品質担保。G6 は budget 整備済なら即適用可。
+
+---
+
+## 4. 推奨実装フェーズ
+
+### Phase 1: Cookie banner + AdSense 緊急対応 (1 週間 / 最大インパクト)
+**狙い**: 主要 8 URL の Mobile LCP を 16,000ms → 4,000ms 以下に。Cookie banner 起点の LCP を一掃する。
+
+**実装**:
+- **A1**: Cookie banner を SSR で render し、`visibility: hidden` 初期 + JS で `visible` 切替
+- **B1**: AdSense JS chunk を vendor-adsense として分離
+- **B5**: AdSense 広告密度を 1 ページ 1-2 個に削減(ranking 一覧 / areas / themes のみに限定)
+
+**検証期日**: 2026-05-23 朝 PSI 自動計測(GitHub Actions 日次 02:00 JST)
+**成功判定**:
+- Mobile LCP < 5,000ms(全 URL)→ effect/full
+- Mobile LCP < 8,000ms(主要 URL)→ effect/partial
+- それ以外 → 仮説再検証
+**撤退条件**: 施策後 8 日経過で Mobile LCP 平均 -30% 未満なら即 revert
+
+### Phase 2: LCP 要素転換 + インフラ最適化 (2-3 週間)
+**狙い**: Mobile LCP を 4,000ms → 2,500ms 達成、Performance スコア 60→80。
+
+**実装**:
+- **C1**: FeaturedRankings SVG を明確に LCP 最大要素に
+- **E1**: Cloudflare Image Resizing 有効化
+- **E2**: Cache-Control max-age=0 → 1h
+- **E5**: KaTeX を blog 専用 lazy chunk 化
+- **E10**: Preconnect / dns-prefetch を必要ページのみに
+
+**検証期日**: Phase 1 完了 + 14 日後
+**成功判定**:
+- Mobile LCP < 2,500ms(全 URL)→ effect/full
+- Performance ≥ 80(全 URL)→ ボーナス
+**撤退条件**: 各施策単独で LCP が悪化したら個別 revert
+
+### Phase 3: 個別ページ最適化 (3-4 週間)
+**狙い**: ranking 詳細・theme 詳細の Leaflet 起点 LCP 対応、mobile 全体の細部チューニング。
+
+**実装**:
+- **D4 + D5**: Leaflet を below-the-fold に下げ + Suspense 後ろに置く
+- **D2**(D4/D5 で目標未達なら): Leaflet → SSR SVG fallback
+- **F1**: Mobile breakpoint で重い D3/Leaflet を簡易版に置換
+- **C2**: h1 タイトル font-size 調整
+
+**成功判定**: Mobile Performance ≥ 90(全 URL)
+
+### Phase 4: 継続監視 (恒久)
+- **G1**: Lighthouse CI を PR に組み込み
+- **G5**: PR ごとに psi-batch 自動取得 + diff 表示
+- **G6**: Performance Budget の自動チェック
+- 月次 PSI レビューで悪化検知(`/performance-improvement` スキル週次運用)
+
+---
+
+## 5. 検証コマンド集
+
+### PSI 単発計測 (curl)
+```bash
+# Mobile
+curl -s "https://www.googleapis.com/pagespeedonline/v5/runPagespeed?url=https://stats47.jp/&strategy=mobile&category=performance" \
+  | jq '.lighthouseResult.audits["largest-contentful-paint"].numericValue,
+        .lighthouseResult.audits["largest-contentful-paint-element"].details.items[0].node'
+
+# Desktop
+curl -s "https://www.googleapis.com/pagespeedonline/v5/runPagespeed?url=https://stats47.jp/&strategy=desktop&category=performance" \
+  | jq '.lighthouseResult.audits["largest-contentful-paint"].numericValue'
+```
+
+### LCP breakdown 詳細取得
+```bash
+node .claude/scripts/psi/fetch-psi-audit.mjs \
+  --urls "https://stats47.jp/,https://stats47.jp/ranking,https://stats47.jp/areas" \
+  --strategy mobile \
+  --out /tmp/psi-after.json
+
+jq -r '.results[] | "\(.url) LCP=\(.lab_data.LCP_ms | floor)ms elem=\(.lcp_element.selector) renderDelay=\(.lcp_element.breakdown_ms.elementRenderDelay)"' /tmp/psi-after.json
+```
+
+### URL Inspection API(Google 認識との乖離検知)
+```bash
+node .claude/scripts/gsc/url-inspection-daily.cjs --limit 10
+```
+
+### 各 Phase 完了時の判定スクリプト
+```bash
+# 前後比較
+jq -s '
+  def url_lcp(d): [d.results[] | select(.strategy=="mobile") | {url, lcp: .lab_data.LCP_ms | floor}];
+  {before: url_lcp(.[0]), after: url_lcp(.[1])} |
+  {diff: (.after | map({url, after_lcp: .lcp})) | map(. + {before_lcp: (.url as $u | $before[] | select(.url==$u).lcp)})}
+' .claude/state/metrics/psi/psi-batch-2026-05-09T17-40-53.json /tmp/psi-after.json
+```
+
+### Performance Budget 違反確認
+```bash
+node .claude/scripts/psi/check-budgets.mjs \
+  --psi-batch /tmp/psi-after.json \
+  --budgets .claude/skills/analytics/performance-improvement/budgets.json
+```
+
+---
+
+## 6. 失敗判定 / 撤退条件(共通)
+
+### 各施策の effect 判定 4 状態
+- **effect/full**: 想定値の 80% 以上達成(7-14 日経過後)
+- **effect/partial**: 想定値の 30-80% 達成
+- **effect/none**: 想定値の 0-30%(noise 圏)
+- **effect/adverse**: LCP / Perf がベースラインより悪化 → **即 revert**
+
+### 撤退条件
+- 各 phase 完了後 8 日経過で目標未達 → 仮説再検証(Lighthouse audit から再開)
+- LCP が悪化したら 24 時間以内に revert(EXP-002 ADVERSE の教訓)
+- elementRenderDelay が施策前より +500ms 以上増加したら警告(EXP-003 PARTIAL の教訓)
+- 同時に複数施策を入れて effect 判定不能になったら、施策を 1 つに絞って再実施
+
+### NG ワード(改善ログ記入時の禁止表現)
+`.claude/rules/evidence-based-judgment.md` 参照。「のはず」「兆候」「浸透待ち」「だろう」「と考えられる」等は使用禁止。代わりに「[仮説]」「検証コマンド」「検証期日」の 3 点セットで書く。
+
+---
+
+## 7. 関連ファイル・参照
+
+### 計測データ
+- `.claude/state/metrics/psi/LATEST.md` — 最新計測サマリー
+- `.claude/state/metrics/psi/psi-batch-2026-05-09T17-40-53.json` — 本ドキュメントのベースデータ
+- `.claude/state/metrics/psi/history.csv` — 時系列推移
+- `.claude/skills/analytics/performance-improvement/budgets.json` — 閾値定義
+- `.claude/skills/analytics/performance-improvement/snapshots/YYYY-MM-DD/metrics.csv` — 過去 snapshot
+
+### 過去履歴・知見
+- `.claude/skills/analytics/performance-improvement/reference/improvement-log.md` — EXP 全履歴
+- `~/.claude/projects/-Users-minamidaisuke-stats47/memory/feedback_lcp_optimization.md` — LCP 改善原則(EXP-002/003 反省)
+- GitHub Issues #74(試み 1: TopoJSON client fetch ADVERSE), #101(試み 2: Resource preload PARTIAL)
+
+### 現状コード(改修対象)
+- `apps/web/src/lib/analytics/components/CookieConsentBanner.tsx:37-92` — Cookie banner(A 群対象)
+- `apps/web/src/lib/google-adsense/components/AdSenseScript.tsx:18-53` — AdSense script(B3, B6, B7)
+- `apps/web/src/lib/google-adsense/components/AdSenseAd.tsx:34-180` — AdSense Ad(B2, B5)
+- `apps/web/src/app/layout.tsx:76-151` — preconnect / GA / NextTopLoader(E10, E11)
+- `apps/web/next.config.ts:44-54, 283-301` — image / D3 chunk(E1, E3, B1)
+- `apps/web/src/lib/fonts/index.ts:13-43` — font config(E6)
+- `apps/web/src/app/page.tsx:85-121` — Hero / FeaturedRankings(C1)
+- `apps/web/src/features/ranking/components/FeaturedRankings/index.tsx:29-140` — FeaturedRankings(C1)
+- `apps/web/src/features/ranking/components/RankingMapChart/RankingMapChartClient.tsx:32-40` — Leaflet dynamic(D 群)
+- `apps/web/src/app/ranking/[rankingKey]/page.tsx:247-255` — tile preload(D1)
+
+### 既存スキル・スクリプト
+- `.claude/skills/analytics/performance-improvement/SKILL.md` — 改善ループ運用
+- `.claude/scripts/psi/fetch-psi-audit.mjs` — PSI 計測スクリプト(LCP breakdown 抽出済)
+- `.claude/scripts/gsc/url-inspection-daily.cjs` — URL Inspection API
+
+### 規約
+- `.claude/rules/evidence-based-judgment.md` — 実証ベース判定ルール
+- `.claude/rules/coding-standards.md` — TypeScript/React/Next.js コーディング標準
+- `CLAUDE.md` — プロジェクト規約
+
+---
+
+## 付録: LCP 要素の詳細(全 19 URL Mobile)
+
+| URL | LCP (ms) | LCP element | render delay (ms) |
+|---|---:|---|---:|
+| / | 16,426 | Cookie banner `<p>` | 8,016 |
+| /ranking | 19,051 | Cookie banner `<p>` | 5,564 |
+| /areas | 13,805 | Cookie banner `<p>` | 9,168 |
+| /ranking/total-population | 14,691 | Cookie banner `<p>` | 6,664 |
+| /areas/13000 | 14,020 | Cookie banner `<p>` | 6,177 |
+| /areas/47000 | 14,035 | Cookie banner `<p>` | 6,777 |
+| /themes | 6,904 | Theme intro `<p>` | 457 |
+| /themes/population-dynamics | 5,104 | Theme intro `<p>` | 2,969 |
+| /themes/local-economy | 7,801 | Theme intro `<p>` | 3,583 |
+| /themes/labor-wages | 6,601 | Theme intro `<p>` | 4,278 |
+| /ranking/future-population-change-rate-2050 | 8,701 | `h1.text-2xl` | 3,299 |
+| /areas/27000 | 6,526 | `h2.text-2xl` | 1,248 |
+| /areas/01000 | 6,301 | `h2.text-2xl` | 1,276 |
+| /search | 7,201 | search input `#placeholder` | 2,366 |
+| /ranking/annual-sunshine-duration | 11,921 | Leaflet tile `img` | 2,399 (+ resourceLoadDelay 1,956) |
+| /ranking/agricultural-output | 12,001 | N/A | N/A |
+| /blog | 9,151 | Blog list `img.object-cover` | 2,367 |
+| /blog/telework-gap-tokyo-6x | 6,451 | Blog body `<p>` | 1,244 |
+| /about | 8,916 | About `<p>` | 2,302 |
+
+**観察**:
+- 主要 6 URL(/ /ranking /areas /ranking/total-population /areas/13000 /areas/47000)はすべて **Cookie banner が LCP**(render delay 5,564〜9,168ms)
+- ranking 詳細では Leaflet と h1 が混在(LCP candidate が試行ごとに変動)
+- theme 詳細 3 URL は SSR text が LCP(render delay 2,969〜4,278ms = hydration 待ち)
+- blog 一覧は image LCP、blog 詳細は本文 `<p>` LCP
+
+**結論**: **Cookie banner 対策(A 群)が最大 ROI**。次に theme 詳細・blog の SSR text の render delay を縮める(B 群 hydration 軽量化)。Leaflet 関連は二次。


### PR DESCRIPTION
## Summary

- `docs/04_レビュー/goals/psi-mobile-lcp-2500-2026-05-15.md` の **Cycle 1 (仮説 A1+B1+B5)** 実装
- 主要 8 URL Mobile LCP **16,000ms → 4,000ms 以下** を目指す（改善策カタログ §3.A.A1 / §3.B.B1+B5 根拠）
- **EXP-004 で踏んだ SSG 崩壊罠を回避する設計ルールを `.claude/rules/nextjs-ssg-preservation.md` に固定化**

## 変更内容

### A1: Cookie banner SSR + visibility:hidden
- `CookieConsentBanner` を sync Server Component に分離
- 新規 `CookieConsentBannerClient.tsx` で SSR 時 `visibility:hidden`、hydration 後に `document.cookie` を見て表示判定
- Lighthouse LCP candidate scoring から visibility:hidden 要素は除外される

### B1: AdSense JS chunk 分離
- `next.config.ts` に `adsenseVendor` splitChunk 追加
- `/lib/google-adsense/` 配下を `vendor-adsense-*.js` に切り出し（メイン chunk parse 時間削減）

### B5: AdSense 広告密度削減 + defer 強化
- `SidebarClient`: `MAIN_SIDEBAR` slot 削除（全ページ表示の 1 slot）
- `RankingKeyPageClient`: `RANKING_PAGE_TABLE_SIDE` slot 削除
- `blog/[slug]/page.tsx`: `RANKING_PAGE_SIDEBAR` slot 削除（xl サイド + モバイル後）
- `AdSenseScript`: 3s setTimeout → 5s + 初回ユーザー操作 (scroll/touch/click) で early-load

### 設計原則の固定化（再発防止）
- `.claude/rules/nextjs-ssg-preservation.md` 新設
- CLAUDE.md ドキュメント参照ガイドから参照
- 当初 `CookieConsentBanner` で `cookies()` を呼ぶ案だったが、2026-05-10 EXP-004（`ebad87c2` で revert）と同パターンで全 ranking 詳細が 500 になる轍を未然に発見・回避

## 検証

### SSG 保全（`next build` 出力）
- ✅ `● /ranking/[rankingKey]` SSG 維持 (1947+ paths)
- ✅ `○ /` / `○ /themes/*` / `○ /ranking` Static 維持
- ✅ `vendor-adsense-72aa8a871ed560d4.js` 生成確認 (2.6KB)

### 型チェック
- ✅ `npx tsc --noEmit -p apps/web/tsconfig.json` exit=0

## Test plan

- [ ] develop マージ後、Cloudflare Pages preview で `/` `/ranking` `/areas/13000` を Mobile Lighthouse 実行
- [ ] LCP element が CookieConsentBanner の `<p>` から外れていることを確認
- [ ] 同意済み state（cookie あり）で hydration 後すぐに banner が `null` 返却されることを確認（Network → Console で `dismissed=true`）
- [ ] AdSense chunk が `vendor-adsense-*.js` として別ロードされることを Network タブで確認
- [ ] main にマージ後、4-7 日後の PSI で実測 LCP を `.claude/state/metrics/psi/LATEST.md` で検証
- [ ] 実測値が想定の 80% 未満なら次の仮説（C1 / A6 / E1 等）を Cycle 2 で立てる

## ロールバック条件

- Cloudflare Pages デプロイ後の手動 PSI で主要 URL LCP が 5/9 baseline (16,000ms) を上回ったら revert
- 同意済みユーザーで banner が 1 回 flicker する場合は visibility:hidden の初期 render を再検討

🤖 Generated with [Claude Code](https://claude.com/claude-code)