### PR TITLE
fix(ci): 3 件の post-deploy エラーを解消

### DIFF
--- a/.claude/scripts/gsc/auto-resubmit.mjs
+++ b/.claude/scripts/gsc/auto-resubmit.mjs
@@ -189,17 +189,37 @@ function appendHistory(url, status, extra = {}) {
 // ---------- auth ----------
 
 function loadAuth() {
-  const keyFile = KEY_CANDIDATES.map((f) => path.join(PROJECT_ROOT, f)).find(
-    (p) => fs.existsSync(p)
-  );
-  if (!keyFile) {
-    console.error(
-      "[error] サービスアカウント鍵が見つかりません: " + KEY_CANDIDATES.join(", ")
+  // GitHub Actions では GOOGLE_SERVICE_ACCOUNT_KEY_JSON env var に鍵 JSON が入っている。
+  // ローカルではプロジェクトルートの JSON ファイルを使う。
+  const envKeyJson = process.env.GOOGLE_SERVICE_ACCOUNT_KEY_JSON;
+  let credentials = null;
+  let keyFile = null;
+
+  if (envKeyJson) {
+    try {
+      credentials = JSON.parse(envKeyJson);
+    } catch (e) {
+      console.error(
+        "[error] GOOGLE_SERVICE_ACCOUNT_KEY_JSON の JSON パース失敗: " + e.message
+      );
+      process.exit(1);
+    }
+  } else {
+    keyFile = KEY_CANDIDATES.map((f) => path.join(PROJECT_ROOT, f)).find((p) =>
+      fs.existsSync(p)
     );
-    process.exit(1);
+    if (!keyFile) {
+      console.error(
+        "[error] サービスアカウント鍵が見つかりません: " +
+          KEY_CANDIDATES.join(", ") +
+          " (環境変数 GOOGLE_SERVICE_ACCOUNT_KEY_JSON も未設定)"
+      );
+      process.exit(1);
+    }
   }
+
   const auth = new google.auth.GoogleAuth({
-    keyFile,
+    ...(credentials ? { credentials } : { keyFile }),
     scopes: ["https://www.googleapis.com/auth/indexing"],
   });
   return google.indexing({ version: "v3", auth });

--- a/.github/workflows/migration-flow-annual.yml
+++ b/.github/workflows/migration-flow-annual.yml
@@ -87,7 +87,7 @@ jobs:
         run: |
           npx tsx packages/r2-storage/src/scripts/diff-push-r2.ts --prefix sns/migration-flow
 
-      - name: 📱 Post to Instagram (Day 1: 25 件)
+      - name: "📱 Post to Instagram (Day 1: 25 件)"
         if: inputs.dry_run != 'true'
         env:
           INSTAGRAM_ACCESS_TOKEN: ${{ secrets.INSTAGRAM_ACCESS_TOKEN }}

--- a/apps/web/tests/smoke/production-smoke.spec.ts
+++ b/apps/web/tests/smoke/production-smoke.spec.ts
@@ -69,7 +69,8 @@ test.describe("本番スモークテスト", () => {
     });
     const heading = page.getByRole("heading", { level: 1 });
     await expect(heading).toBeVisible({ timeout: 10_000 });
-    await expect(heading).toContainText("比較");
+    // h1 フォーマット: "<area-a>vs<area-b><category>" (例: 東京都vs大阪府国土・気象)
+    await expect(heading).toContainText("vs");
   });
 
   test("存在しないページで404が返る", async ({ page }) => {


### PR DESCRIPTION
## Summary

直前のデプロイ (PR #343) 後の CI/CD で検出された 3 件の post-deploy エラーを解消する。
いずれも #292+ デプロイとは独立した pre-existing 問題。

- **smoke test (compare page)**: h1 assertion を実際の出力フォーマットに合わせて更新
- **migration-flow-annual.yml**: YAML parse エラー (step name 内のコロン) で phantom push failure が発生していた
- **gsc auto-resubmit**: GitHub Actions secret は設定済だが、スクリプトが env var を読まない実装だった

## Test plan

- [ ] CI green (pr-quality-check.yml が PASS)
- [ ] Post-Deploy Smoke Test がマージ後 success になる
- [ ] migration-flow-annual.yml が push 時に phantom failure を出さない (next push で確認)
- [ ] GSC Auto-resubmit が次回 21:50 UTC schedule で正常実行

🤖 Generated with [Claude Code](https://claude.com/claude-code)