### PR TITLE
fix(layout): body スクロール化で next/image lazy load 復活 + develop 集約

### DIFF
--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -144,24 +144,22 @@ export default function RootLayout({
         {/* テーマプロバイダー（ダークモード対応） */}
         <ThemeProvider>
           {/* メインレイアウトコンテナ */}
-          <div className="relative flex flex-col h-screen overflow-hidden" suppressHydrationWarning>
+          <div className="relative flex flex-col" suppressHydrationWarning>
             {/* ヘッダー（全ページ共通） */}
             <Header />
             {/* コンテンツエリア（サイドバー + メインコンテンツ） */}
-            <div className="flex flex-1 min-h-0">
+            <div className="flex flex-1">
               {/* サイドバーナビゲーション */}
               <Suspense fallback={<SidebarSkeleton />}>
                 <Sidebar />
               </Suspense>
               {/* メインコンテンツエリア（各ページのコンテンツがここに表示される） */}
-              <main className="flex-1 min-h-0 overflow-y-auto">
+              <main className="flex-1 min-w-0">
                 {children}
               </main>
             </div>
             {/* フッター（全ページ共通） */}
-            <div className="flex-shrink-0">
-              <Footer />
-            </div>
+            <Footer />
           </div>
           {/* トースト通知（成功、エラー、警告などの通知を表示） */}
           <Toaster position="top-right" richColors />

--- a/apps/web/src/components/organisms/Sidebar/SidebarClient.tsx
+++ b/apps/web/src/components/organisms/Sidebar/SidebarClient.tsx
@@ -153,7 +153,7 @@ export function SidebarClient({ categories, error }: SidebarClientProps) {
   }
 
   return (
-    <div className="hidden lg:block shrink-0 h-full">
+    <div className="hidden lg:block shrink-0 sticky top-16 self-start h-[calc(100vh-4rem)]">
       <div className="w-60 min-w-[240px] shrink-0 h-full bg-sidebar border-r border-border flex flex-col">
         {sidebarInner}
       </div>

--- a/apps/web/src/components/organisms/Sidebar/SidebarSkeleton/index.tsx
+++ b/apps/web/src/components/organisms/Sidebar/SidebarSkeleton/index.tsx
@@ -7,7 +7,7 @@
 
 export function SidebarSkeleton() {
   return (
-    <div className="w-60 h-full bg-sidebar border-r border-border flex flex-col">
+    <div className="hidden lg:flex w-60 shrink-0 sticky top-16 self-start h-[calc(100vh-4rem)] bg-sidebar border-r border-border flex-col">
       {/* Content */}
       <div className="flex-1 overflow-y-auto p-4">
         {/* Home Section */}


### PR DESCRIPTION
## Summary

- **fix(layout)**: \`h-screen overflow-hidden\` を解除し body スクロール化。`next/image` の lazy load が `<main>` のスクロールを検知できず viewport 外の thumbnail が永久に fetch されない問題を解消（/blog で 51/179 → 179/179 リクエスト、Playwright 実証済み）
- **feat(blog)**: chart-placeholder を inline SVG bar chart に置換、GSC 起点ブログ量産フロー (article-writer agent)、measure-gsc-impact baseline
- **feat(ranking-seo)**: Tier 1+2+3 仕上げ (OG image / sitemap lastmod / a11y / 最終更新表示)、FAQ 可視化 / Dataset 強化 / Category breadcrumb
- **feat(ai-content)**: generate-parallel に haiku/sonnet/opus model 切替・prefectureCommentary backfill
- **feat(infra)**: YouTube OAuth weekly health check workflow
- **docs(cleanup)**: 80_参考資料 廃止 + frontmatter 整備、PR を develop→main 1 段階に集約

## Test plan

- [x] /blog 全 179 thumbnail が表示される（Playwright で window scroll 後 179/179 リクエスト確認）
- [x] Sidebar が sticky で固定表示維持（`top:64px`）
- [x] Console エラー 0
- [ ] 本番マージ後、storage.stats47.jp の thumbnail が正常表示されるか手動確認
- [ ] Footer の挙動変化（常時表示 → 末尾スクロールイン）が許容範囲か視覚確認
- [ ] CI green