### PR TITLE
feat(cwv): [auto] LCP 改修案 for /themes/population-dynamics

### DIFF
--- a/apps/web/src/features/theme-dashboard/components/ThemeLeafletMap.tsx
+++ b/apps/web/src/features/theme-dashboard/components/ThemeLeafletMap.tsx
@@ -28,7 +28,7 @@ const LeafletChoroplethMap = dynamic(
   () => import("@stats47/visualization/leaflet").then((mod) => mod.LeafletChoroplethMap),
   {
     ssr: false,
-    loading: () => <Skeleton className="h-[400px] w-full rounded-md" />,
+    loading: () => <Skeleton className="h-[400px] lg:h-[500px] w-full rounded-md" />,
   }
 );
 


### PR DESCRIPTION
## Auto-generated CWV improvement PR

**警告**: この PR は Claude (Anthropic Cloud Routine) が自動生成しました。merge 前に人手レビュー必須。

- **URL**: https://stats47.jp/themes/population-dynamics
- **対象ファイル**: `apps/web/src/features/theme-dashboard/components/ThemeLeafletMap.tsx`
- **過去施策ヒント**: dynamic import + tile preload (T1-PSI-LCP-02)
- **目標**: LCP < 3.5s (mobile) / desktop LCP < 2000ms

### 元 PSI Alert
- Issue #344 (2026-05-24)
- `/themes/population-dynamics` mobile: LCP **7351ms** 🚨
- `/themes/population-dynamics` desktop: LCP **2534ms** 🚨 (LCP element: `div.leaflet-pane`)

### 変更内容
`LeafletChoroplethMap` の dynamic import 時 skeleton 高さを実マップに合わせる:

```diff
-    loading: () => <Skeleton className="h-[400px] w-full rounded-md" />,
+    loading: () => <Skeleton className="h-[400px] lg:h-[500px] w-full rounded-md" />,
```

実マップは `h-[400px] lg:h-[500px]` のため、skeleton が 400px のままだとデスクトップで hydrate 後に **100px 分のリフロー** が発生し、leaflet タイルの LCP 発火タイミングが遅延する。skeleton を一致させることで:

1. **LCP**: 初回ペイントで正しいビューポート領域が予約されるため、leaflet タイルが reflow なしで描画 → LCP 発火が早まる
2. **CLS** (副次効果): 100px ジャンプが消える

### レビュー観点
- [ ] dynamic import の skeleton が適切（実マップ `h-[400px] lg:h-[500px]` と一致）
- [ ] 既存 props 互換性が維持されている（変更は loading 内の className のみ）
- [ ] PSI で LCP 改善を実測 (mobile < 3.5s / desktop < 2.0s)
- [ ] `/themes/local-economy` `/themes/labor-wages` 等の同コンポーネント利用ページも改善されるか確認

🤖 Generated by Anthropic Cloud Routine stats47-weekly-cwv-pr

---
_Generated by [Claude Code](https://claude.ai/code/session_01DqkdtEDRdAHVtRxVQt5x9e)_