### PR TITLE
feat(ranking-seo): Tier 1+2+3 SEO仕上げ (OG image / sitemap lastmod / a11y / 最終更新表示)

### DIFF
--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -55,6 +55,24 @@ import { ThemeProvider } from "@/providers/theme-provider";
 export const metadata = generateRootMetadata();
 
 /**
+ * Viewport / themeColor (Next.js 15 の viewport export)
+ * - themeColor: iOS Safari ステータスバー / PWA タイル色
+ * - light/dark 両モード対応
+ *
+ * `import type { Viewport } from "next"` を使うと eslint import/order が
+ * `next` (bare) と他の external の並び順 + group 分離で恒久的に衝突するため、
+ * inline 型注釈 (`satisfies import("next").Viewport`) で代替する。
+ */
+export const viewport = {
+  themeColor: [
+    { media: "(prefers-color-scheme: light)", color: "#ffffff" },
+    { media: "(prefers-color-scheme: dark)", color: "#0f172a" },
+  ],
+  width: "device-width",
+  initialScale: 1,
+} satisfies import("next").Viewport;
+
+/**
  * ルートレイアウトコンポーネント
  *
  * @param children - レイアウト内に表示するコンテンツ（各ページのコンポーネント）

--- a/apps/web/src/app/sitemap.ts
+++ b/apps/web/src/app/sitemap.ts
@@ -113,6 +113,7 @@ async function getRankingPages(): Promise<MetadataRoute.Sitemap> {
     })
     .map((row) => ({
       url: `${BASE_URL}/ranking/${row.rankingKey}`,
+      lastModified: row.updatedAt ? new Date(row.updatedAt) : undefined,
       changeFrequency: "monthly" as const,
       priority: 0.9,
     }));

--- a/apps/web/src/features/ranking/components/AiContentAccordion.tsx
+++ b/apps/web/src/features/ranking/components/AiContentAccordion.tsx
@@ -21,7 +21,7 @@ export function AiContentAccordion({ title, children }: AiContentAccordionProps)
       <Accordion type="single" collapsible>
         <AccordionItem value="content" className="border-none">
           <AccordionTrigger className="px-6 py-4 hover:no-underline">
-            <h3 className="text-lg font-semibold">{title}</h3>
+            <h2 className="text-lg font-semibold">{title}</h2>
           </AccordionTrigger>
           <AccordionContent className="px-6 pb-6 pt-0">
             {children}

--- a/apps/web/src/features/ranking/components/AiMarkdownContent.tsx
+++ b/apps/web/src/features/ranking/components/AiMarkdownContent.tsx
@@ -1,16 +1,59 @@
+import Link from "next/link";
+
 import ReactMarkdown from "react-markdown";
 import remarkBreaks from "remark-breaks";
 import remarkGfm from "remark-gfm";
 
 import { addLineBreaksAfterPeriod } from "../utils";
 
-const proseClasses = "prose prose-sm dark:prose-invert max-w-none text-muted-foreground prose-headings:text-foreground prose-h2:text-[15px] prose-h2:font-semibold prose-h2:mt-5 prose-h2:mb-1 prose-h3:text-sm prose-h3:font-semibold prose-h3:mt-4 prose-h3:mb-1 prose-p:my-2 prose-p:leading-relaxed";
+const proseClasses = "prose prose-sm dark:prose-invert max-w-none text-muted-foreground prose-headings:text-foreground prose-h2:text-[15px] prose-h2:font-semibold prose-h2:mt-5 prose-h2:mb-1 prose-h3:text-sm prose-h3:font-semibold prose-h3:mt-4 prose-h3:mb-1 prose-p:my-2 prose-p:leading-relaxed prose-a:text-primary prose-a:underline-offset-2 hover:prose-a:underline";
 
-/** AI 生成 Markdown をサーバーサイドで HTML に変換して表示する */
+/** 内部 (同一オリジン) リンク判定 */
+function isInternalHref(href: string | undefined): boolean {
+  if (!href) return false;
+  if (href.startsWith("/") || href.startsWith("#")) return true;
+  try {
+    const url = new URL(href);
+    return /(^|\.)stats47\.jp$/.test(url.hostname);
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * AI 生成 Markdown を HTML に変換して表示する。
+ *
+ * リンクハンドリング:
+ * - 内部 (相対 path or stats47.jp) → next/link で SPA 遷移、内部リンク評価対象
+ * - 外部 → `target="_blank" rel="noopener noreferrer"` でセキュリティ確保
+ */
 export function AiMarkdownContent({ content }: { content: string }) {
   return (
     <div className={proseClasses}>
-      <ReactMarkdown remarkPlugins={[remarkGfm, remarkBreaks]}>
+      <ReactMarkdown
+        remarkPlugins={[remarkGfm, remarkBreaks]}
+        components={{
+          a: ({ href, children, ...rest }) => {
+            if (isInternalHref(href)) {
+              return (
+                <Link href={href as string} {...rest}>
+                  {children}
+                </Link>
+              );
+            }
+            return (
+              <a
+                href={href}
+                target="_blank"
+                rel="noopener noreferrer"
+                {...rest}
+              >
+                {children}
+              </a>
+            );
+          },
+        }}
+      >
         {addLineBreaksAfterPeriod(content)}
       </ReactMarkdown>
     </div>

--- a/apps/web/src/features/ranking/components/RankingDataTable/index.tsx
+++ b/apps/web/src/features/ranking/components/RankingDataTable/index.tsx
@@ -158,6 +158,8 @@ export function RankingDataTable({
           showRowCount={false}
           className="h-full flex flex-col"
           getRowId={(row) => row.areaCode}
+          ariaLabel={`${rankingItem?.title ?? "ランキング"}の都道府県別データ表`}
+          caption={`${rankingItem?.title ?? "ランキング"}の47都道府県別ランキング表。順位・都道府県名・値・偏差値の列。`}
         />
       </CardContent>
       {cardFooter && (

--- a/apps/web/src/features/ranking/components/RankingFaqSection.tsx
+++ b/apps/web/src/features/ranking/components/RankingFaqSection.tsx
@@ -77,9 +77,9 @@ export function RankingFaqSection({ faqJson, rankingName }: RankingFaqSectionPro
       >
         <details open className="group">
           <summary className="flex cursor-pointer items-center justify-between px-6 py-4 font-semibold text-slate-900">
-            <h3 id="ranking-faq-heading" className="text-lg">
+            <h2 id="ranking-faq-heading" className="text-lg">
               {rankingName} についてよくある質問
-            </h3>
+            </h2>
             <span aria-hidden className="text-muted-foreground transition-transform group-open:rotate-180">
               ▼
             </span>

--- a/apps/web/src/features/ranking/components/RankingKeyPage/RankingKeyPageClient.tsx
+++ b/apps/web/src/features/ranking/components/RankingKeyPage/RankingKeyPageClient.tsx
@@ -327,6 +327,22 @@ export function RankingKeyPageClient({
         });
     };
 
+    // 最終更新日とデータ年度の表示用 (SEO freshness)
+    const formattedUpdated = (() => {
+        if (!rankingItem.updatedAt) return null;
+        try {
+            const d = new Date(rankingItem.updatedAt);
+            if (Number.isNaN(d.getTime())) return null;
+            return d.toISOString().slice(0, 10);
+        } catch {
+            return null;
+        }
+    })();
+    const latestYearName =
+        rankingItem.availableYears?.find((y) => y.yearCode === currentYear)?.yearName ??
+        rankingItem.latestYear?.yearName ??
+        null;
+
     return (
         <div className="container mx-auto px-4 py-4">
             <h1 className="text-2xl font-bold">
@@ -336,6 +352,21 @@ export function RankingKeyPageClient({
                     return detail ? <span className="text-muted-foreground font-normal">（{detail}）</span> : null;
                 })()}
             </h1>
+
+            {/* データ年度 + 最終更新日 (SEO freshness + UX) */}
+            {(formattedUpdated || latestYearName) && (
+                <p className="mt-1 flex flex-wrap items-center gap-3 text-xs text-muted-foreground">
+                    {latestYearName && <span>データ年度: {latestYearName}</span>}
+                    {formattedUpdated && (
+                        <span>
+                            最終更新:{" "}
+                            <time dateTime={rankingItem.updatedAt ?? formattedUpdated}>
+                                {formattedUpdated}
+                            </time>
+                        </span>
+                    )}
+                </p>
+            )}
 
             {/* normalization_basis グループトグル（別URL切替）*/}
             {groupMembers.length > 1 && (

--- a/apps/web/src/features/ranking/components/RankingMapChart/RankingMapChartClient.tsx
+++ b/apps/web/src/features/ranking/components/RankingMapChart/RankingMapChartClient.tsx
@@ -185,21 +185,31 @@ export function RankingMapChartClient({
             </div>
           ) : (
             <>
-              <LeafletChoroplethMap
-                key={`${areaType}-${currentTile.url}`}
-                topology={activeTopology}
-                data={filteredData}
-                colorConfig={mapConfig}
-                tileUrl={currentTile.url}
-                attribution={currentTile.attribution}
-                unit={rankingItem.unit}
-                onPrefectureClick={areaType === "prefecture" ? handlePrefectureClick : undefined}
-                selectedPrefectureCode={areaType === "prefecture" ? selectedPrefectureCode : undefined}
-                borderColor={isDark ? "#475569" : "#94a3b8"}
-                className="h-[500px]"
-                valueDisplay={rankingItem.valueDisplay ?? undefined}
-                showNoDataLabel={areaType === "prefecture" && filteredData.length < 47}
-              />
+              {/* SR-only summary: 地図の代替テキスト (a11y + SEO) */}
+              <p className="sr-only">
+                {rankingItem.title}の{areaType === "city" ? "市区町村別" : "都道府県別"}カラーマップ。
+                値が高いほど濃い色で表示されます。詳細データは下のテーブルを参照してください。
+              </p>
+              <div
+                role="img"
+                aria-label={`${rankingItem.title}の${areaType === "city" ? "市区町村" : "都道府県"}別カラーマップ`}
+              >
+                <LeafletChoroplethMap
+                  key={`${areaType}-${currentTile.url}`}
+                  topology={activeTopology}
+                  data={filteredData}
+                  colorConfig={mapConfig}
+                  tileUrl={currentTile.url}
+                  attribution={currentTile.attribution}
+                  unit={rankingItem.unit}
+                  onPrefectureClick={areaType === "prefecture" ? handlePrefectureClick : undefined}
+                  selectedPrefectureCode={areaType === "prefecture" ? selectedPrefectureCode : undefined}
+                  borderColor={isDark ? "#475569" : "#94a3b8"}
+                  className="h-[500px]"
+                  valueDisplay={rankingItem.valueDisplay ?? undefined}
+                  showNoDataLabel={areaType === "prefecture" && filteredData.length < 47}
+                />
+              </div>
               <TileSwitcher onTileChange={setCurrentTile} isDark={isDark} />
             </>
           )}

--- a/apps/web/src/features/ranking/components/RankingPageHeader/RankingPageHeader.tsx
+++ b/apps/web/src/features/ranking/components/RankingPageHeader/RankingPageHeader.tsx
@@ -15,6 +15,10 @@ export interface RankingPageHeaderProps {
     annotation?: string | null;
     /** 調査名バッジ（Server Component から注入） */
     surveyBadge?: ReactNode;
+    /** ページ最終更新日 (ISO8601、SEO freshness 表示用) */
+    updatedAt?: string | null;
+    /** データの最新年度（例: "2024年度"） */
+    latestYearName?: string | null;
 }
 
 /**
@@ -30,12 +34,27 @@ export function RankingPageHeader({
     actions,
     annotation,
     surveyBadge,
+    updatedAt,
+    latestYearName,
 }: RankingPageHeaderProps) {
     // メタ情報のパーツを構築（値があるものだけ表示）
     const metaParts: string[] = [];
     if (subtitle) metaParts.push(subtitle);
     if (demographicAttr) metaParts.push(demographicAttr);
     if (normalizationBasis) metaParts.push(normalizationBasis);
+
+    // updatedAt を YYYY-MM-DD に整形 (JST)
+    const formattedUpdated = updatedAt
+        ? (() => {
+              try {
+                  const d = new Date(updatedAt);
+                  if (Number.isNaN(d.getTime())) return null;
+                  return d.toISOString().slice(0, 10);
+              } catch {
+                  return null;
+              }
+          })()
+        : null;
 
     return (
         <div>
@@ -51,6 +70,21 @@ export function RankingPageHeader({
                 </div>
                 {actions && <div className="flex-shrink-0">{actions}</div>}
             </div>
+            {(formattedUpdated || latestYearName) && (
+                <p className="mt-1 flex flex-wrap items-center gap-3 text-xs text-muted-foreground">
+                    {latestYearName && (
+                        <span>データ年度: {latestYearName}</span>
+                    )}
+                    {formattedUpdated && (
+                        <span>
+                            最終更新:{" "}
+                            <time dateTime={updatedAt ?? formattedUpdated}>
+                                {formattedUpdated}
+                            </time>
+                        </span>
+                    )}
+                </p>
+            )}
             {annotation && (
                 <p className="text-xs text-muted-foreground mt-1 whitespace-pre-wrap leading-relaxed">
                     {annotation}

--- a/apps/web/src/features/ranking/components/RankingPrefectureCommentarySection.tsx
+++ b/apps/web/src/features/ranking/components/RankingPrefectureCommentarySection.tsx
@@ -74,12 +74,12 @@ export function RankingPrefectureCommentarySection({
       <Accordion type="single" collapsible>
         <AccordionItem value="root" className="border-none">
           <AccordionTrigger className="px-6 py-4 hover:no-underline">
-            <h3
+            <h2
               id="prefecture-commentary-heading"
               className="text-lg font-semibold"
             >
               都道府県別の解説（全{sorted.length}県）
-            </h3>
+            </h2>
           </AccordionTrigger>
           <AccordionContent className="px-6 pb-6 pt-0">
             <p className="mb-3 text-sm text-muted-foreground">

--- a/apps/web/src/features/ranking/utils/__tests__/generate-meta-data.test.ts
+++ b/apps/web/src/features/ranking/utils/__tests__/generate-meta-data.test.ts
@@ -12,6 +12,7 @@ const mockItem: Partial<RankingItem> = {
     unit: "万円",
     latestYear: { yearCode: "2021", yearName: "2021年度" },
     availableYears: [{ yearCode: "2021", yearName: "2021年度" }],
+    updatedAt: "2026-05-17T03:00:00.000Z",
 };
 
 describe("generateRankingPageMetaData", () => {
@@ -46,14 +47,45 @@ describe("generateRankingPageMetaData", () => {
         expect((result.twitter as Record<string, unknown>)?.card).toBe("summary_large_image");
     });
 
-    it("openGraph.images を設定しない（opengraph-image.tsx に委ねる）", () => {
+    it("openGraph.images / twitter.images を ranking 別動的画像 URL で明示設定する", () => {
         const result = generateRankingPageMetaData({
             rankingItem: mockItem as RankingItem,
             areaType: "prefecture",
         });
 
-        expect((result.openGraph as Record<string, unknown>)?.images).toBeUndefined();
-        expect((result.twitter as Record<string, unknown>)?.images).toBeUndefined();
+        const og = result.openGraph as Record<string, unknown>;
+        const ogImages = og.images as Array<Record<string, unknown>>;
+        expect(ogImages).toHaveLength(1);
+        expect(ogImages[0].url).toBe("/ranking/annual-sales-amount-per-employee/opengraph-image");
+        expect(ogImages[0].width).toBe(1200);
+        expect(ogImages[0].height).toBe(630);
+
+        const twitter = result.twitter as Record<string, unknown>;
+        const twImages = twitter.images as string[];
+        expect(twImages).toEqual(["/ranking/annual-sales-amount-per-employee/opengraph-image"]);
+    });
+
+    it("openGraph.url が canonical path を指すこと", () => {
+        const result = generateRankingPageMetaData({
+            rankingItem: mockItem as RankingItem,
+            areaType: "prefecture",
+        });
+
+        const og = result.openGraph as Record<string, unknown>;
+        expect(og.url).toBe("/ranking/annual-sales-amount-per-employee");
+    });
+
+    it("updatedAt があれば article:modified_time + openGraph.modifiedTime に出力される", () => {
+        const result = generateRankingPageMetaData({
+            rankingItem: mockItem as RankingItem,
+            areaType: "prefecture",
+        });
+
+        const og = result.openGraph as Record<string, unknown>;
+        expect(og.modifiedTime).toBe("2026-05-17T03:00:00.000Z");
+
+        const other = result.other as Record<string, unknown> | undefined;
+        expect(other?.["article:modified_time"]).toBe("2026-05-17T03:00:00.000Z");
     });
 
     it("canonical URLが正しく設定されていること", () => {

--- a/apps/web/src/features/ranking/utils/generate-meta-data.ts
+++ b/apps/web/src/features/ranking/utils/generate-meta-data.ts
@@ -1,7 +1,15 @@
 /**
  * ランキングページのメタデータ生成
  *
- * SEO対策のためのメタデータを生成
+ * SEO対策のためのメタデータを生成。
+ *
+ * OG / Twitter Card:
+ *   - 画像は ranking 別に動的生成される `/ranking/[rankingKey]/opengraph-image` を参照
+ *   - `metadataBase` (root-metadata) により相対 URL → 絶対 URL に展開される
+ *
+ * Freshness:
+ *   - `article:modified_time` + `openGraph.modifiedTime` で OG/Article spec 上の更新日を表現
+ *   - JSON-LD `dateModified` (generate-structured-data) と二重に出すことで Google freshness 評価強化
  */
 
 import {
@@ -30,6 +38,8 @@ export function generateRankingPageMetaData({
 
   const title = rankingItem.seoTitle ?? rankingItem.title;
   const description = rankingItem.seoDescription ?? "";
+  const path = `/ranking/${rankingItem.rankingKey}`;
+  const ogImagePath = `${path}/opengraph-image`;
 
   return {
     title,
@@ -38,14 +48,32 @@ export function generateRankingPageMetaData({
       title,
       description,
       type: "article",
+      url: path,
+      images: [
+        {
+          url: ogImagePath,
+          width: 1200,
+          height: 630,
+          alt: title,
+        },
+      ],
+      ...(rankingItem.updatedAt && {
+        modifiedTime: rankingItem.updatedAt,
+      }),
     },
     twitter: {
       card: "summary_large_image",
       title,
       description,
+      images: [ogImagePath],
     },
     alternates: {
-      canonical: `/ranking/${rankingItem.rankingKey}`,
+      canonical: path,
     },
+    ...(rankingItem.updatedAt && {
+      other: {
+        "article:modified_time": rankingItem.updatedAt,
+      },
+    }),
   };
 }

--- a/packages/components/src/molecules/data-table/components/data-table-header-cell.tsx
+++ b/packages/components/src/molecules/data-table/components/data-table-header-cell.tsx
@@ -25,6 +25,7 @@ export function DataTableHeaderCell<TData, TValue>({
     if (header.isPlaceholder) {
         return (
             <th
+                scope="col"
                 style={{ width, minWidth }}
                 className="h-10 px-3 py-2 text-sm text-left align-middle font-medium text-muted-foreground [&:has([role=checkbox])]:pr-0"
             />
@@ -34,6 +35,7 @@ export function DataTableHeaderCell<TData, TValue>({
     if (!canSort) {
         return (
             <th
+                scope="col"
                 style={{ width, minWidth }}
                 className="h-10 px-3 py-2 text-sm text-left align-middle font-medium text-muted-foreground [&:has([role=checkbox])]:pr-0"
             >
@@ -44,6 +46,7 @@ export function DataTableHeaderCell<TData, TValue>({
 
     return (
         <th
+            scope="col"
             style={{ width, minWidth }}
             className="h-10 px-3 py-2 text-sm text-left align-middle font-medium text-muted-foreground [&:has([role=checkbox])]:pr-0"
         >

--- a/packages/components/src/molecules/data-table/data-table.tsx
+++ b/packages/components/src/molecules/data-table/data-table.tsx
@@ -40,6 +40,8 @@ export function DataTable<TData>({
     onRowClick,
     rowClassName,
     showRowCount = true,
+    ariaLabel,
+    caption,
 }: DataTableProps<TData> & { className?: string }) {
     // インデックス・行選択カラムを追加
     const columnsWithExtras = useIndexColumn(columns, showIndex, enableRowSelection);
@@ -87,7 +89,13 @@ export function DataTable<TData>({
                     />
                 ) : (
                     <div className="flex-1 overflow-auto relative min-h-0">
-                        <table className="w-full caption-bottom text-sm table-fixed">
+                        <table
+                            className="w-full caption-bottom text-sm table-fixed"
+                            {...(ariaLabel ? { "aria-label": ariaLabel } : {})}
+                        >
+                            {caption && (
+                                <caption className="sr-only">{caption}</caption>
+                            )}
                             <DataTableHeader table={table} enableSorting={enableSorting} />
                             <DataTableBody table={table} emptyMessage={emptyMessage} onRowClick={onRowClick} rowClassName={rowClassName} />
                         </table>

--- a/packages/components/src/molecules/data-table/types.ts
+++ b/packages/components/src/molecules/data-table/types.ts
@@ -27,6 +27,10 @@ export interface DataTableProps<TData> {
   rowClassName?: (row: TData) => string | undefined;
   /** ページネーションの総件数ラベルを非表示にする */
   showRowCount?: boolean;
+  /** テーブルのアクセシブル名 (aria-label) — スクリーンリーダー向け */
+  ariaLabel?: string;
+  /** テーブルの caption (sr-only で SEO + a11y、視覚的には非表示) */
+  caption?: string;
 }
 
 export interface DataTableColumnMeta {


### PR DESCRIPTION
## Summary

PR #301 で投入した SEO 基盤に続く第 2 弾。技術 SEO + a11y の 9 改修で「最高品質」に仕上げる。

### Tier 1: メタタグ + sitemap + freshness
- **og:image / twitter:image / og:url**: `/ranking/[key]/opengraph-image` を明示参照 → SNS シェア時 CTR ↑
- **article:modified_time + og:modifiedTime**: rankingItem.updatedAt → Google freshness シグナル
- **sitemap lastmod**: ranking entries に updatedAt 反映 → 再クロール頻度 ↑
- **themeColor**: viewport export で light/dark 両対応

### Tier 2: a11y + 構造
- **DataTable**: `<caption>` (sr-only) + `<th scope="col">` 全件統一 + ariaLabel
- **Leaflet 地図**: role="img" + aria-label + sr-only 代替テキスト
- **見出し階層**: section 見出し h3 → h2 統一 (Accordion 系 3 ファイル)
- **AiMarkdownContent**: 内部リンクは next/link、外部リンクは target=_blank rel="noopener noreferrer"

### Tier 3: 可視 freshness
- ranking h1 直下に `<time>最終更新: YYYY-MM-DD</time>` + データ年度 表示

## Test plan

- [x] `npx vitest run apps/web/src/features/ranking` → 59/59 pass
- [x] generate-meta-data.test.ts に og.images / twitter.images / og.url / modifiedTime テスト 4 件追加
- [x] ranking-faq-section.test.ts 8/8 pass (regression なし)
- [x] `npx tsc --noEmit -p apps/web/tsconfig.json` clean
- [x] `npx next lint --dir src` (apps/web cwd) clean
- [ ] CI green を確認
- [ ] マージ後本番反映 → ranking ページの HTML で確認:
  - `<meta property="og:image">` が `/ranking/<key>/opengraph-image` を指す
  - `<meta property="article:modified_time">` 出力
  - `<meta name="theme-color">` 出力
  - `<table>` に `<caption>` と `<th scope>` 付与
  - 地図に `aria-label`
  - h1 直下に最終更新日表示
  - sitemap.xml の `/ranking/*` entries に `<lastmod>` 含む
- [ ] Lighthouse SEO スコア 100 / a11y 95+ 期待
- [ ] GSC リッチリザルトテストで Dataset / FAQPage / Breadcrumb valid
- [ ] Twitter Card Validator で `summary_large_image` 画像付き表示

## 残作業 (別 PR / 別セッション)

- prefectureCommentary AI 生成 (~600 ranking、generate-parallel.ts はユーザー端末で実行)
- Statistic / Q&A 個別ページ等の追加スキーマ (現時点ではスコープ外)

🤖 Generated with [Claude Code](https://claude.com/claude-code)