### PR TITLE
feat: Phase 0 SEO/UX 改善 3 件 (sitemap tags / regional UI / robots ?norm=)

### DIFF
--- a/apps/web/src/app/ranking/[rankingKey]/page.tsx
+++ b/apps/web/src/app/ranking/[rankingKey]/page.tsx
@@ -317,6 +317,12 @@ export default async function RankingKeyPage({
             ? <AiContentAccordion title="データの考察"><AiMarkdownContent content={aiContent.insights} /></AiContentAccordion>
             : null
         }
+        // AI生成コンテンツ: 地域別の傾向（折りたたみ）
+        regionalAnalysisSection={
+          aiContent?.regionalAnalysis
+            ? <AiContentAccordion title="地域別の傾向"><AiMarkdownContent content={aiContent.regionalAnalysis} /></AiContentAccordion>
+            : null
+        }
         // AI生成コンテンツ: FAQ JSON-LD（非表示 script）
         faqSection={
           aiContent?.faq

--- a/apps/web/src/app/robots.ts
+++ b/apps/web/src/app/robots.ts
@@ -36,7 +36,8 @@ export default function robots(): MetadataRoute.Robots {
     rules: [
       {
         userAgent: "*",
-        allow: "/",
+        // ranking の派生指標 toggle URL (?norm=per_population / per_area / per_household) を明示的に許可
+        allow: ["/", "/ranking/*?norm=*"],
         disallow: [
           "/admin/*", // 管理画面
           "/api/*", // 内部 route handler（blog-data, ranking-data 等）。フロントから fetch するだけで Googlebot に露出させない
@@ -47,7 +48,7 @@ export default function robots(): MetadataRoute.Robots {
       },
       {
         userAgent: "Google-Extended", // Google Gemini
-        allow: "/", // 明示的に全ページを許可
+        allow: ["/", "/ranking/*?norm=*"], // 明示的に全ページ + 派生指標 URL を許可
         disallow: [
           "/admin/*", // 管理画面は除外
           "/api/*", // 内部 route handler

--- a/apps/web/src/app/sitemap.ts
+++ b/apps/web/src/app/sitemap.ts
@@ -198,12 +198,27 @@ function getCityPages(): MetadataRoute.Sitemap {
 }
 
 async function getTagPages(): Promise<MetadataRoute.Sitemap> {
-  const tagMeta = await listAllTagsWithCount().catch(() => []);
+  let tagMeta: Awaited<ReturnType<typeof listAllTagsWithCount>>;
+  try {
+    tagMeta = await listAllTagsWithCount();
+  } catch (error) {
+    console.error("[sitemap/getTagPages] listAllTagsWithCount failed", { error });
+    return [];
+  }
   // 旧クエリで count >= 5 を要求していたため踏襲
   const eligible = tagMeta.filter((t) => t.count >= 5);
-  if (eligible.length === 0) return [];
+  if (eligible.length === 0) {
+    console.warn("[sitemap/getTagPages] no eligible tags (count>=5)", { totalTags: tagMeta.length });
+    return [];
+  }
 
-  const articlesAll = await listLatestArticles(10000).catch(() => []);
+  let articlesAll: Awaited<ReturnType<typeof listLatestArticles>>;
+  try {
+    articlesAll = await listLatestArticles(10000);
+  } catch (error) {
+    console.error("[sitemap/getTagPages] listLatestArticles failed", { error });
+    return [];
+  }
   // 各 tag の最新 publishedAt を slug→tags リレーション無しで安価に解決するため、
   // 全 article から tagKey 別の max(publishedAt) を組み立てる。
   // 全 article 取得は snapshot in-memory cache 経由なので追加 fetch は発生しない。


### PR DESCRIPTION
## Summary

Phase A (派生指標オート生成、PR #294) と blog 21 記事公開 (PR #296) の続編として、SEO/UX 改善 7 施策のうち低リスク 3 件を実装。

## 内訳

1. **fix(sitemap)**: tags segment の D1 catch を `console.error` 出力に変更し、空 0 の真因 (D1 失敗 / count<5 / 未登録) を観測可能に
2. **feat(ranking)**: `regionalAnalysisSection` を UI 配線。DB の `metrics.regional_analysis` (AI 生成、1,950 件中多数) を「地域別の傾向」accordion に表示。E-E-A-T 強化
3. **chore(robots)**: `/ranking/*?norm=*` 派生指標 URL を `Allow` に明示。Phase A で投入した per-population/per-area/per-household toggle へのクロール導線を確保

## 影響

- ✅ 1,586 metric × 3 normalization の派生 URL がクロール許可
- ✅ regionalAnalysisSection が表示されることでページ word count +200-500 (SEO 価値)
- ✅ sitemap tags 0 URL バグの真因が log で観測可能に (今後の修正の足場)

## Test plan

- [ ] dev で `/ranking/lighting-consumption-expenditure` が「地域別の傾向」accordion 表示
- [ ] sitemap/7.xml で tag URL >= 8 (catch ログがあれば真因を確認)
- [ ] robots.txt に `Allow: /ranking/*?norm=*` 記載
- [ ] 既存 ranking ページに退行なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)