### PR TITLE
fix(redesign): マスタープラン準拠に hero/home 復元 + 関連 develop 取込

### DIFF
--- a/apps/web/src/app/category/[categoryKey]/page.tsx
+++ b/apps/web/src/app/category/[categoryKey]/page.tsx
@@ -29,6 +29,9 @@ import {
   type CategoryRankingListItem,
 } from "@/features/ranking";
 import {
+  HeroShell,
+  KpiGrid,
+  KpiTile,
   NativeAffiliateRow,
   SectionEyebrow,
   InfeedAd,
@@ -193,23 +196,50 @@ export default async function CategoryPage({ params }: PageProps) {
 
   return (
     <div className="container mx-auto px-4 py-4 text-foreground">
-      {/* Hero (軽量): カテゴリ名 + 件数 + メタ */}
-      <header className="mb-5">
-        <p className="text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">
-          カテゴリ
-        </p>
-        <h1 className="mt-1 text-2xl font-bold leading-tight text-foreground sm:text-3xl">
-          {category.categoryName}
-          <span className="ml-3 align-middle text-xs font-medium text-muted-foreground">
-            {rankingItems.length}件
-            {featuredCount > 0 && ` · 注目${featuredCount}件`}
-            {latestYear && ` · 最新${latestYear}年`}
-          </span>
-        </h1>
-        <p className="mt-2 max-w-2xl text-sm leading-relaxed text-muted-foreground">
-          {category.categoryName}分野の都道府県別ランキングを、地図・グラフ・テーブルで比較できます。
-        </p>
-      </header>
+      {/* Hero (D 暗色) — マスタープラン § 5.3 準拠 */}
+      <HeroShell variant="dark" className="mb-6">
+        <div className="grid grid-cols-1 gap-6 p-6 md:grid-cols-[1fr,420px] md:p-8">
+          <div className="min-w-0">
+            <p className="inline-flex rounded-full bg-white/15 px-2.5 py-0.5 text-[10.5px] font-bold uppercase tracking-widest text-white">
+              カテゴリ
+            </p>
+            <h1 className="mt-2 text-2xl font-extrabold leading-tight text-white sm:text-3xl">
+              {category.categoryName}
+            </h1>
+            <p className="mt-2 max-w-xl text-sm leading-relaxed text-white/85">
+              {category.categoryName}分野の都道府県別ランキング {rankingItems.length} 件を、地図・グラフ・テーブルで比較できます。
+            </p>
+          </div>
+          <div>
+            <KpiGrid columns={2}>
+              <KpiTile
+                label="ランキング数"
+                value={String(rankingItems.length)}
+                unit="件"
+                variant="dark"
+              />
+              <KpiTile
+                label="注目"
+                value={String(featuredCount)}
+                unit="件"
+                variant="dark"
+              />
+              <KpiTile
+                label="最新データ"
+                value={latestYear || "—"}
+                unit={latestYear ? "年" : ""}
+                variant="dark"
+              />
+              <KpiTile
+                label="関連調査"
+                value={String(surveysResult.length)}
+                unit="件"
+                variant="dark"
+              />
+            </KpiGrid>
+          </div>
+        </div>
+      </HeroShell>
 
       <div className="flex gap-4 items-start">
         {/* メインコンテンツ */}

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -1,7 +1,7 @@
 import Link from "next/link";
 
 import { Button } from "@stats47/components/atoms/ui/button";
-import { BarChart3, ExternalLink, MapPin, Search, TrendingUp } from "lucide-react";
+import { BarChart3, Download, ExternalLink, MapPin, Search, TrendingUp } from "lucide-react";
 import { Metadata } from "next";
 
 import { ThemeAwareImage } from "@/components/atoms/ThemeAwareImage";
@@ -9,6 +9,7 @@ import { ThemeAwareImage } from "@/components/atoms/ThemeAwareImage";
 import { TrackedAffiliateLink } from "@/features/ads";
 import {
   buildFurusatoNozeiUrl,
+  FURUSATO_NOZEI_LINKS,
 } from "@/features/ads/constants/furusato-nozei";
 import { listLatestArticles } from "@/features/blog/server";
 import { FeaturedRankings } from "@/features/ranking/server";
@@ -114,10 +115,30 @@ const DISCOVERY_CARDS = [
   },
 ];
 
+/** ホームのふるさと納税ピックアップ対象（北海道・山形・宮崎・沖縄） */
+const HOME_FURUSATO_PICKS = ["01000", "06000", "45000", "47000"] as const;
+
+/** 県コードに基づく安定パステルパレット (画像なしサムネ用) */
+function pickPalette(prefCode: string) {
+  const palettes = [
+    { start: "#bbf7d0", end: "#16a34a" },
+    { start: "#fbcfe8", end: "#ec4899" },
+    { start: "#fde68a", end: "#f59e0b" },
+    { start: "#bfdbfe", end: "#3b82f6" },
+    { start: "#fef3c7", end: "#fbbf24" },
+    { start: "#ddd6fe", end: "#8b5cf6" },
+  ];
+  const idx = parseInt(prefCode.slice(0, 2), 10) % palettes.length;
+  return palettes[idx];
+}
+
 export default async function HomePage() {
   const latestArticles = await listLatestArticles(4).catch(() => []);
   const affiliateId = process.env.NEXT_PUBLIC_RAKUTEN_AFFILIATE_ID;
-  const furusatoTopUrl = buildFurusatoNozeiUrl("", affiliateId);
+
+  const furusatoPicks = HOME_FURUSATO_PICKS
+    .map((code) => FURUSATO_NOZEI_LINKS.find((l) => l.prefCode === code))
+    .filter((l): l is NonNullable<typeof l> => l != null);
 
   return (
     <div className="w-full" suppressHydrationWarning>
@@ -253,34 +274,121 @@ export default async function HomePage() {
         </section>
       )}
 
-      {/* ⑤ ふるさと納税 1 行ミニバナー (PR) */}
-      <section className="px-4 py-4">
+      {/* ⑤ ふるさと納税 4 県ネイティブ枠 (マスタープラン § 5.3) */}
+      <section className="px-4 py-8">
         <div className="mx-auto max-w-6xl">
-          <TrackedAffiliateLink
-            href={furusatoTopUrl || "https://event.rakuten.co.jp/furusato/"}
-            category="furusato"
-            label="楽天ふるさと納税"
-            position="home-furusato-banner"
-            className="group flex items-center gap-3 rounded-xl border border-amber-200 bg-amber-50/40 px-4 py-3 transition-shadow hover:shadow-sm dark:border-amber-900/40 dark:bg-amber-950/20"
+          <div
+            className="overflow-hidden rounded-2xl border border-amber-200 shadow-sm"
+            style={{
+              background: "linear-gradient(135deg, #fef3c7, #ffffff)",
+            }}
           >
-            <span aria-hidden className="text-xl">🎁</span>
-            <div className="min-w-0 flex-1">
-              <p className="text-sm font-semibold text-amber-900 dark:text-amber-200">
-                都道府県別の人気返礼品を探す
-                <span className="ml-2 rounded-full bg-amber-900 px-1.5 py-0.5 text-[9px] font-bold text-white">
+            <div className="flex flex-col items-start gap-3 border-b border-amber-200 px-5 py-4 sm:flex-row sm:items-center sm:justify-between">
+              <div className="flex items-center gap-3">
+                <span aria-hidden className="text-2xl">🎁</span>
+                <div>
+                  <h2 className="text-base font-bold text-amber-900 sm:text-lg">
+                    地域から選ぶ ふるさと納税
+                  </h2>
+                  <p className="text-xs text-muted-foreground">
+                    都道府県の人気返礼品ピックアップ
+                  </p>
+                </div>
+                <span className="ml-2 rounded-full bg-amber-900 px-2 py-0.5 text-[10.5px] font-semibold text-white">
                   PR
                 </span>
-              </p>
-              <p className="mt-0.5 text-xs text-muted-foreground">
-                楽天ふるさと納税 — エリア別の返礼品をピックアップ
-              </p>
+              </div>
+              <Link
+                href="/areas"
+                className="rounded-md bg-amber-700 px-3 py-1.5 text-xs font-semibold text-white hover:bg-amber-800"
+              >
+                都道府県から探す →
+              </Link>
             </div>
-            <ExternalLink className="h-4 w-4 shrink-0 text-amber-700" />
-          </TrackedAffiliateLink>
+            <div className="grid grid-cols-2 gap-3 p-4 md:grid-cols-4">
+              {furusatoPicks.map((pick) => {
+                const url = buildFurusatoNozeiUrl(pick.rakutenAreaSlug, affiliateId);
+                const palette = pickPalette(pick.prefCode);
+                return (
+                  <TrackedAffiliateLink
+                    key={pick.prefCode}
+                    href={url}
+                    category="furusato"
+                    label={`${pick.prefName}のふるさと納税`}
+                    position="home-furusato-row"
+                    className="group flex flex-col gap-2 rounded-xl border border-border bg-card p-3 transition-shadow hover:shadow-md"
+                  >
+                    <div
+                      aria-hidden
+                      className="aspect-[4/3] rounded-lg"
+                      style={{
+                        background: `linear-gradient(135deg, ${palette.start}, ${palette.end})`,
+                      }}
+                    />
+                    <div>
+                      <p className="text-[10.5px] font-semibold text-muted-foreground">
+                        {pick.prefName}
+                      </p>
+                      <p className="mt-0.5 line-clamp-2 text-xs font-medium leading-snug text-foreground">
+                        {pick.prefName}の人気返礼品を探す
+                      </p>
+                      <p className="mt-1.5 inline-flex items-center gap-0.5 text-[11px] font-bold text-amber-700">
+                        楽天ふるさと納税
+                        <ExternalLink className="h-3 w-3" />
+                      </p>
+                    </div>
+                  </TrackedAffiliateLink>
+                );
+              })}
+            </div>
+          </div>
         </div>
       </section>
 
-      {/* ⑥ AdSense (footer) */}
+      {/* ⑥ データパック CTA (マスタープラン § 3.3) */}
+      <section className="px-4 py-8">
+        <div className="mx-auto max-w-6xl">
+          <div
+            className="flex flex-col items-start gap-4 rounded-2xl border border-primary/20 p-6 shadow-sm sm:flex-row sm:items-center"
+            style={{
+              background: "linear-gradient(135deg, var(--primary-50, rgba(239,246,255,1)), #ffffff)",
+            }}
+          >
+            <div className="inline-flex h-14 w-14 shrink-0 items-center justify-center rounded-xl bg-primary text-primary-foreground">
+              <Download className="h-7 w-7" />
+            </div>
+            <div className="min-w-0 flex-1">
+              <h2 className="text-base font-bold text-primary">データを活用する</h2>
+              <p className="mt-1 text-xs leading-relaxed text-muted-foreground">
+                1,800指標 × 47都道府県 × 30年 = 250万件以上のデータを CSV で取得できます。クレジット表記すれば無料で商用利用可能。
+              </p>
+            </div>
+            <div className="flex flex-wrap items-center gap-2">
+              <Button asChild>
+                <Link href="/ranking">CSV を見る</Link>
+              </Button>
+              <button
+                type="button"
+                disabled
+                title="準備中"
+                className="cursor-not-allowed rounded-md border border-border bg-muted/30 px-3 py-1.5 text-xs font-medium text-muted-foreground opacity-60"
+              >
+                JSON
+              </button>
+              <button
+                type="button"
+                disabled
+                title="準備中"
+                className="cursor-not-allowed rounded-md border border-border bg-muted/30 px-3 py-1.5 text-xs font-medium text-muted-foreground opacity-60"
+              >
+                Excel
+              </button>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* ⑦ AdSense (footer) */}
       <div className="my-6 flex justify-center px-4">
         <AdSenseAd
           format={RANKING_PAGE_FOOTER.format}

--- a/apps/web/src/app/survey/[surveyKey]/page.tsx
+++ b/apps/web/src/app/survey/[surveyKey]/page.tsx
@@ -22,6 +22,9 @@ import {
   type CategoryRankingListItem,
 } from "@/features/ranking";
 import {
+  HeroShell,
+  KpiGrid,
+  KpiTile,
   NativeAffiliateRow,
   SectionEyebrow,
   InfeedAd,
@@ -155,36 +158,65 @@ export default async function SurveyPage({ params }: PageProps) {
 
   return (
     <div className="container mx-auto px-4 py-4 text-foreground">
-      {/* Hero (軽量): 政府統計バッジ + タイトル + メタ */}
-      <header className="mb-5">
-        <div className="inline-flex items-center gap-1.5 rounded-full bg-primary/10 px-2.5 py-0.5 text-[10.5px] font-semibold text-primary">
-          📊 政府統計
+      {/* Hero (D 暗色) — マスタープラン § 5.3 準拠 */}
+      <HeroShell variant="dark" className="mb-6">
+        <div className="grid grid-cols-1 gap-6 p-6 md:grid-cols-[1fr,420px] md:p-8">
+          <div className="min-w-0">
+            <p className="inline-flex items-center gap-1.5 rounded-full bg-white/15 px-2.5 py-0.5 text-[10.5px] font-bold uppercase tracking-widest text-white">
+              📊 政府統計
+            </p>
+            <h1 className="mt-2 text-2xl font-extrabold leading-tight text-white sm:text-3xl">
+              {survey.name}
+            </h1>
+            <p className="mt-2 text-sm font-medium text-white/80">
+              {survey.organization}
+            </p>
+            {survey.description && (
+              <p className="mt-2 max-w-xl text-sm leading-relaxed text-white/80">
+                {survey.description}
+              </p>
+            )}
+            {survey.url && (
+              <a
+                href={survey.url}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="mt-3 inline-flex items-center gap-1 rounded-md border border-white/30 px-3 py-1.5 text-xs font-medium text-white transition-colors hover:bg-white/10"
+              >
+                公式サイト ↗
+              </a>
+            )}
+          </div>
+          <div>
+            <KpiGrid columns={2}>
+              <KpiTile
+                label="ランキング数"
+                value={String(rankingItems.length)}
+                unit="件"
+                variant="dark"
+              />
+              <KpiTile
+                label="注目"
+                value={String(featuredCount)}
+                unit="件"
+                variant="dark"
+              />
+              <KpiTile
+                label="最新データ"
+                value={latestYear || "—"}
+                unit={latestYear ? "年" : ""}
+                variant="dark"
+              />
+              <KpiTile
+                label="エリア"
+                value="47"
+                unit="都道府県"
+                variant="dark"
+              />
+            </KpiGrid>
+          </div>
         </div>
-        <h1 className="mt-2 text-2xl font-bold leading-tight text-foreground sm:text-3xl">
-          {survey.name}
-          <span className="ml-3 align-middle text-xs font-medium text-muted-foreground">
-            {rankingItems.length}件 · {latestYear || ""}{latestYear ? "年" : ""}
-          </span>
-        </h1>
-        <div className="mt-2 flex flex-wrap items-center gap-x-3 gap-y-1 text-sm text-muted-foreground">
-          <span>{survey.organization}</span>
-          {survey.url && (
-            <a
-              href={survey.url}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="text-primary underline-offset-4 hover:underline"
-            >
-              公式サイト ↗
-            </a>
-          )}
-        </div>
-        {survey.description && (
-          <p className="mt-2 max-w-3xl text-sm leading-relaxed text-muted-foreground">
-            {survey.description}
-          </p>
-        )}
-      </header>
+      </HeroShell>
 
       {featuredItems.length > 0 && (
         <section className="mb-8">

--- a/apps/web/src/app/tag/[tagKey]/page.tsx
+++ b/apps/web/src/app/tag/[tagKey]/page.tsx
@@ -21,7 +21,12 @@ import {
     listAllUniqueTags,
     listArticleSummariesByTagKey,
 } from "@/features/blog/server";
-import { NativeAffiliateRow } from "@/features/redesign";
+import {
+    HeroShell,
+    KpiGrid,
+    KpiTile,
+    NativeAffiliateRow,
+} from "@/features/redesign";
 
 import { AdSenseAd, CONTENT_FOOTER } from "@/lib/google-adsense";
 
@@ -108,21 +113,37 @@ export default async function TagArticlesPage({ params }: PageProps) {
             </div>
 
             <div className="container mx-auto px-4 py-4">
-                {/* Hero (軽量): タグ名 + 件数 */}
-                <header className="mb-5">
-                    <p className="text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">
-                        タグ
-                    </p>
-                    <h1 className="mt-1 text-2xl font-bold leading-tight text-foreground sm:text-3xl">
-                        {tag}
-                        <span className="ml-3 align-middle text-xs font-medium text-muted-foreground">
-                            {articles.length} 記事
-                        </span>
-                    </h1>
-                    <p className="mt-2 max-w-2xl text-sm leading-relaxed text-muted-foreground">
-                        「{tag}」タグが付いた都道府県統計ブログの記事一覧
-                    </p>
-                </header>
+                {/* Hero (D 暗色) — マスタープラン § 5.3 準拠 */}
+                <HeroShell variant="dark" className="mb-6">
+                    <div className="grid grid-cols-1 gap-6 p-6 md:grid-cols-[1fr,320px] md:p-8">
+                        <div className="min-w-0">
+                            <p className="inline-flex items-center gap-1.5 rounded-full bg-white/15 px-2.5 py-0.5 text-[10.5px] font-bold uppercase tracking-widest text-white">
+                                タグ
+                            </p>
+                            <h1 className="mt-2 text-2xl font-extrabold leading-tight text-white sm:text-3xl">
+                                {tag}
+                            </h1>
+                            <p className="mt-2 max-w-xl text-sm leading-relaxed text-white/85">
+                                「{tag}」タグが付いた都道府県統計ブログの記事 {articles.length} 本を掲載しています。
+                            </p>
+                        </div>
+                        <div>
+                            <KpiGrid columns={2}>
+                                <KpiTile
+                                    label="記事数"
+                                    value={String(articles.length)}
+                                    unit="件"
+                                    variant="dark"
+                                />
+                                <KpiTile
+                                    label="タグ"
+                                    value={tag}
+                                    variant="dark"
+                                />
+                            </KpiGrid>
+                        </div>
+                    </div>
+                </HeroShell>
 
                 {articles.length === 0 ? (
                     notFound()

--- a/apps/web/src/app/themes/page.tsx
+++ b/apps/web/src/app/themes/page.tsx
@@ -1,6 +1,11 @@
 
 import Link from "next/link";
 
+import {
+  HeroShell,
+  KpiGrid,
+  KpiTile,
+} from "@/features/redesign";
 import { ALL_THEMES } from "@/features/theme-dashboard/server";
 
 import { AdSenseAd, CONTENT_FOOTER } from "@/lib/google-adsense";
@@ -29,18 +34,49 @@ export default function ThemesPage() {
 
   return (
     <div className="container mx-auto px-4 py-4 text-foreground">
-      {/* Hero (軽量): テーマ一覧の入口 */}
-      <header className="mb-5">
-        <h1 className="text-2xl font-bold text-foreground sm:text-3xl">
-          テーマダッシュボード
-          <span className="ml-3 align-middle text-xs font-medium text-muted-foreground">
-            {ALL_THEMES.length}テーマ / {totalRankings}指標
-          </span>
-        </h1>
-        <p className="mt-2 max-w-2xl text-sm leading-relaxed text-muted-foreground">
-          少子高齢化・労働・医療・観光・物価など、社会課題に直結するダッシュボードでテーマ別に都道府県を比較できます。
-        </p>
-      </header>
+      {/* Hero (D 暗色) — マスタープラン § 5.3 準拠 */}
+      <HeroShell variant="dark" className="mb-6">
+        <div className="grid grid-cols-1 gap-6 p-6 md:grid-cols-[1fr,360px] md:p-8">
+          <div className="min-w-0">
+            <p className="text-[11px] font-bold uppercase tracking-widest text-white/70">
+              ディスカバリー
+            </p>
+            <h1 className="mt-2 text-2xl font-extrabold leading-tight text-white sm:text-3xl">
+              テーマダッシュボード
+            </h1>
+            <p className="mt-2 max-w-xl text-sm leading-relaxed text-white/85">
+              テーマ別に複数の指標を横断して都道府県を比較できます。少子高齢化・労働・医療・観光・物価など、社会課題に直結するダッシュボードを {ALL_THEMES.length} 種類。
+            </p>
+          </div>
+          <div>
+            <KpiGrid columns={2}>
+              <KpiTile
+                label="テーマ数"
+                value={String(ALL_THEMES.length)}
+                unit="件"
+                variant="dark"
+              />
+              <KpiTile
+                label="指標合計"
+                value={String(totalRankings)}
+                unit="件"
+                variant="dark"
+              />
+              <KpiTile
+                label="エリア"
+                value="47"
+                unit="都道府県"
+                variant="dark"
+              />
+              <KpiTile
+                label="可視化"
+                value="地図 + グラフ"
+                variant="dark"
+              />
+            </KpiGrid>
+          </div>
+        </div>
+      </HeroShell>
 
       <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
         {ALL_THEMES.map((theme) => (

--- a/apps/web/src/features/theme-dashboard/components/ThemePageLayout.tsx
+++ b/apps/web/src/features/theme-dashboard/components/ThemePageLayout.tsx
@@ -10,7 +10,12 @@ import {
 } from "@stats47/components/atoms/ui/breadcrumb";
 
 import { resolveAffiliateBanners } from "@/features/ads/server";
-import { NativeAffiliateRow } from "@/features/redesign";
+import {
+  HeroShell,
+  KpiGrid,
+  KpiTile,
+  NativeAffiliateRow,
+} from "@/features/redesign";
 import { loadPageComponents } from "@/features/stat-charts/server";
 import { prefetchThemeKpiData } from "@/features/stat-charts/services/prefetch-theme-kpi";
 
@@ -72,21 +77,49 @@ export async function ThemePageLayout({ theme, data }: Props) {
         </BreadcrumbList>
       </Breadcrumb>
 
-      {/* Hero (軽量・データ主役): タイトル + 1 行 description + 指標数バッジ */}
-      <header className="mb-5">
-        <p className="text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">
-          テーマダッシュボード
-        </p>
-        <h1 className="mt-1 text-2xl font-bold leading-tight text-foreground sm:text-3xl">
-          {theme.title}
-          <span className="ml-3 align-middle text-xs font-medium text-muted-foreground">
-            {theme.rankingKeys.length}指標
-          </span>
-        </h1>
-        <p className="mt-2 max-w-2xl text-sm leading-relaxed text-muted-foreground">
-          {theme.description}
-        </p>
-      </header>
+      {/* Hero (D 暗色) — マスタープラン § 5.3 準拠 */}
+      <HeroShell variant="dark" className="mb-6">
+        <div className="grid grid-cols-1 gap-6 p-6 md:grid-cols-[1fr,360px] md:p-8">
+          <div className="min-w-0">
+            <p className="text-[11px] font-bold uppercase tracking-widest text-white/70">
+              テーマダッシュボード
+            </p>
+            <h1 className="mt-2 text-2xl font-extrabold leading-tight text-white sm:text-3xl">
+              {theme.title}
+            </h1>
+            <p className="mt-2 max-w-xl text-sm leading-relaxed text-white/85">
+              {theme.description}
+            </p>
+          </div>
+          <div>
+            <KpiGrid columns={2}>
+              <KpiTile
+                label="指標数"
+                value={String(theme.rankingKeys.length)}
+                unit="件"
+                variant="dark"
+              />
+              <KpiTile
+                label="エリア"
+                value="47"
+                unit="都道府県"
+                variant="dark"
+              />
+              <KpiTile
+                label="可視化"
+                value="地図 + グラフ"
+                variant="dark"
+              />
+              <KpiTile
+                label="データ"
+                value="CSV"
+                unit="DL 可"
+                variant="dark"
+              />
+            </KpiGrid>
+          </div>
+        </div>
+      </HeroShell>
 
       <ThemeDashboardClient
         themeConfig={theme}

--- a/docs/02_実装計画/cities-revival-plan.md
+++ b/docs/02_実装計画/cities-revival-plan.md
@@ -1,0 +1,290 @@
+---
+type: implementation-plan
+status: design-approved-pending-phase-1
+created: 2026-05-23
+updated: 2026-05-23
+target_phase: 100x Phase 1 (2026-W29 〜 W44)
+related_files:
+  - docs/02_実装計画/100x-pv-strategy.md
+  - docs/05_改善ログ/indexing.md  # P0-CITIES-DIAG section
+  - apps/web/src/app/areas/[areaCode]/cities/[cityCode]/page.tsx
+  - apps/web/src/app/areas/[areaCode]/cities/[cityCode]/[categoryKey]/page.tsx
+  - packages/area-profile/  # 既存 prefecture profile を city にも拡張するベース
+---
+
+# 市区町村ページ復活戦略 (100x Phase 1 主軸)
+
+> P0-CITIES-DIAG の成果物。100倍 PV 戦略 Phase 1 (W29 〜 W44) の中核投資判断材料。
+
+## Executive Summary
+
+- **資産**: 2,701 市区町村 × 162 metrics = 186 万行の統計データが D1 にある
+- **現状**: 25,785 URL が公開済みだが GSC indexed **21 / 25,785 (0.08%)**、impressions 33、clicks 0
+- **真因**: city pages は実質**空のプレースホルダー** (タイトル + ナビのみ)、`generateStaticParams() returns []` で動的レンダ、sitemap からも除外中
+- **データはあるが UI に出てない** → Phase 1 で「データ表示 + SSG 化 + sitemap 段階追加」を実施し、Phase 1 倍率 ×4 (38K → 150K PV/月) の主要寄与施策にする
+
+---
+
+## 1. 現状診断 (2026-W21 実測)
+
+### 1.1 D1 のデータ状況
+
+| テーブル | 行数 | 内容 |
+|---|---|---|
+| `cities` | 2,701 | 市区町村マスタ (code, name, prefecture_code) |
+| `stats_city` | 1,866,054 | 市区町村別統計 (metric_key, area_code, value, rank, year_code) |
+| city × metric カバレッジ | 2,701 × 162 = ~437,562 | 1 市につき平均 692 行 (複数年度含む) |
+| `area_profiles` (city rows) | **0** | 県のみ 18,460 行、city profile 未生成 |
+
+### 1.2 既存ページ実装
+
+| ファイル | 機能 | 問題点 |
+|---|---|---|
+| `apps/web/src/app/areas/[areaCode]/cities/[cityCode]/page.tsx` | 市町村 top | h1 + サブタイトル + カテゴリナビのみ。**統計データ表示 0**。`generateStaticParams() returns []` |
+| `apps/web/src/app/areas/[areaCode]/cities/[cityCode]/[categoryKey]/page.tsx` | 市町村×カテゴリ | AreaDashboardSection でチャート表示。**こちらは内容あり** |
+
+### 1.3 R2 の状況
+
+| キー | 状態 |
+|---|---|
+| `app/areas/{prefCode}/profile.json` | ✅ 47 ファイル (prefecture profile) |
+| `app/areas/{prefCode}/cities/{cityCode}/profile.json` | ❌ 不存在 (本提案で生成) |
+| `app/areas/{prefCode}/cities/{cityCode}/{categoryKey}/*.json` | ✅ 部分的に存在 (city-category subpage 用) |
+
+### 1.4 GSC 状況 (2026-W21 snapshot)
+
+- 市区町村 URL: GSC に出ているのは **21 件**、impressions 33、clicks 0
+- 平均 impressions/URL = 1.5/週
+- 比較: /blog 78% indexed、/ranking 40% indexed、市区町村 0.08% indexed
+
+**結論**: ページの content quality が極端に薄いため、Google が「インデックスする価値なし」と判定。
+
+---
+
+## 2. 復活戦略
+
+### 2.1 基本方針
+
+> **「データ表示 + SSG 化 + sitemap 段階追加」の 3 本柱で、Top 500 都市を 4 週間で indexed 化する**
+
+3 つの柱を同時並行で進めるのではなく、**1 → 2 → 3 を順次** 実行。1 で結果が出るまで 2 は本格着手しない (リスク管理: 低品質ページの大量公開で site-wide ranking を下げないため)。
+
+### 2.2 段階導入計画 (Phase 1 内)
+
+| Stage | 期間 | 対象都市 | sitemap | 検証指標 | GO/NO-GO |
+|---|---|---|---|---|---|
+| **S1: パイロット** | W29-W30 | 政令指定都市 20 + 中核市 60 = **80 都市** | 追加 | 4 週後 indexed 50+ 件 | indexed ≥ 60% で S2 GO |
+| **S2: 拡大** | W31-W34 | 普通市 (人口 5 万以上) **420 都市** | 段階追加 (週 100) | 8 週後 indexed 250+ | indexed ≥ 60% で S3 GO |
+| **S3: 全域** | W35-W44 | 残り **2,201 都市** | 全追加 | 12 週後 indexed 1,200+ (全 2,701 中 60%) | — |
+
+S1 で indexed 率 60% 達成失敗の場合: 品質テンプレを再設計、S2 は遅延。
+
+### 2.3 品質テンプレート (各 city page の必須要素)
+
+city profile ページ (`/areas/{prefCode}/cities/{cityCode}`) に以下を順に配置:
+
+```
+1. Hero
+   - h1: "{市町村名}の統計データ｜{県名}｜{TOP指標} 全国{N}位"
+   - サブタイトル: 県名 + 人口 + 面積
+   - 推定 SEO ボリューム: city name + "ランキング" or "統計"
+
+2. 強み (この市の上位指標 5 件)
+   - 各 metric の bar chart (この市 vs 県平均 vs 全国平均)
+   - クリックで /ranking/{key} へ
+
+3. 弱み (この市の下位指標 5 件)
+   - 同上
+
+4. 統計カテゴリナビ
+   - 既存の CategoryNavGrid を再利用 (人口・経済・教育など 17 カテゴリ)
+
+5. 同県内の類似都市 (人口規模が近い上位 5 件)
+   - 内部リンク強化
+
+6. 親県へのリンク
+   - "{県名}の統計データ全体を見る" → /areas/{prefCode}
+
+7. 出典・更新日
+```
+
+**最低品質基準** (Stage GO の前提):
+- 1 ページ最低 1,500 文字相当 (構造化データ含む)
+- 6 チャート以上
+- 内部リンク ≥ 10 (parent / siblings / categories / rankings)
+- structured data: `BreadcrumbList`, `Place`, `Dataset`
+
+### 2.4 R2 キーパス設計
+
+| データ | R2 キー | 生成ソース |
+|---|---|---|
+| city profile (strengths/weaknesses) | `app/areas/{prefCode}/cities/{cityCode}/profile.json` | D1 `stats_city` から batch 生成 |
+| city ↔ city 比較データ (類似都市) | `app/areas/{prefCode}/cities/{cityCode}/similar.json` | 同県内 + 人口近似で算出 |
+| 既存 (city-category) | `app/areas/{prefCode}/cities/{cityCode}/{categoryKey}/...` | 既存維持 |
+
+### 2.5 batch service 設計
+
+既存の `packages/area-profile/src/services/run-batch-area-profile.ts` を拡張:
+
+```typescript
+// 新規: packages/area-profile/src/services/run-batch-city-profile.ts
+// - cities テーブルから 2,701 cityCode を取得
+// - 各 city について stats_city から data を集めて
+//   extractStrengthsAndWeaknesses を実行 (rank>=1 フィルタ済)
+// - area_profiles テーブルに area_type='city' として INSERT
+// - 既存 prefecture batch と並走可能 (UNIQUE INDEX で衝突なし)
+```
+
+実行コマンド: `npm run batch:city --workspace=@stats47/area-profile`
+
+### 2.6 R2 export 設計
+
+既存の `packages/area-profile/src/exporters/area-profile-snapshot.ts` を拡張:
+
+```typescript
+// 新規 export 関数を追加
+// - area_profiles WHERE area_type='city' を 2,701 cities に対して
+//   各 `app/areas/{prefCode}/cities/{cityCode}/profile.json` に書き出す
+// - 既存 prefecture export とは別の export 関数として呼び分け
+```
+
+### 2.7 page.tsx 改修
+
+`apps/web/src/app/areas/[areaCode]/cities/[cityCode]/page.tsx`:
+
+```typescript
+// 1. generateStaticParams を [] → Stage S1 (80 cities) → S2 (500) → S3 (2,701) と段階拡大
+//    Stage 移行は環境変数 NEXT_PUBLIC_CITY_SSG_STAGE で制御 (1/2/3)
+//    NOT_STAGED な city は dynamic (SSR) のまま、indexed 対象外
+export function generateStaticParams() {
+  const stage = parseInt(process.env.CITY_SSG_STAGE ?? "0", 10);
+  if (stage === 0) return [];
+  return getCitiesInStage(stage); // Stage 別の cityCode リスト
+}
+
+// 2. profile.json を R2 から読み込む
+//    rank>=1 フィルタは extract-strengths-and-weaknesses で既に対応済 (今日のバグ修正)
+const profile = await readCityProfileFromR2(prefCode, cityCode);
+
+// 3. profile.strengths + profile.weaknesses をレンダリング
+//    既存 AreaProfilePageClient を再利用 (componentが prefecture/city 両対応)
+```
+
+### 2.8 sitemap.ts 改修
+
+`apps/web/src/app/sitemap.ts`:
+
+```typescript
+// 既存: 市区町村は意図的に sitemap から除外
+// 新規: Stage 別で段階追加
+const STAGE_1_CITIES = [...]; // 80 都市 (政令市 + 中核市)
+const STAGE_2_CITIES = [...]; // 500 都市
+const STAGE_3_CITIES = [...]; // 全 2,701 都市
+
+function getCitiesToInclude(): string[] {
+  const stage = parseInt(process.env.CITY_SITEMAP_STAGE ?? "0", 10);
+  if (stage >= 3) return STAGE_3_CITIES;
+  if (stage >= 2) return STAGE_2_CITIES;
+  if (stage >= 1) return STAGE_1_CITIES;
+  return [];
+}
+```
+
+### 2.9 内部リンク強化
+
+- **parent 都道府県ページ**: `/areas/{prefCode}` に「主要都市の統計」セクション追加 (5-10 都市へリンク)
+- **city-level ranking ページ**: `/ranking/{cityRankingKey}` (例: cpi-regional-difference-index-food-51cities100) のテーブルから city pages へリンク (今日の RankingDataTable 変更で既に対応済)
+- **prefecture ranking ページ**: prefecture-level ranking では city link は不要 (既存仕様維持)
+
+---
+
+## 3. 想定効果 (Phase 1 ×4 の主要寄与)
+
+### 3.1 ベース仮説
+
+- **[仮説]** Stage S3 (全 2,701 都市) 完了で indexed 1,200-1,500 件 (60% 達成)
+- **[仮説]** 1 indexed URL あたり月 5-10 PV (city × statistic ニッチクエリ流入)
+- → **月 +6,000 〜 +15,000 PV** 追加
+
+### 3.2 Phase 1 全体への寄与
+
+| 寄与源 | 月 PV 追加 |
+|---|---|
+| Stage S3 city pages (indexed 1,200) | +6,000 〜 +15,000 |
+| city-category subpages (既存、SSG 化で indexed 増) | +3,000 〜 +6,000 |
+| 内部リンク経由の prefecture / ranking 強化 (halo effect) | +2,000 〜 +5,000 |
+| **Phase 1 全体での city 関連寄与** | **+11,000 〜 +26,000** |
+
+Phase 1 目標 38K → 150K (+112K) の **10-25% をこの施策で確保**。
+
+### 3.3 根拠データ
+
+- /blog インデックス率 78% を上限と仮定 → 2,701 × 0.6 = 1,620 程度が現実的上限
+- 「東京都 渋谷区 統計」「札幌市 人口」など city + 統計クエリは検索ボリュームが堅実
+- todo-ran や uub には city 個別ページがなく、競合不在の領域
+
+---
+
+## 4. リスクと対処
+
+| リスク | 影響 | 対処 |
+|---|---|---|
+| 低品質ページ大量公開で site-wide ranking ダウン | -30% PV (致命的) | 段階導入 (S1=80 で 4 週検証してから拡大)。品質テンプレ厳守 |
+| Cloudflare Pages build 時間が長大化 | デプロイ遅延 | SSG 対象を段階導入。Stage 別の generateStaticParams で制御。最終 2,701 ページなら ~6-8 分追加見込み |
+| R2 ストレージ増加 (2,701 ファイル × 約 5KB = ~13MB) | 軽微 | 無視可能 |
+| city が動的 rendering のまま (SSG されない) | indexed されない | generateStaticParams + R2 snapshot 必須化 |
+| データ更新時の R2 同期遅延 | データ古い | 既存 `/sync-snapshots` フローに統合 |
+| Stage 内の URL に低品質ページが混入 | -20% PV | Stage 移行前に「全 city page が品質テンプレ準拠か」を automated check |
+
+---
+
+## 5. 完了判定基準 (Phase 1 全体での Cities revival)
+
+- [ ] Stage S1 完了: 80 都市が SSG 化 + sitemap 追加 + 4 週後 indexed ≥ 50
+- [ ] Stage S2 完了: 500 都市が SSG 化 + 8 週後 indexed ≥ 250
+- [ ] Stage S3 完了: 2,701 都市が SSG 化 + 12 週後 indexed ≥ 1,200
+- [ ] 月間 PV: city 関連で +10K 以上 (4 週連続観測)
+- [ ] site-wide CTR / position が悪化していない (副作用検証)
+
+---
+
+## 6. 実装ロードマップ (Phase 1 W29 〜 W44)
+
+| Week | 作業 | 成果物 |
+|---|---|---|
+| W29 | city profile batch service 実装 | `packages/area-profile/src/services/run-batch-city-profile.ts` |
+| W29 | city profile R2 exporter 実装 | `packages/area-profile/src/exporters/city-profile-snapshot.ts` |
+| W30 | city page.tsx を profile レンダリングに改修 + generateStaticParams (S1) | 80 都市の SSG ビルド成功 |
+| W30 | sitemap.ts S1 追加 + `/deploy` | S1 deploy 完了 |
+| W30-W33 | S1 観測 (毎週 GSC snapshot で indexed 件数を追跡) | 4 週後判定 |
+| W34 | S1 OK なら S2 設定変更 + deploy | S2 deploy 完了 |
+| W34-W37 | S2 観測 | 8 週後判定 |
+| W38 | S2 OK なら S3 設定変更 + deploy | S3 deploy 完了 |
+| W38-W44 | S3 観測 + 内部リンク追加調整 | Phase 1 完了判定 |
+
+---
+
+## 7. 関連 TODO の更新
+
+本設計書完成により、以下の改善ログ TODO を更新:
+
+- `docs/05_改善ログ/indexing.md` **[P0-CITIES-DIAG]** → status: completed, **設計書リンク追加**, **次の TODO**: P1-CITIES-EXEC (Phase 1 実装) として新規追加
+- `docs/02_実装計画/100x-pv-strategy.md` Phase 1 section に本設計書のリンクを追加
+
+---
+
+## 8. 補足: 今日の area-profile rank=0 修正との整合性
+
+- 2026-05-23 デプロイした area-profile 修正 (`extract-strengths-and-weaknesses` の rank>=1 フィルタ) は **prefecture / city 両対応**
+- city profile batch を実装する際、同じ extract 関数を使うため、rank=0 排除は自動的に適用される
+- 別途 city-specific の filter 実装は不要
+
+---
+
+## 関連ドキュメント
+
+- 親計画: `docs/02_実装計画/100x-pv-strategy.md` Phase 1
+- 既存 prefecture profile 実装: `packages/area-profile/`
+- R2 設計ルール: `.claude/rules/r2-storage-design.md`
+- 実証ベース判定: `.claude/rules/evidence-based-judgment.md` (Stage GO/NO-GO 判定時に必読)
+- Next.js SSG 保全: `.claude/rules/nextjs-ssg-preservation.md` (generateStaticParams 変更時に必読)

--- a/docs/05_改善ログ/gsc.md
+++ b/docs/05_改善ログ/gsc.md
@@ -9,6 +9,75 @@ updated: 2026-05-23
 
 施策ベースで append-only。新しい施策は最新を上に追加。判定が変わったら section 末尾に追記。
 
+## [BLOG-CTR-03] 高インプレ × 低 CTR Top 5 記事の seoTitle/description 改修 (curiosity gap パターン適用)
+
+- **status**: pending
+- **tier**: 2
+- **target_metric**: blog-ctr
+- **owner**: claude
+- **deployed_at**: 2026-05-23
+- **due**: 2026-06-20 (W25 4 週後の効果計測)
+- **related_plan**: `docs/02_実装計画/100x-pv-strategy.md` Phase 0
+- **verification_command**: `node .claude/scripts/blog/measure-gsc-impact.mjs 2026-W21 2026-W25`
+
+### 背景
+
+ブログ品質診断 (2026-05-23) で、187 記事中 chart 採用 1% (2 件) であり、top パフォーマー (health-life-expectancy-structure, CTR 4.6%) も chart なし。**真の品質ギャップは「タイトルの curiosity gap」**であることが判明。
+
+成功パターン (health-life-expectancy-structure):
+- タイトル: 「寿命は延びたが**不健康期間も延びた**」 (矛盾・驚き要素)
+- description: 「世界トップクラスです。しかし...」 (緊張感セットアップ)
+
+失敗パターン (sugar-consumption-prefecture-gap, W19 新規 6 本 CTR 0%):
+- タイトル: 「砂糖消費量1位は三重5kg・最下位東京」 (事実羅列、フック無し)
+
+### 対象 (高インプレ × 低 CTR Top 5)
+
+| slug | 改修前 impressions / clicks / CTR / position | 改修前 seoTitle |
+|---|---|---|
+| `child-height-regional-gap` | 1,597 / 12 / 0.75% / 10.68 | 中学生身長ランキング2023｜秋田163.6cm・1位、高知159.7cmで3.9cm差 |
+| `price-index-high-low-prefecture` | 1,373 / 26 / 1.9% / 8.50 | 物価ランキング2024｜東京104.0が全国1位、群馬96.2と7.8pt差 |
+| `temperature-extremes-map` | 1,337 / 20 / 1.5% / 9.14 | 年平均気温ランキング2024｜沖縄24.4℃・47都道府県、北海道と14℃差 |
+| `habitable-area-land-use` | 643 / 2 / **0.31%** / 8.15 | 可住地面積割合ランキング2026｜大阪70.0%・全国1位、高知16.3%で4.3倍差 |
+| `fiscal-self-reliance-gap` | 549 / 14 / 2.5% / 8.83 | 都道府県別の財政力指数ランキング｜自前で稼げる自治体はどこか |
+
+### 改修内容 (curiosity gap パターン)
+
+| slug | 改修後 seoTitle (要点) |
+|---|---|
+| `child-height-regional-gap` | 「中学生の身長は県で3.9cm違う｜**なぜ東北が高い?**」 |
+| `price-index-high-low-prefecture` | 「**住居費だけ1.6倍格差**、47都道府県別」(食料は0.5倍だが住居は1.6倍の対比) |
+| `temperature-extremes-map` | 「**猛暑日は京都が全国1位**の意外」(沖縄ではなく京都という逆転) |
+| `habitable-area-land-use` | 「人口密度の真因が見える」(なぜ面積1位の北海道が人口密度1位ではないか) |
+| `fiscal-self-reliance-gap` | 「**唯一「自立」できる47都道府県**は」(東京 1.06 が唯一の「1超」) |
+
+各 description にも「同じ日本でも...」「なぜ...?」 など緊張感セットアップを追加。
+
+### 想定効果
+
+**[仮説]** 5 記事合計で:
+- 改修前 clicks: 74/週 (平均 CTR 1.5%)
+- 改修後想定 CTR: 3.5% (業界平均、position 8-11 帯)
+- 改修後 clicks: 175/週 → **+101 clicks/週 (+540/月)**
+
+**根拠**: Backlinko 2023 業界平均で position 8-11 帯の CTR は 3-5%。今回 0.3-2.5% から 3% 台への上昇は curiosity gap 効果の標準的な範囲。最も改善余地が大きいのは habitable-area (0.31% → 3.0% で +9.7x の clicks)。
+
+### 検証
+
+- **検証コマンド**: `node .claude/scripts/blog/measure-gsc-impact.mjs 2026-W21 <観測週>`
+- **検証期日**: 2026-06-20 (4 週後の GSC snapshot で確定)
+- **期日後の判定**:
+  - 5 記事合計 clicks ≥ 150/週 → effect/full
+  - 100-150/週 → effect/partial
+  - < 100/週 → effect/none、次の検証: 本文イントロも書き換え or h1 修正
+
+### デプロイ手順 (今回実施)
+
+1. `.local/r2/app/blog/{slug}/article.md` の frontmatter (seoTitle, description) を編集 (5 記事)
+2. `npm run articles:sync-from-r2 --workspace=packages/database` で D1 articles テーブル更新 (193件中 5 件が実質変更)
+3. `bash .claude/skills/db/sync-snapshots/run.sh --only blog` で R2 push (6 files updated)
+4. 本 commit を develop → main PR で Cloudflare Pages rebuild trigger
+
 ## [P0-RANKING-INDEX] /ranking インデックス率 43% → 70%+ 改善 (100x Phase 0 主軸)
 
 - **status**: in-progress

--- a/docs/05_改善ログ/indexing.md
+++ b/docs/05_改善ログ/indexing.md
@@ -21,14 +21,29 @@ Coverage Drilldown / sitemap / Indexing API のインデックスカバレッジ
 
 ## [P0-CITIES-DIAG] 市区町村ページの Phase 1 復活戦略設計
 
-- **status**: pending
+- **status**: effect/full
 - **tier**: 1
 - **target_metric**: gsc-index-coverage / sitemap-strategy
 - **owner**: claude
-- **deployed_at**: -
+- **deployed_at**: 2026-05-23
 - **due**: 2026-07-13
 - **related_plan**: `docs/02_実装計画/100x-pv-strategy.md` Phase 0
+- **deliverable**: `docs/02_実装計画/cities-revival-plan.md`
 - **verification_command**: `node .claude/scripts/gsc/url-inspection-daily.cjs --pattern '/areas/.+/cities/'`
+
+### 完了 (2026-05-23)
+
+設計書 `docs/02_実装計画/cities-revival-plan.md` を完成。Phase 1 (W29-W44) 着手の前提条件すべて文書化:
+
+- 現状診断: cities テーブル 2,701 行 + stats_city 186 万行のデータは揃っているが、city page は空のプレースホルダー (h1 + ナビのみ、`generateStaticParams() returns []`)
+- 復活戦略 3 本柱: データ表示 + SSG 化 + sitemap 段階追加 (S1=80 都市 → S2=500 → S3=2,701 を 4-12 週で観測)
+- R2 キー設計: `app/areas/{prefCode}/cities/{cityCode}/profile.json` (新規) + 既存の subpage 維持
+- batch service 設計: 既存 `area-profile` パッケージを city 対応に拡張
+- 期待効果: Phase 1 全体 +112K のうち 11-26K (10-25%) を本施策で確保
+
+### 後続 TODO (Phase 1 で実行)
+
+新規 TODO **[P1-CITIES-EXEC]** を Phase 1 開始時に追加する (W29 着手予定)。
 
 ### 背景
 


### PR DESCRIPTION
## Summary

複数の改善を含む:

### 1. fix(redesign) hero/home (b292e97e)
- マスタープラン § 5.3 に忠実に hero/home を復元 (前 PR でのデザイン修正)

### 2. docs(gsc): BLOG-CTR-03 — 高インプレ × 低 CTR Top 5 記事の seoTitle 改修 (67ae0681)
ブログ品質診断の結果、187 記事中 chart 採用 1% (top パフォーマーも chart なし)。真の品質ギャップは「タイトルの curiosity gap」と特定し、Top 5 記事を改修:

| slug | imp | 旧 CTR | 改修ポイント |
|---|---|---|---|
| child-height-regional-gap | 1,597 | 0.75% | 「なぜ東北が高い?」追加 |
| price-index-high-low-prefecture | 1,373 | 1.9% | 「住居費だけ1.6倍格差」を前面 |
| temperature-extremes-map | 1,337 | 1.5% | 「猛暑日は京都が全国1位の意外」追加 |
| habitable-area-land-use | 643 | **0.31%** | 「人口密度の真因が見える」(最大改善余地) |
| fiscal-self-reliance-gap | 549 | 2.5% | 「唯一「自立」できる47都道府県は」 |

データフロー:
1. `.local/r2/app/blog/{slug}/article.md` frontmatter 編集
2. `npm run articles:sync-from-r2 --workspace=packages/database` → D1 articles 更新 (5/193)
3. `bash .claude/skills/db/sync-snapshots/run.sh --only blog` → R2 push (6 files)
4. 本 PR が Cloudflare Pages rebuild trigger

想定効果: 5 記事合計 +101 clicks/週 (+540/月)。検証期日 2026-06-20 (W25)。

## Test plan

- [ ] CI green
- [ ] Deploy 後、Google で `site:stats47.jp child-height` 等を検索して新 title が反映されているか確認
- [ ] 2026-06-20 (W25, 4 週後) に GSC snapshot で clicks/CTR を再計測

🤖 Generated with [Claude Code](https://claude.com/claude-code)