### PR TITLE
feat(maps): 高速道路時系列ページ /maps/highway-timeline 追加

### DIFF
--- a/apps/web/src/app/maps/highway-timeline/[year]/page.tsx
+++ b/apps/web/src/app/maps/highway-timeline/[year]/page.tsx
@@ -1,0 +1,212 @@
+import Link from "next/link";
+import { notFound } from "next/navigation";
+
+import {
+  Breadcrumb,
+  BreadcrumbItem,
+  BreadcrumbLink,
+  BreadcrumbList,
+  BreadcrumbPage,
+  BreadcrumbSeparator,
+} from "@stats47/components/atoms/ui/breadcrumb";
+
+import {
+  HighwayTimelineMap,
+  loadHighwayStats,
+} from "@/features/highway-history";
+
+import type { Metadata } from "next";
+
+export const revalidate = 604800;
+
+const YEAR_START = 1962;
+const YEAR_END = 2020;
+
+export function generateStaticParams(): Array<{ year: string }> {
+  const years: Array<{ year: string }> = [];
+  for (let y = YEAR_START; y <= YEAR_END; y++) {
+    years.push({ year: String(y) });
+  }
+  return years;
+}
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ year: string }>;
+}): Promise<Metadata> {
+  const { year } = await params;
+  const y = Number(year);
+  if (!Number.isInteger(y) || y < YEAR_START || y > YEAR_END) return {};
+  return {
+    title: `${y}年時点の日本の高速道路マップ｜国土数値情報 N06`,
+    description: `${y}年までに開通した日本の高速道路ネットワークを地図で可視化。1962年からの累計区間数・累計距離を年別に確認できます。`,
+    alternates: { canonical: `/maps/highway-timeline/${y}` },
+  };
+}
+
+export default async function HighwayTimelineYearPage({
+  params,
+}: {
+  params: Promise<{ year: string }>;
+}) {
+  const { year } = await params;
+  const y = Number(year);
+  if (!Number.isInteger(y) || y < YEAR_START || y > YEAR_END) notFound();
+
+  const stats = await loadHighwayStats();
+  const cumSections = stats.cumByYear[String(y)] ?? 0;
+  const cumKm = stats.cumKmByYear[String(y)] ?? 0;
+  const milestone = stats.milestones.find((m) => m.year === y);
+  const prevYear = y > YEAR_START ? y - 1 : null;
+  const nextYear = y < YEAR_END ? y + 1 : null;
+
+  return (
+    <main className="mx-auto max-w-5xl px-4 py-6">
+      <Breadcrumb className="mb-4">
+        <BreadcrumbList>
+          <BreadcrumbItem>
+            <BreadcrumbLink href="/">ホーム</BreadcrumbLink>
+          </BreadcrumbItem>
+          <BreadcrumbSeparator />
+          <BreadcrumbItem>
+            <BreadcrumbLink href="/maps/highway-timeline">
+              高速道路 時系列マップ
+            </BreadcrumbLink>
+          </BreadcrumbItem>
+          <BreadcrumbSeparator />
+          <BreadcrumbItem>
+            <BreadcrumbPage>{y}年</BreadcrumbPage>
+          </BreadcrumbItem>
+        </BreadcrumbList>
+      </Breadcrumb>
+
+      <header className="mb-6">
+        <p className="text-sm font-semibold uppercase tracking-widest text-slate-500">
+          Highway Timeline
+        </p>
+        <h1 className="mt-1 text-2xl font-bold text-slate-900">
+          {y}年時点の日本の高速道路マップ
+        </h1>
+        {milestone ? (
+          <p className="mt-2 inline-block rounded-md border border-cyan-300 bg-cyan-50 px-3 py-1 text-sm font-semibold text-cyan-700">
+            🛣 {y} マイルストーン: {milestone.label}
+          </p>
+        ) : null}
+      </header>
+
+      <section className="mb-6 grid grid-cols-2 gap-4 sm:grid-cols-3">
+        <Stat
+          label="累計区間"
+          value={`${cumSections.toLocaleString("ja-JP")}`}
+          unit="区間"
+        />
+        <Stat
+          label="累計距離"
+          value={`${cumKm.toLocaleString("ja-JP")}`}
+          unit="km"
+        />
+        <Stat
+          label="年代進捗"
+          value={`${Math.round(((y - YEAR_START) / (YEAR_END - YEAR_START)) * 100)}`}
+          unit="%"
+        />
+      </section>
+
+      <section className="mb-6">
+        <HighwayTimelineMap year={y} />
+      </section>
+
+      <nav className="mb-8 flex flex-wrap items-center justify-between gap-3 rounded-lg border border-slate-200 bg-white p-4">
+        {prevYear ? (
+          <Link
+            href={`/maps/highway-timeline/${prevYear}`}
+            className="text-sm font-semibold text-slate-700 hover:text-slate-900"
+          >
+            ← {prevYear}年
+          </Link>
+        ) : (
+          <span />
+        )}
+        <Link
+          href="/maps/highway-timeline"
+          className="text-sm font-semibold text-amber-600 hover:text-amber-700"
+        >
+          年表一覧へ
+        </Link>
+        {nextYear ? (
+          <Link
+            href={`/maps/highway-timeline/${nextYear}`}
+            className="text-sm font-semibold text-slate-700 hover:text-slate-900"
+          >
+            {nextYear}年 →
+          </Link>
+        ) : (
+          <span />
+        )}
+      </nav>
+
+      <section className="mb-6 rounded-lg border border-slate-200 bg-white p-5">
+        <h2 className="mb-3 text-lg font-bold text-slate-900">
+          マイルストーン年に飛ぶ
+        </h2>
+        <ul className="flex flex-wrap gap-2">
+          {stats.milestones.map((m) => (
+            <li key={m.year}>
+              <Link
+                href={`/maps/highway-timeline/${m.year}`}
+                className="inline-block rounded-md border border-slate-300 bg-slate-50 px-3 py-1.5 text-sm font-semibold text-slate-700 hover:bg-slate-100"
+              >
+                {m.year}: {m.label}
+              </Link>
+            </li>
+          ))}
+        </ul>
+      </section>
+
+      <footer className="text-xs text-slate-500">
+        <p>
+          出典: {stats.source}{" "}
+          <a
+            href={stats.sourceUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="underline"
+          >
+            (配布ページ)
+          </a>
+        </p>
+        <p className="mt-1">
+          詳細解説:{" "}
+          <Link
+            href="/blog/highway-japan-58years"
+            className="text-amber-600 underline"
+          >
+            日本の高速道路は58年で14,805 kmに広がった
+          </Link>
+        </p>
+      </footer>
+    </main>
+  );
+}
+
+function Stat({
+  label,
+  value,
+  unit,
+}: {
+  label: string;
+  value: string;
+  unit: string;
+}) {
+  return (
+    <div className="rounded-lg border border-slate-200 bg-white px-4 py-3">
+      <div className="text-xs font-semibold tracking-widest text-slate-500">
+        {label}
+      </div>
+      <div className="mt-1 text-2xl font-bold tabular-nums text-slate-900">
+        {value} <span className="text-sm font-semibold text-slate-500">{unit}</span>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/app/maps/highway-timeline/page.tsx
+++ b/apps/web/src/app/maps/highway-timeline/page.tsx
@@ -1,0 +1,178 @@
+import Link from "next/link";
+
+import {
+  Breadcrumb,
+  BreadcrumbItem,
+  BreadcrumbLink,
+  BreadcrumbList,
+  BreadcrumbPage,
+  BreadcrumbSeparator,
+} from "@stats47/components/atoms/ui/breadcrumb";
+
+import {
+  HighwayTimelineMap,
+  loadHighwayStats,
+} from "@/features/highway-history";
+
+import type { Metadata } from "next";
+
+export const revalidate = 604800;
+
+export const metadata: Metadata = {
+  title: "日本の高速道路 時系列マップ｜1962〜2020 年表",
+  description:
+    "1962年の名神部分開通から2020年まで、日本の高速道路ネットワークが58年でどう広がったかを年別マップで可視化。マイルストーン年 (1965 名神/1969 東名/1985 関越/2005 圏央道) から該当年に直接ジャンプできます。",
+  alternates: { canonical: "/maps/highway-timeline" },
+};
+
+const YEAR_END = 2020;
+
+export default async function HighwayTimelineIndexPage() {
+  const stats = await loadHighwayStats();
+
+  return (
+    <main className="mx-auto max-w-5xl px-4 py-6">
+      <Breadcrumb className="mb-4">
+        <BreadcrumbList>
+          <BreadcrumbItem>
+            <BreadcrumbLink href="/">ホーム</BreadcrumbLink>
+          </BreadcrumbItem>
+          <BreadcrumbSeparator />
+          <BreadcrumbItem>
+            <BreadcrumbPage>高速道路 時系列マップ</BreadcrumbPage>
+          </BreadcrumbItem>
+        </BreadcrumbList>
+      </Breadcrumb>
+
+      <header className="mb-6">
+        <p className="text-sm font-semibold uppercase tracking-widest text-slate-500">
+          Highway Timeline
+        </p>
+        <h1 className="mt-1 text-2xl font-bold text-slate-900">
+          日本の高速道路 時系列マップ ({stats.yearStart}→{stats.yearEnd})
+        </h1>
+        <p className="mt-2 text-sm text-slate-600">
+          1962年の名神部分開通から2020年まで、日本の高速道路ネットワークが
+          <strong className="mx-1 text-amber-700">
+            58年で {stats.totalKm.toLocaleString("ja-JP")} km
+          </strong>
+          に広がった軌跡を年別マップで確認できます。
+        </p>
+      </header>
+
+      <section className="mb-6 grid grid-cols-2 gap-4 sm:grid-cols-3">
+        <Stat
+          label="累計距離 (2020)"
+          value={stats.totalKm.toLocaleString("ja-JP")}
+          unit="km"
+        />
+        <Stat
+          label="累計区間"
+          value={stats.totalSections.toLocaleString("ja-JP")}
+          unit="区間"
+        />
+        <Stat label="期間" value={`${stats.totalYears}`} unit="年" />
+      </section>
+
+      <section className="mb-6">
+        <h2 className="mb-3 text-lg font-bold text-slate-900">
+          2020年時点のネットワーク
+        </h2>
+        <HighwayTimelineMap year={YEAR_END} />
+      </section>
+
+      <section className="mb-6 rounded-lg border border-slate-200 bg-white p-5">
+        <h2 className="mb-3 text-lg font-bold text-slate-900">マイルストーン年</h2>
+        <ul className="space-y-2">
+          {stats.milestones.map((m) => (
+            <li key={m.year}>
+              <Link
+                href={`/maps/highway-timeline/${m.year}`}
+                className="flex items-baseline justify-between rounded-md border border-slate-200 bg-slate-50 px-4 py-2 hover:bg-slate-100"
+              >
+                <span className="text-base font-bold text-slate-900">
+                  {m.year}
+                  <span className="ml-2 text-sm font-normal text-slate-600">
+                    {m.label}
+                  </span>
+                </span>
+                <span className="text-xs font-semibold text-amber-600">
+                  {(stats.cumKmByYear[String(m.year)] ?? 0).toLocaleString("ja-JP")} km →
+                </span>
+              </Link>
+            </li>
+          ))}
+        </ul>
+      </section>
+
+      <section className="mb-6 rounded-lg border border-slate-200 bg-white p-5">
+        <h2 className="mb-3 text-lg font-bold text-slate-900">10年単位で見る</h2>
+        <ul className="flex flex-wrap gap-2">
+          {[1962, 1970, 1980, 1990, 2000, 2010, 2020].map((y) => (
+            <li key={y}>
+              <Link
+                href={`/maps/highway-timeline/${y}`}
+                className="inline-block rounded-md border border-slate-300 bg-white px-3 py-1.5 text-sm font-semibold text-slate-700 hover:bg-slate-100"
+              >
+                {y}年
+              </Link>
+            </li>
+          ))}
+        </ul>
+      </section>
+
+      <section className="mb-6 rounded-lg border border-amber-200 bg-amber-50 p-5">
+        <h2 className="mb-2 text-lg font-bold text-slate-900">関連コンテンツ</h2>
+        <ul className="list-disc space-y-1 pl-5 text-sm text-slate-700">
+          <li>
+            <Link
+              href="/blog/highway-japan-58years"
+              className="font-semibold text-amber-700 underline"
+            >
+              詳細解説: 日本の高速道路は58年で14,805 kmに広がった
+            </Link>
+            （動画 + マイルストーン + TOP 5 路線）
+          </li>
+          <li>
+            <Link href="/ranking/road-extension-actual" className="underline">
+              都道府県別 道路実延長ランキング
+            </Link>
+          </li>
+        </ul>
+      </section>
+
+      <footer className="text-xs text-slate-500">
+        出典: {stats.source}{" "}
+        <a
+          href={stats.sourceUrl}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="underline"
+        >
+          (配布ページ)
+        </a>
+      </footer>
+    </main>
+  );
+}
+
+function Stat({
+  label,
+  value,
+  unit,
+}: {
+  label: string;
+  value: string;
+  unit: string;
+}) {
+  return (
+    <div className="rounded-lg border border-slate-200 bg-white px-4 py-3">
+      <div className="text-xs font-semibold tracking-widest text-slate-500">
+        {label}
+      </div>
+      <div className="mt-1 text-2xl font-bold tabular-nums text-slate-900">
+        {value} <span className="text-sm font-semibold text-slate-500">{unit}</span>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/features/highway-history/HighwayTimelineMap.tsx
+++ b/apps/web/src/features/highway-history/HighwayTimelineMap.tsx
@@ -1,5 +1,6 @@
 import { geoMercator, geoPath, geoLength } from "d3-geo";
 import { feature as topoFeature } from "topojson-client";
+
 import type { GeometryCollection, Topology } from "topojson-specification";
 
 const R2_HIGHWAY_TOPOJSON =

--- a/apps/web/src/features/highway-history/HighwayTimelineMap.tsx
+++ b/apps/web/src/features/highway-history/HighwayTimelineMap.tsx
@@ -1,0 +1,135 @@
+import { geoMercator, geoPath, geoLength } from "d3-geo";
+import { feature as topoFeature } from "topojson-client";
+import type { GeometryCollection, Topology } from "topojson-specification";
+
+const R2_HIGHWAY_TOPOJSON =
+  "https://storage.stats47.jp/app/highway-history/highway-sections.topojson";
+const R2_PREFECTURE_TOPOJSON =
+  "https://storage.stats47.jp/gis/mlit/20240101/prefecture.topojson";
+const R2_STATS_JSON = "https://storage.stats47.jp/app/highway-history/stats.json";
+
+export interface HighwayStats {
+  yearStart: number;
+  yearEnd: number;
+  totalYears: number;
+  totalSections: number;
+  totalKm: number;
+  cumByYear: Record<string, number>;
+  cumKmByYear: Record<string, number>;
+  topRoutes: Array<{ name: string; km: number; sections: number }>;
+  milestones: Array<{ year: number; label: string }>;
+  source: string;
+  sourceUrl: string;
+  generatedAt: string;
+}
+
+export async function loadHighwayStats(): Promise<HighwayStats> {
+  const res = await fetch(R2_STATS_JSON, { next: { revalidate: 86400 } });
+  if (!res.ok) throw new Error("Failed to load highway stats");
+  return (await res.json()) as HighwayStats;
+}
+
+interface MapProps {
+  year: number;
+  width?: number;
+  height?: number;
+}
+
+/** Server Component: 指定年までに開通した高速道路区間を SVG で描画 */
+export async function HighwayTimelineMap({
+  year,
+  width = 900,
+  height = 1100,
+}: MapProps) {
+  const [prefRes, hwyRes] = await Promise.all([
+    fetch(R2_PREFECTURE_TOPOJSON, { next: { revalidate: 2592000 } }),
+    fetch(R2_HIGHWAY_TOPOJSON, { next: { revalidate: 2592000 } }),
+  ]);
+  const prefTopo = (await prefRes.json()) as Topology;
+  const hwyTopo = (await hwyRes.json()) as Topology;
+
+  const prefObjKey = Object.keys(prefTopo.objects)[0];
+  const hwyObjKey = Object.keys(hwyTopo.objects)[0];
+  const prefFc = topoFeature(
+    prefTopo,
+    prefTopo.objects[prefObjKey] as GeometryCollection,
+  ) as unknown as GeoJSON.FeatureCollection<
+    GeoJSON.Geometry,
+    { N03_007?: string }
+  >;
+  const hwyFc = topoFeature(
+    hwyTopo,
+    hwyTopo.objects[hwyObjKey] as GeometryCollection,
+  ) as unknown as GeoJSON.FeatureCollection;
+
+  const mainPref: GeoJSON.FeatureCollection = {
+    type: "FeatureCollection",
+    features: prefFc.features.filter((f) => f.properties?.N03_007 !== "47"),
+  };
+
+  const projection = geoMercator().fitExtent(
+    [
+      [30, 30],
+      [width - 30, height - 30],
+    ],
+    mainPref,
+  );
+  const pathGen = geoPath(projection);
+  const prefPath = pathGen(mainPref as never) || "";
+
+  const visibleHwy: GeoJSON.FeatureCollection = {
+    type: "FeatureCollection",
+    features: hwyFc.features.filter((f, idx) => {
+      const props = (hwyTopo.objects[hwyObjKey] as GeometryCollection).geometries[idx]
+        .properties as { N06_002?: number };
+      const openYear = Number(props?.N06_002 ?? 9999);
+      if (openYear > year) return false;
+      const coords = (f.geometry as { coordinates: number[][] }).coordinates;
+      if (coords?.[0]?.[1] !== undefined && coords[0][1] < 30) return false;
+      return true;
+    }),
+  };
+  const hwyPath = pathGen(visibleHwy as never) || "";
+
+  const newCount = (hwyTopo.objects[hwyObjKey] as GeometryCollection).geometries.filter(
+    (g) => Number((g.properties as { N06_002?: number })?.N06_002 ?? 9999) === year,
+  ).length;
+
+  let newKm = 0;
+  for (let i = 0; i < hwyFc.features.length; i++) {
+    const props = (hwyTopo.objects[hwyObjKey] as GeometryCollection).geometries[i]
+      .properties as { N06_002?: number };
+    if (Number(props?.N06_002 ?? 9999) === year) {
+      newKm += geoLength(hwyFc.features[i]) * 6371;
+    }
+  }
+
+  return (
+    <div className="rounded-lg border border-slate-200 bg-slate-50 p-2">
+      <svg
+        viewBox={`0 0 ${width} ${height}`}
+        className="block w-full h-auto"
+        role="img"
+        aria-label={`${year}年時点の日本の高速道路ネットワーク`}
+      >
+        <path d={prefPath} fill="#e2e8f0" stroke="#94a3b8" strokeWidth={0.6} />
+        <path
+          d={hwyPath}
+          fill="none"
+          stroke="#d97706"
+          strokeWidth={1.6}
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          opacity={0.92}
+        />
+      </svg>
+      {newCount > 0 && (
+        <p className="mt-2 text-xs text-slate-500">
+          {year}年 新規開通:{" "}
+          <span className="font-semibold text-amber-600">+{newCount} 区間</span>{" "}
+          (約{Math.round(newKm).toLocaleString("ja-JP")} km)
+        </p>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/features/highway-history/index.ts
+++ b/apps/web/src/features/highway-history/index.ts
@@ -1,0 +1,5 @@
+export {
+  HighwayTimelineMap,
+  loadHighwayStats,
+  type HighwayStats,
+} from "./HighwayTimelineMap";


### PR DESCRIPTION
## Summary
- 国土数値情報 N06 (高速道路時系列データ) を Web で利用可能に整備
- `/maps/highway-timeline` インデックス + `/maps/highway-timeline/[year]` 59 年分 SSG (1962-2020)
- Server Component で d3-geo + topojson から SVG 生成、Cloudflare Workers 互換
- SNS 投稿 (highway-history v8 動画) の Web 着地ページとして機能

## 関連アセット (既に R2 push 済み)
- \`app/highway-history/highway-sections.topojson\` (498KB)
- \`app/highway-history/stats.json\` (4KB)
- \`app/blog/highway-japan-58years/article.md\` + \`video.mp4\` (詳細解説ブログ)

## Test plan
- [ ] CI green (lint / typecheck / build)
- [ ] Cloudflare Preview デプロイで /maps/highway-timeline 表示確認
- [ ] /maps/highway-timeline/1965, /1985, /2020 で SVG レンダリング正常
- [ ] sitemap.ts 自動追加 (もし生成スクリプトがあれば確認)

🤖 Generated with [Claude Code](https://claude.com/claude-code)