### PR TITLE
feat(city-ssg): Phase 1 S1 - 政令指定都市 20 市の SSG 化

### DIFF
--- a/apps/web/src/app/areas/[areaCode]/cities/[cityCode]/page.tsx
+++ b/apps/web/src/app/areas/[areaCode]/cities/[cityCode]/page.tsx
@@ -20,6 +20,7 @@ import { isOk } from "@stats47/types";
 import { FurusatoNozeiCard } from "@/features/ads";
 import { AreaBannerAd } from "@/features/ads/server";
 import { CategoryNavGrid, CitiesNavCard } from "@/features/area-profile";
+import { STAGE_1_DESIGNATED_CITIES } from "@/features/area-profile/constants/stage-1-cities";
 import { listCategories } from "@/features/category/server";
 import {
     PAGE_COMPONENTS_SNAPSHOT_KEY,
@@ -114,7 +115,7 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
 // ---------------------------------------------------------------------------
 
 export function generateStaticParams() {
-    return [];
+    return STAGE_1_DESIGNATED_CITIES;
 }
 
 // ---------------------------------------------------------------------------

--- a/apps/web/src/features/area-profile/constants/stage-1-cities.ts
+++ b/apps/web/src/features/area-profile/constants/stage-1-cities.ts
@@ -1,0 +1,30 @@
+/**
+ * Phase 1 S1: SSG 対象の政令指定都市 20 市
+ *
+ * area_profiles に強みデータが揃っており、indexed 化の効果が高い。
+ * S2 (中核市 60 市追加)、S3 (全 2,701 cities) は次フェーズ。
+ *
+ * 詳細: docs/02_実装計画/cities-revival-plan.md §2.2
+ */
+export const STAGE_1_DESIGNATED_CITIES: Array<{ areaCode: string; cityCode: string }> = [
+    { areaCode: "01000", cityCode: "01100" }, // 札幌市
+    { areaCode: "04000", cityCode: "04100" }, // 仙台市
+    { areaCode: "11000", cityCode: "11100" }, // さいたま市
+    { areaCode: "12000", cityCode: "12100" }, // 千葉市
+    { areaCode: "14000", cityCode: "14100" }, // 横浜市
+    { areaCode: "14000", cityCode: "14130" }, // 川崎市
+    { areaCode: "14000", cityCode: "14150" }, // 相模原市
+    { areaCode: "15000", cityCode: "15100" }, // 新潟市
+    { areaCode: "22000", cityCode: "22100" }, // 静岡市
+    { areaCode: "22000", cityCode: "22130" }, // 浜松市
+    { areaCode: "23000", cityCode: "23100" }, // 名古屋市
+    { areaCode: "26000", cityCode: "26100" }, // 京都市
+    { areaCode: "27000", cityCode: "27100" }, // 大阪市
+    { areaCode: "27000", cityCode: "27140" }, // 堺市
+    { areaCode: "28000", cityCode: "28100" }, // 神戸市
+    { areaCode: "33000", cityCode: "33100" }, // 岡山市
+    { areaCode: "34000", cityCode: "34100" }, // 広島市
+    { areaCode: "40000", cityCode: "40100" }, // 北九州市
+    { areaCode: "40000", cityCode: "40130" }, // 福岡市
+    { areaCode: "43000", cityCode: "43100" }, // 熊本市
+];


### PR DESCRIPTION
## Summary

PR #335 (city profile UI 統合) の続編。generateStaticParams を `[]` → 政令指定都市 20 市の固定リストに変更し、build 時に pre-rendered HTML を生成。

## 対象

20 政令指定都市:
札幌・仙台・さいたま・千葉・横浜・川崎・相模原・新潟・静岡・浜松・名古屋・京都・大阪・堺・神戸・岡山・広島・北九州・福岡・熊本

## 想定効果

- Google が pre-rendered HTML を即座に取得 → indexed 化が早まる
- PR #335 の強み section + 差別化 metadata の効果が full に発揮
- これらは「県内人口最大」の市で、impressions ポテンシャル高い

## ビルド時間影響

20 都市分: +30-60 秒程度 (Cloudflare Pages 既存 build ~5-7 分 → ~6-8 分)。許容範囲。

## 残作業

- Phase 1 S2 (中核市 60 市追加): W33-W36 予定
- Phase 1 S3 (全 2,701 cities): W37-W44 予定

詳細: `docs/02_実装計画/cities-revival-plan.md` §2.2

🤖 Generated with [Claude Code](https://claude.com/claude-code)