### PR TITLE
chore(trends): discover-trends snapshot 2026-05-17

### DIFF
--- a/.claude/skills/blog/trends-snapshots/trends-all-2026-05-17.md
+++ b/.claude/skills/blog/trends-snapshots/trends-all-2026-05-17.md
@@ -1,0 +1,362 @@
+# トレンド × stats47 マッチング結果（source: all）
+
+> 調査日時: 2026-05-17 (土)
+> ソース: trends / gsc / hatena / news / yahoo / note (6 ソース)
+> トレンド総数: 約 140 件 / 採用: 30 件 / 除外: 約 110 件 / クロスソースヒット (3+): 4 件
+> GSC ウィンドウ: WoW (2026-05-07 〜 2026-05-13) + MoM (2026-04-16 〜 2026-05-13)
+
+---
+
+## サマリー
+
+今日の最強候補は **小麦粉消費量 (GSC コンテンツギャップ)** と **米消費量 (はてブ 219 ブクマ)** の 2 本柱。両方とも食関連で、家計調査と農林統計の組み合わせで書ける。
+
+クロスソースヒット 4 件:
+1. **真夏日 / 熱中症** (google-trends, google-news, yahoo) — 5/16 東京 30℃、19日頃 35℃予想
+2. **私大削減 / 大学** (hatena, google-news, yahoo) — 文科省案 + 五月祭爆破予告
+3. **ナフサ・食品値上げ** (google-trends, google-news, yahoo) — 「車の血液」物流懸念
+4. **自衛隊・防衛改革** (hatena, google-news, yahoo) — 「大将」「大佐」呼称変更
+
+GSC は規模が小さく WoW では新規・急上昇クエリゼロ。MoM 28日比較で「小麦粉消費量ランキング」が新規 122 imp で浮上 (★★★)。
+
+note.com 系では「2026年2月発表 47都道府県転入超過数完全ランキング」が直近 (★★★)。
+
+---
+
+## クロスソースヒット (3 ソース以上で出現)
+
+| # | キーワード | ヒット数 | ソース | カテゴリ | マッチ度 |
+|---|---|---|---|---|---|
+| 1 | 真夏日 / 熱中症 / 気温 | 3 | trends(岡山県・夏連想), news, yahoo | landweather | ★★☆ |
+| 2 | 私大削減 / 大学 | 3 | hatena(五月祭), news, yahoo | educationsports | ★★☆ |
+| 3 | ナフサ / 食品値上げ / 物価 | 3 | trends(ナフサショック), news, yahoo | economy | ★★☆ |
+| 4 | 自衛隊 / 防衛 | 3 | hatena, news, yahoo | (metrics 未登録) | ★☆☆ |
+
+---
+
+## 候補一覧
+
+| # | トレンド | ソース | マッチ度 | カテゴリ | 記事の切り口 | 必要アクション |
+|---|---|---|---|---|---|---|
+| 1 | 小麦粉消費量 (GSC コンテンツギャップ) | gsc | ★★★ | economy / agriculture | 小麦粉消費量で見える「粉もん文化」都道府県マップ | すぐ執筆可 |
+| 2 | コメ消費量・米離れ 7年ぶり低水準 | hatena(219), news | ★★★ | economy / agriculture | 米消費量が多い県・少ない県、米離れの地域差 | 家計調査データ少し追加 |
+| 3 | 真夏日・熱中症拡大 (5/19 35℃予想) | trends, news, yahoo | ★★☆ | landweather / socialsecurity | 真夏日が多い県・熱中症搬送数の地域差 | 救急搬送データ要取得 |
+| 4 | 47都道府県転入超過数 2025 (2026年2月発表) | note | ★★★ | population | 2025 年実績の地域選別、選ばれている県・捨てられている県 | すぐ執筆可 |
+| 5 | 使用済み核燃料への課税 (15年で税収2.5倍) | news, yahoo | ★★★ | energy / administrativefinancial | 原発立地市町の財政依存度 | すぐ執筆可 |
+| 6 | 私大削減案 (文科省) | hatena, news, yahoo | ★★☆ | educationsports | 私大過剰県・私大不足県、地方私大の存続危機 | すぐ執筆可 |
+| 7 | ナフサ・食品値上げ (おかめ納豆15%、肥料14.5%) | trends, news, yahoo | ★★☆ | economy | 食品インフレの 1 年経過後リバウンド 既存4本との差別化 | 慎重に差別化 |
+| 8 | 5大銀行純利益 5.8兆円 / 銀行預金 | news | ★★☆ | economy | 銀行預金残高の都道府県格差、銀行が稼ぐ場所 | すぐ執筆可 |
+| 9 | TSMC熊本工場初の黒字 / 半導体 | hatena(136), news | ★★☆ | miningindustry | 製造業集中の地殻変動、九州製造業の伸長 | 既存記事と差別化 |
+| 10 | 県のマチアプ2万円助成 (婚活) | yahoo | ★★☆ | population | 自治体の少子化対策コスト、婚活助成の地域差 | データ追加調査 |
+| 11 | 退職金時代遅れ・老後資金 | yahoo | ★☆☆ | administrativefinancial | 公務員退職金の都道府県差 | 限定的データ |
+| 12 | 47都道府県格差変動スコア (note) | note | ★★☆ | (複合) | 10年で都道府県の格差はどう変わったか | 競合と差別化必要 |
+| 13 | 「酒を飲まないなら居酒屋へ」(はてブ560) | hatena | ★☆☆ | economy | 酒類消費・外食支出の地域差 | データあり |
+| 14 | 闇バイト型強盗 (栃木4人逮捕) | yahoo | ★☆☆ | safetyenvironment | 強盗認知件数の県別、闇バイト摘発状況 | 既存記事と差別化 |
+| 15 | 仙台市の「県からの独立」運動 | hatena, news | ★☆☆ | administrativefinancial | 政令市と県の財政分配、政令市独立の損益 | 検討課題 |
+| 16 | 雹被害・損保注力 | yahoo | ★☆☆ | landweather | 雹・ひょう被害の県別 (データ少) | データ要調査 |
+| 17 | AI を人手不足の自治体業務に / 公務員AI | news | ★☆☆ | administrativefinancial | 公務員数と AI 投資 | 限定的 |
+| 18 | スバル EV 開発延期 | news | ★☆☆ | tourism | 自動車保有率・EV 普及率 (EVデータなし) | 既存指標で代替 |
+| 19 | はしか / 麻しん拡大 (東京緊急接種) | news, yahoo | ★☆☆ | socialsecurity | 予防接種率の都道府県差 | estat candidate 4 件 |
+| 20 | 心不全急増・高齢化 (CNN/Yahoo!フィナンス) | news | ★☆☆ | socialsecurity | 心疾患死亡率 × 高齢化率 | 既存記事改善 |
+
+---
+
+## 候補詳細 (マッチ度 ★★★ + クロスソースヒット)
+
+### 候補 1: 小麦粉消費量ランキング (マッチ度: ★★★ / ソース: gsc)
+
+- **トレンド概要**: GSC 直近28日で「小麦粉消費量 ランキング」が新規クエリとして 122 impressions / クリック 1 で浮上。流入先は既存ランキングページ (`/ranking/wheat-flour-consumption-expenditure`)。ブログ記事は存在しない＝**コンテンツギャップ**
+- **注目度**: 月 122-176 impr (関連 3 クエリ合計約 365 impr)
+- **分類カテゴリ**: economy（家計調査）/ agriculture
+- **タイミング**: 既に検索需要が立っており、書けば即流入が見込める
+- **ヒットソース数**: 1 / 6
+- **検出ソース**: gsc (gscType: 新規 / 表示急増)
+- **ソース別注目度**:
+  - gsc: imprGrowth 2,100% (前月8 → 今月176)
+
+#### 使えるデータ
+| データ | ソース | ranking_key / statsDataId | 備考 |
+|---|---|---|---|
+| 小麦粉消費支出額 | DB既存 | `wheat-flour-consumption-expenditure` | 家計調査 |
+| 小麦粉消費量 | DB既存 | `wheat-flour-consumption-quantity` | 家計調査 |
+| 食パン消費量 | DB既存 | `white-bread-consumption-quantity` | 補強用 |
+| 中華麺消費量 | DB既存 | `chinese-noodles-consumption-quantity` | 「粉もん文化」関連 |
+
+#### 既存記事 (差別化)
+- `noodle-consumption-prefecture-character` うどん県・そば県・ラーメン県
+- `food-trio-prefecture-map` 豆腐・焼酎・昆布
+- `food-consumption-prefecture-battle` 食の県民性対決
+
+→ 既存 3 本は「麺」「特定食品トリオ」「食全般対決」で、**小麦粉に正面から踏み込んだ記事はない**
+
+#### 記事の切り口（案）
+1. **粉もん文化マップ**: 小麦粉消費量が多い県 (大阪・兵庫・香川？) と少ない県、お好み焼き / うどん / パン文化との結びつき
+2. **小麦粉 vs 米**: 1人当たり小麦粉消費 vs 米消費 で見る「主食の県民性」
+3. **小麦粉価格高騰インパクト**: ナフサ・小麦値上げ報道とのリンク
+
+#### 推奨チャート
+- 47県棒グラフ: 小麦粉消費量ランキング
+- スキャタプロット: 小麦粉 vs 米消費量 (主食ポジショニング)
+- ヒートマップ: 小麦粉 / 食パン / 中華麺の 3 軸プロファイル
+
+#### 次のアクション
+- [ ] `/fetch-article-data` で wheat-flour-consumption-* + 関連麺類データを一括取得
+- [ ] `/generate-article-charts` でチャート生成
+- [ ] 記事執筆 (slug 案: `wheat-flour-konamon-culture`)
+
+---
+
+### 候補 2: コメ消費量・米離れ 7年ぶり低水準 (マッチ度: ★★★ / ソース: hatena + news)
+
+- **トレンド概要**: 「コメ消費量、7年ぶり低水準 価格高騰、茶わん4杯分減」がはてブ 219、Google News ビジネス。価格高騰による米離れ
+- **注目度**: hatena 219 ブクマ (政治と経済カテゴリで 1 位)
+- **分類カテゴリ**: economy（家計） + agriculture
+- **タイミング**: 5/16 の 47NEWS 報道直後、ネット議論が燃え上がっている
+- **ヒットソース数**: 2 / 6
+- **検出ソース**: hatena (1位), google-news (ビジネス)
+- **ソース別注目度**:
+  - hatena: 219 ブクマ
+  - google-news: 上位ビジネスニュース
+
+#### 使えるデータ
+| データ | ソース | ranking_key / statsDataId | 備考 |
+|---|---|---|---|
+| 水稲収穫量 | DB既存 | `rice-harvest-volume` | 生産側 |
+| 水稲作付面積 | DB既存 | `rice-cultivated-area` | 生産側 |
+| せんべい消費支出額 | DB既存 | `rice-cracker-consumption-expenditure` | 米加工品 |
+| うるち米販売価格 | e-Stat候補 | 0003225086 (うるち白米10kg) | 月別販売価格 |
+| 米水陸稲収穫量 | e-Stat候補 | 0003418935 | 主産県別 |
+| 米消費 (家計調査) | 要 fetch | (statsDataId: 0003348233 など) | `/fetch-estat-data` |
+
+#### 既存記事 (差別化)
+- `food-consumption-prefecture-battle` 食の県民性対決 (米単独はカバーしてない)
+- `noodle-consumption-prefecture-character` 麺消費
+- 米消費の都道府県別記事は**ゼロ**
+
+#### 記事の切り口（案）
+1. **米消費量ランキング**: 1人当たり米購入量 (家計調査)、新潟・山形・東北 vs 沖縄・大阪
+2. **米離れの地域差**: どの県が「米離れ」が早かったか、世代差との関係
+3. **生産県 vs 消費県の逆転**: 新潟 (1位生産県) 県民の米消費量は実は高くない仮説検証
+
+#### 推奨チャート
+- 47県棒グラフ: 1 世帯当たり米消費量
+- 散布図: 米生産量 vs 県内消費量 (生産県は本当に消費しているか)
+- 折れ線: 10 年間の米消費トレンド (全国平均 vs 各県)
+
+#### 次のアクション
+- [ ] `/fetch-estat-data` で家計調査の米購入量データ取得
+- [ ] DB に metric 追加 (`rice-purchase-quantity`, `rice-purchase-expenditure`)
+- [ ] 47NEWS 記事を一次ソースとして引用 (5/16付け)
+- [ ] 記事執筆 (slug 案: `rice-consumption-7year-low`)
+
+---
+
+### 候補 3: 47都道府県転入超過数 2025年実績 (マッチ度: ★★★ / ソース: note)
+
+- **トレンド概要**: 総務省「住民基本台帳人口移動報告 2025 年結果」が 2026 年 2 月に発表。note 上で複数のクリエイターがランキング記事をアップ
+- **注目度**: note 検索 1 位記事、関連記事複数
+- **分類カテゴリ**: population
+- **タイミング**: 2026 年 2 月の発表データ、まだ stats47 では未カバー
+- **ヒットソース数**: 1 / 6 (note)
+
+#### 使えるデータ
+| データ | ソース | ranking_key | 備考 |
+|---|---|---|---|
+| 転入者数 | DB既存 | `movers-in` / `japanese-movers-in` | |
+| 転出者数 | DB既存 | `movers-out` / `japanese-movers-out` | |
+| 転入超過率 | DB既存 | `moving-in-excess-rate` / `moving-in-excess-rate-japanese` | |
+| 社会増減数 | DB既存 | `social-increase` / `social-increase-rate` | |
+
+#### 既存記事 (差別化)
+- `future-population-tokyo-paradox` 東京だけが増える 2050 年 → 将来推計ベース
+- → 2025 年**実績ベースで「現在進行形」の社会増減**を扱った記事はゼロ
+
+#### 記事の切り口（案）
+1. **2025 年実績ランキング**: 47 都道府県の転入超過数、東京一極集中の現状
+2. **「選ばれている県」**: 神奈川・千葉・埼玉・福岡 vs 「捨てられている県」
+3. **東京から再流出**: コロナ後の「東京回帰」が続いているか反転したか
+
+#### 推奨チャート
+- 47県棒グラフ: 転入超過数 (黒 = プラス、赤 = マイナス)
+- 折れ線: 過去 10 年の転入超過トレンド (主要都府県)
+- 地図: 増加県 / 減少県のコロプレス
+
+#### 次のアクション
+- [ ] DB の `movers-in` / `social-increase` の最新年（2025）が入っているか確認
+- [ ] 入ってなければ `/fetch-estat-data` で更新
+- [ ] 記事執筆 (slug 案: `migration-2025-tokyo-concentration`)
+
+---
+
+### 候補 4: 真夏日・熱中症拡大 (マッチ度: ★★☆ / クロスソースヒット 3)
+
+- **トレンド概要**: 5/16-17 真夏日、19日頃 35℃予想。熱中症搬送が増加。Google Trends 「岡山県」(高校総体報道) と関連
+- **ヒットソース数**: 3 / 6 (google-trends, google-news, yahoo)
+- **ソース別注目度**:
+  - google-trends: 「岡山県」検索急上昇 100+
+  - google-news: 「明日17日は真夏日地点がさらに増加…35℃予想…熱中症に警戒」
+  - yahoo: 「東京30℃で今年初の真夏日予想」(主要・国内)
+
+#### 使えるデータ
+| データ | ソース | ranking_key | 備考 |
+|---|---|---|---|
+| 年平均気温 | DB既存 | `average-temperature` | landweather |
+| 最高気温 | DB既存 | `maximum-temperature` | landweather |
+| 最低気温 | DB既存 | `lowest-temperature` | landweather |
+| 真夏日数 | (なし) | 要 e-Stat 確認 | candidate 0件 |
+| 熱中症搬送数 | (なし) | 消防庁データ要取得 | DB外 |
+
+#### 既存記事 (差別化)
+- `temperature-extremes-map` 年平均気温 14℃差 → 平均気温メイン、真夏日数や熱中症はカバーしていない
+
+#### 記事の切り口（案）
+1. **真夏日数の都道府県差**: 何月から何月まで真夏日が出るか、夏季の長さの違い
+2. **最高気温記録県**: 過去最高気温の県別、近年の上昇トレンド
+3. **熱中症搬送数ランキング**: 高齢化率との相関 (消防庁データが必要)
+
+#### 推奨チャート
+- 47県棒グラフ: 真夏日年間日数
+- ヒートマップ: 月別真夏日数 × 県 (47×12)
+- 散布図: 高齢化率 × 熱中症搬送数
+
+#### 次のアクション
+- [ ] 気象庁データから真夏日数を抽出 (estat candidate なし、scraping 要検討)
+- [ ] 消防庁「救急搬送 (熱中症)」データ調査
+- [ ] 既存 `temperature-extremes-map` との差別化を明確化
+- [ ] 記事執筆 (slug 案: `summer-day-count-prefecture`)
+
+---
+
+### 候補 5: 使用済み核燃料への課税 (マッチ度: ★★★ / ソース: news + yahoo)
+
+- **トレンド概要**: Yahoo!経済 トピックスで「使用済み核燃料に課税 原子力施設立地市町の税収、15年で2.5倍」(8:24 GMT)。原発立地自治体の財政が話題
+- **ヒットソース数**: 2 / 6 (google-news, yahoo)
+- **ソース別注目度**:
+  - yahoo (経済): 主要トピック
+  - google-news (テクノロジー): 同記事
+
+#### 使えるデータ
+| データ | ソース | ranking_key | 備考 |
+|---|---|---|---|
+| 原子力発電所数 | DB既存 | `nuclear-power-plant-count` | energy |
+| 発電電力量 | DB既存 | `electricity-generation-capacity` | |
+| 地方税収 | DB既存 | `local-tax-prefecture` | administrativefinancial |
+| 地方交付税 | DB既存 | `local-allocation-tax-prefecture` | |
+| 地方税割合 | DB既存 | `local-tax-ratio-pref-finance` | 自前財源比率 |
+
+#### 既存記事 (差別化)
+- `local-tax-revenue-gap` 地方税だけで回る県 → 一般論
+- `electricity-bill-hike-impact` 電気代値上げ → 消費者側
+- → 原発立地県の財政依存に踏み込んだ記事はゼロ
+
+#### 記事の切り口（案）
+1. **原発立地県の財政成績表**: 福井・福島・新潟・佐賀など 13 道県の電源三法交付金 + 課税収入
+2. **原発がなくなると財政はどうなるか**: 廃炉・運転停止が地方財政に与えるインパクト
+3. **使用済み核燃料税**: 立地市町の独自課税スキーム、税収トレンド
+
+#### 推奨チャート
+- 47県棒グラフ: 原発立地県の地方税自前割合 (vs 非立地県)
+- 折れ線: 原発立地市町の税収推移 15 年
+- 表: 電源三法交付金の都道府県別配分
+
+#### 次のアクション
+- [ ] 経済産業省・原発立地市町の電源三法交付金データを調査
+- [ ] estat metainfo に該当データなし → 外部データ要参照
+- [ ] 記事執筆 (slug 案: `nuclear-plant-municipality-finance`)
+
+---
+
+## 候補詳細 (マッチ度 ★★☆)
+
+### 候補 6: 私大削減案 (クロスソースヒット 3)
+
+- **ヒットソース**: hatena (五月祭爆破予告), google-news (政治), yahoo (国内)
+- **使えるデータ**: `university-count-per-100k`, `private-university-student-ratio`, `university-capacity-index`, `university-advancement-capacity` 等
+- **既存記事**: `university-advancement-capacity` (進学率) → 私立大学過剰県・不足県の論点は手薄
+- **切り口**:
+  1. 私大学生比率が高い県・低い県、地方私大の経営状況
+  2. 短大が消えた県・残った県 (短大廃止トレンド)
+  3. 18歳人口減少と私大定員のミスマッチ
+- **slug 案**: `private-university-oversupply-prefecture`
+
+### 候補 7: ナフサ・食品値上げ (クロスソースヒット 3)
+
+- **ヒットソース**: google-trends (ナフサショック), google-news (おかめ納豆15%値上げ, JA全農 肥料14.5%値上げ), yahoo (経済)
+- **使えるデータ**: `cpi-change-rate-total`, `consumer-price-difference-index-overall`, `food-price-regional-2026` (既存記事)
+- **既存記事 (差別化困難)**: `food-price-regional-2026`, `household-spending-before-after-inflation`, `inflation-rate-prefecture-gap`, `price-index-high-low-prefecture` — **4 本既出のため新規企画は慎重に**
+- **差別化案**: 「2026年5月時点の食品物価追加調査 (おかめ納豆15%値上げ後)」のスナップショット更新版として `food-price-regional-2026` を改稿する案
+
+### 候補 8: 5大銀行純利益 / 銀行預金
+
+- **ヒットソース**: google-news (ビジネス)
+- **使えるデータ**: `domestic-bank-deposit-balance`, `bank-deposit-balance-per-person`, `bank-personal-deposit`, `bank-loan-balance`
+- **既存記事**: なし
+- **切り口**:
+  1. 銀行預金残高ランキング (1人当たり) — 東京・大阪・愛知の集中度
+  2. 預貸率の都道府県差 (都市は融資、地方は預金過剰)
+  3. 預金ストックと所得フローの相関
+- **slug 案**: `bank-deposit-prefecture-concentration`
+
+### 候補 9: TSMC熊本・半導体集中
+
+- **ヒットソース**: hatena (136 ブクマ), google-news (ビジネス)
+- **使えるデータ**: `manufacturing-shipment-prefecture-ranking` (既存記事), `manufacturing-industry-added-value`, `manufacturing-establishments`
+- **既存記事 (差別化困難)**: `manufacturing-shipment-prefecture-ranking` (愛知一強の話)
+- **差別化案**: 熊本県の製造業 5 年トレンド (TSMC 前 / 後)。九州製造業のリバランス
+
+### 候補 10: マチアプ自治体助成
+
+- **ヒットソース**: yahoo (地域)
+- **使えるデータ**: `marriages`, `unmarried-ratio-*`, `average-age-of-first-marriage-*`
+- **既存記事**: `marriage-divorce-okinawa`, `marriage-unmarried-crisis`, `unmarried-rate-40years-crisis` (3 本)
+- **差別化案**: 自治体の少子化対策予算 (マチアプ助成 / 結婚支援) の地域比較。**自治体側の支出データが必要**
+
+### 候補 12: 47都道府県格差変動スコア (note)
+
+- **ヒットソース**: note
+- **既存記事 (差別化困難)**: `livable-prefecture-composite-ranking`, `childcare-friendly-prefecture-ranking` (合成スコア記事)
+- **差別化案**: 「10 年で格差が広がった指標 / 縮まった指標」の探索的可視化 (note の競合記事と切り口を変える)
+
+---
+
+## 除外トレンド
+
+| トレンド | 除外理由 |
+|---|---|
+| 菅野智之 / 亀田興毅 / G大阪ACL2優勝 / 大谷翔平 / 前田大然 / 安部裕葵 | スポーツ選手・試合結果 |
+| eurovision 2026 / 百想芸術大賞 | 海外エンタメ |
+| にじさんじフェス2026 / エバース / Switch Online / ARC Raiders / MURASH GAMING / THE SECOND | ゲーム・お笑い・サブカル |
+| xperia / iPhone 17e / Nothing Phone | 商品単発リリース (一般スマホ普及率ならカバー可) |
+| 宮根誠司 / 名探偵コナン声優死去 / 櫻坂46卒業 / 蘭役死去 / 元北海道知事死去 | 個人ニュース・訃報 |
+| トランプ / 米中首脳会談 / 台湾独立 / イラン情勢 / イスラエル / ガザ / スペースX IPO / ラトビア首相辞任 / 文革 / アフリカ青年遭難 | 海外政治・国際情勢 (都道府県データ結合困難) |
+| 山崎和佳奈さん死去 / 増本綺良卒業 | 個人 (芸能) |
+| Claude Code / Claudeミュトス / OpenAI ChatGPT / LLM限界 / AI漫劇 | テック詳報 (一般利用普及率ならカバー可) |
+| キッセイ薬品 血管炎治療薬 20人死亡 / 米承認撤回 | 個別企業案件 (統計化困難) |
+| エボラ コンゴ感染 240人 / ハマス軍事部門トップ殺害 | 海外 (日本データなし) |
+| 巨大蛇行剣古墳 / 唐辛子1000倍辛い植物 / クリトリス×粒子加速器 / 6万年前石器虫歯 | 学術・サイエンス単発話題 |
+| 仙台市の宮城県からの独立 | 地域政治運動 (★☆☆ で候補入り) |
+| 自衛隊「大将」「大佐」呼称変更 | 制度変更で metrics データ少 (★☆☆ で候補入り) |
+| 五月祭爆破予告 (個別事件) | 事件 (大学テーマで★★☆候補入り) |
+| ちいかわ入店禁止 / 朝セールコンビニ / NOJESS終了 / 古い漫画雑誌 | 個別ビジネス事象 |
+| 部活移動 車出し / 指定サングラス / 高2保護者会 | 個別教育論議 |
+| 名鉄駅モニター / 3きょうだい22年前再現 / 山頂リュック / アフリカ青年 | 個別ヒューマン記事 |
+| アメリカ皮膚科学会 日焼け止め誤情報 / 高血圧の日 / 米国市況 / 円安 (個別) | 個別海外/市況 |
+
+---
+
+## 推奨アクション (今日着手すべき順)
+
+1. **小麦粉消費量 (slug: `wheat-flour-konamon-culture`)** — GSC 由来の確実な流入機会。データは既に DB にあり、すぐ書ける。**今日 1 番**
+2. **47都道府県転入超過数 2025 (slug: `migration-2025-tokyo-concentration`)** — 2026年2月の最新データを反映、note 競合が既に書いているが stats47 ブランドで上書き可能
+3. **コメ消費量・米離れ (slug: `rice-consumption-7year-low`)** — はてブ 219 ブクマで議論中、家計調査データを少し追加で書ける
+4. **使用済み核燃料・原発立地市町の財政 (slug: `nuclear-plant-municipality-finance`)** — 外部データ要調査だがユニーク。中期執筆
+5. **5大銀行純利益 / 銀行預金 (slug: `bank-deposit-prefecture-concentration`)** — 既存記事ゼロでデータあり、執筆余地大
+
+物価系 (候補 7) は既出 4 本があるため新規ではなく `food-price-regional-2026` の更新版として書き直す方が無駄が少ない。
+
+## メタ情報
+
+- **GSC コンテンツギャップ検出力低下中**: WoW では new/up 共にゼロ。stats47 のオーガニック検索規模がまだ小さく、wow ではノイズに埋もれる。MoM (28日) を運用したほうがシグナル抽出力高い
+- **note 経由のトレンドソースは精度低**: WebFetch では note.com の Topic ページが取れない (JS レンダリング)。WebSearch で間接取得した結果は stats47 自身の記事が紛れ込むため要フィルタ
+- **Yahoo!ニュース life カテゴリ取得失敗 (500)**: 影響軽微 (他カテゴリでカバー)
+- 次回サマリーで「3週連続出ているクロスソースヒット」を追跡するとシグナル品質向上見込み


### PR DESCRIPTION
## Summary

`discover-trends` skill で生成された 2026-05-17 のトレンド snapshot を追加 (過去分と同じ運用)。

- GSC コンテンツギャップ: 小麦粉消費量 (本 PR と同日デプロイの新規記事 #7 でカバー済)
- はてブ 219 ブクマ: 米消費量 (次回企画候補)
- クロスソースヒット 4 件: 真夏日 (新規記事 extreme-heat-days で部分カバー)、私大削減、ナフサ値上げ、自衛隊改革

## Test plan

- [ ] git ls-files で trends-all-2026-05-17.md が tracked