### PR TITLE
fix(ranking): モバイルで計算方法トグルが崩れる不具合を Select 切替で解決

### DIFF
--- a/apps/web/src/features/ranking/components/RankingHeroCard/RankingHeroCard.tsx
+++ b/apps/web/src/features/ranking/components/RankingHeroCard/RankingHeroCard.tsx
@@ -2,8 +2,6 @@
 
 import { useMemo, type ReactNode } from "react";
 
-import { Sigma, Users, LandPlot } from "lucide-react";
-
 import {
   Select,
   SelectContent,
@@ -11,6 +9,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@stats47/components/atoms/ui/select";
+import { Sigma, Users, LandPlot } from "lucide-react";
 
 import type { NormalizationOption, RankingValue } from "@stats47/ranking";
 

--- a/apps/web/src/features/ranking/components/RankingHeroCard/RankingHeroCard.tsx
+++ b/apps/web/src/features/ranking/components/RankingHeroCard/RankingHeroCard.tsx
@@ -4,6 +4,14 @@ import { useMemo, type ReactNode } from "react";
 
 import { Sigma, Users, LandPlot } from "lucide-react";
 
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@stats47/components/atoms/ui/select";
+
 import type { NormalizationOption, RankingValue } from "@stats47/ranking";
 
 /**
@@ -163,16 +171,42 @@ export function RankingHeroCard({
           )}
         </div>
 
-        {/* 単位ピル切替 */}
+        {/* 単位ピル切替 (sm 以上) / Select (sm 未満) */}
         {showPills && (
           <div>
             <p className="mb-1.5 text-[11px] font-semibold uppercase tracking-normal text-muted-foreground">
               計算方法を切替
             </p>
+            {/* モバイル: Select */}
+            <div className="sm:hidden">
+              <Select
+                value={normalizationValue}
+                onValueChange={onNormalizationChange}
+                disabled={normalizationDisabled}
+              >
+                <SelectTrigger aria-label="計算方法" className="h-9 w-full text-sm">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  {pills.map((p) => {
+                    const PillIcon = pillIcon(p.type);
+                    return (
+                      <SelectItem key={p.type} value={p.type}>
+                        <span className="inline-flex items-center gap-1.5">
+                          <PillIcon className="h-3.5 w-3.5" />
+                          {p.label}
+                        </span>
+                      </SelectItem>
+                    );
+                  })}
+                </SelectContent>
+              </Select>
+            </div>
+            {/* デスクトップ: pills */}
             <div
               role="radiogroup"
               aria-label="計算方法"
-              className="inline-flex rounded-full border border-border bg-white p-1 shadow-sm"
+              className="hidden sm:inline-flex rounded-full border border-border bg-white p-1 shadow-sm"
             >
               {pills.map((p) => {
                 const active = normalizationValue === p.type;

--- a/apps/web/src/features/ranking/components/RankingKeyPage/RankingKeyPageClient.tsx
+++ b/apps/web/src/features/ranking/components/RankingKeyPage/RankingKeyPageClient.tsx
@@ -3,8 +3,15 @@
 import { ReactNode, useEffect, useMemo, useState, useTransition } from "react";
 
 import Link from "next/link";
-import { usePathname } from "next/navigation";
+import { usePathname, useRouter } from "next/navigation";
 
+import {
+    Select,
+    SelectContent,
+    SelectItem,
+    SelectTrigger,
+    SelectValue,
+} from "@stats47/components/atoms/ui/select";
 import { Skeleton } from "@stats47/components/atoms/ui/skeleton";
 import {
     Tabs,
@@ -117,6 +124,7 @@ export function RankingKeyPageClient({
     const [currentAreaType, setCurrentAreaType] = useState<AreaType>(areaType ?? "prefecture");
     const [isPending, startTransition] = useTransition();
     const pathname = usePathname();
+    const router = useRouter();
     const isBelowLg = useBreakpoint("belowLg");
     const isAboveXl = useBreakpoint("aboveXl");
 
@@ -385,30 +393,58 @@ export function RankingKeyPageClient({
             />
 
             {/* normalization_basis グループトグル（別URL切替）*/}
-            {groupMembers.length > 1 && (
-                <div className="flex items-center gap-0.5 mt-3 w-fit">
-                    {[...groupMembers].sort((a, b) => (a.normalizationBasis ? 1 : 0) - (b.normalizationBasis ? 1 : 0)).map((member) => {
-                        const isCurrent = member.rankingKey === rankingKey;
-                        const label = member.normalizationBasis || "総数";
-                        return isCurrent ? (
-                            <span
-                                key={member.rankingKey}
-                                className="text-xs px-2.5 pb-1 border-b-2 border-primary text-foreground font-medium"
+            {groupMembers.length > 1 && (() => {
+                const sortedMembers = [...groupMembers].sort(
+                    (a, b) => (a.normalizationBasis ? 1 : 0) - (b.normalizationBasis ? 1 : 0)
+                );
+                return (
+                    <>
+                        {/* モバイル: Select */}
+                        <div className="mt-3 sm:hidden">
+                            <Select
+                                value={rankingKey}
+                                onValueChange={(key) => {
+                                    if (key !== rankingKey) router.push(`/ranking/${key}`);
+                                }}
                             >
-                                {label}
-                            </span>
-                        ) : (
-                            <Link
-                                key={member.rankingKey}
-                                href={`/ranking/${member.rankingKey}`}
-                                className="text-xs px-2.5 pb-1 border-b-2 border-transparent text-muted-foreground hover:text-foreground hover:border-muted-foreground/30 transition-colors"
-                            >
-                                {label}
-                            </Link>
-                        );
-                    })}
-                </div>
-            )}
+                                <SelectTrigger aria-label="表示基準" className="h-9 w-full text-sm">
+                                    <SelectValue />
+                                </SelectTrigger>
+                                <SelectContent>
+                                    {sortedMembers.map((member) => (
+                                        <SelectItem key={member.rankingKey} value={member.rankingKey}>
+                                            {member.normalizationBasis || "総数"}
+                                        </SelectItem>
+                                    ))}
+                                </SelectContent>
+                            </Select>
+                        </div>
+                        {/* デスクトップ: テキストタブ */}
+                        <div className="hidden sm:flex items-center gap-0.5 mt-3 w-fit">
+                            {sortedMembers.map((member) => {
+                                const isCurrent = member.rankingKey === rankingKey;
+                                const label = member.normalizationBasis || "総数";
+                                return isCurrent ? (
+                                    <span
+                                        key={member.rankingKey}
+                                        className="text-xs px-2.5 pb-1 border-b-2 border-primary text-foreground font-medium"
+                                    >
+                                        {label}
+                                    </span>
+                                ) : (
+                                    <Link
+                                        key={member.rankingKey}
+                                        href={`/ranking/${member.rankingKey}`}
+                                        className="text-xs px-2.5 pb-1 border-b-2 border-transparent text-muted-foreground hover:text-foreground hover:border-muted-foreground/30 transition-colors"
+                                    >
+                                        {label}
+                                    </Link>
+                                );
+                            })}
+                        </div>
+                    </>
+                );
+            })()}
 
             {/* メインコンテンツ + 右サイドバー (CSS のみで切替: JS ハイドレーション由来の CLS を防ぐ) */}
             <div className="mt-4 lg:flex lg:gap-4 lg:items-start">

--- a/docs/50_Issues/feature-backlog.md
+++ b/docs/50_Issues/feature-backlog.md
@@ -366,3 +366,90 @@ N02 鉄道路線を路線図レイヤーとして追加。新幹線（`lineName`
 - `docs/01_技術設計/09_国土交通データプラットフォーム.md`: S12 取得元（MCP `mlit-dpf-mcp`）
 - `.claude/rules/r2-storage-design.md`: R2 配信化する場合の名前空間規約
 - 流用元: `apps/remotion/src/features/migration-flow/` / `population-choropleth/`
+
+---
+
+## [T2-RANKING-NORM-SSG-01] ranking 正規化派生 (人口10万人あたり等) の SSG 化 + SEO 対応
+
+- **tier**: 2
+- **status**: pending
+- **created**: 2026-05-25
+- **target_metric**: GSC clicks / impressions (normalization 派生 URL の indexing)
+
+### 背景
+
+`/ranking/[rankingKey]` ページには 2 系統の「表示基準切替」UI が並存している:
+
+| 系統 | UI | 計算ソース | URL | SSG | SEO |
+|---|---|---|---|---|---|
+| pill (RankingHeroCard) | rounded-full ボタン | stats47 計算 (per_population / per_area / per_household) | `?norm=per_population` などの query param | ✗ (CSR 限定) | ✗ indexable 不可 |
+| group toggle (RankingKeyPageClient) | テキストタブ | 別 metric (e-Stat 提供の「従業員1人あたり」「事業所1ヶ所あたり」等) | `/ranking/{別 rankingKey}` | ✓ | ✓ 別 page として indexed |
+
+### 問題
+
+1. **SEO 損失**: pill 切替の派生 (例: 「人口10万人あたり製造品出荷額」) は SSG 対象外で、検索エンジンに認識されない。同じ意味の e-Stat 由来派生 (「従業員1人あたり」) は別 rankingKey として SSG されており、indexing 状況が非対称。
+2. **UI 混乱**: pill と group で「表示基準を変える」操作が縦に並ぶ。pill は CSR 限定、group は別 URL 遷移という挙動の違いがユーザーに見えない。
+3. **データ重複**: pill 限定派生も group 由来派生も、本質的には「分子 / 分母 * scaleFactor」の同型計算。同じ概念が「どこから来たデータか」で UI / URL 設計が分かれている。
+4. **意味バグ**: `total-population` (denominator key 自身) に per_population オプションが付いており「人口あたりの人口」という無意味な選択肢が pill に並ぶ。`isBaseMetric()` ガード追加前のデータが残存している (T3-RANKING-NORM-DATA-CLEAN-01 で対応)。
+
+### 対応案
+
+#### 案 A (推奨): pill 選択肢を SSG 化する route 拡張
+
+- `app/ranking/[rankingKey]/page.tsx` の `generateStaticParams` に norm 種別を加え、`/ranking/{key}/{norm?}` のような route を生成
+- canonical: 各 norm 毎に独自 URL、`<link rel="alternate">` で他 norm を関連付け
+- sitemap.ts: 全 norm URL を含める (件数増、容量検討要)
+- 内部リンク: ranking-items-by-category 等、関連 ranking 列挙ロジックで norm 派生を含めるか検討
+
+工数: 中 (page.tsx の generateStaticParams / metadata / sitemap / 内部リンク全般)
+
+#### 案 B: pill 派生を別 rankingKey に昇格 (group に一本化)
+
+- `auto-attach-normalization.ts` の派生を、`metrics` テーブルの別 row として登録 (例: `manufacturing-shipment-amount-per-population` という新 key)
+- 既存の group toggle 機構をそのまま使うため、UI 統合が容易
+- 欠点: metric 数が 2-3 倍に膨らむ。snapshot 容量 / ビルド時間 / D1 行数の試算が必要
+
+工数: 大 (DB 設計変更 + 既存 R2 スナップショット移行 + 旧 `?norm=` URL の 301)
+
+#### 案 C: pill を維持しつつ canonical で吸収
+
+- 現状の `?norm=` URL を canonical で元 URL に統合し、pill は CSR 限定の便利機能と割り切る
+- 「人口10万人あたり製造品出荷額」のような検索クエリは諦める
+
+工数: 小 (canonical タグの整備のみ)
+
+### 関連
+
+- 短期対応 (モバイル UI Select 化): claude/admiring-noether-HeeLC (2026-05-25)
+- 派生計算ロジック: `packages/ranking/src/services/compute-normalization.ts`
+- snapshot: `packages/ranking/src/exporters/ranking-normalized-values-snapshot.ts`
+- denominator マップ: `WELL_KNOWN_DENOMINATORS` in compute-normalization.ts
+
+---
+
+## [T3-RANKING-NORM-DATA-CLEAN-01] denominator 系 metric から不適切な normalizationOptions を削除
+
+- **tier**: 3
+- **status**: pending
+- **created**: 2026-05-25
+
+### 背景
+
+`total-population`, `total-area-*`, `households` 等の denominator として使われる metric に、自分自身の denominator を使う norm option が混入している。`isBaseMetric()` ガード追加 (`packages/ranking/src/utils/is-base-metric.ts`) 以前のデータが DB に残存。
+
+### 例
+
+- `total-population` の `calculation.normalizationOptions` に `per_population` (label: 「人口10万人あたり」) が含まれる → 「人口あたりの人口」で意味なし
+
+### 対応
+
+- `packages/ranking/src/scripts/` に cleanup CLI を追加 (`drop-invalid-norm-options.ts`)
+- ロジック: `DENOMINATOR_KEYS` に該当する metric の `normalizationOptions` から、対応する `type` を除外
+- 実行: `--dry-run` で対象確認 → `--apply` で DB 更新 → `/sync-snapshots` で R2 再生成
+
+工数: 小
+
+### 関連
+
+- `packages/ranking/src/utils/is-base-metric.ts` DENOMINATOR_KEYS
+- `packages/ranking/src/scripts/auto-attach-normalization.ts` (既存の自動付与スクリプト)


### PR DESCRIPTION
## Summary

ランキング詳細ページのモバイル表示で「計算方法を切替」トグルと normalization_basis グループタブが崩れていた不具合を、shadcn Select への CSS 切替で修正。

## 原因

`/ranking/[rankingKey]` には 2 系統の表示基準切替 UI が並存:

| 系統 | UI | 例 (manufacturing-shipment-amount) | 横幅 (375px viewport で) |
|---|---|---|---|
| RankingHeroCard の pill | rounded-full ボタン群 | 総数 / 人口10万人あたり / 面積100km²あたり / 1世帯あたり | 約 380px |
| RankingKeyPageClient の groupMembers タブ | テキストタブ群 | 1従業者あたり / 1事業所あたり / (別 sibling) | 内容次第で同様にはみ出し |

いずれも `inline-flex` で折り返さず、日本語ラベルが長いため viewport を押し広げる。

## Changes

- `apps/web/src/features/ranking/components/RankingHeroCard/RankingHeroCard.tsx`: pill 群を `hidden sm:inline-flex` に変更し、`sm:hidden` の shadcn `Select` を追加
- `apps/web/src/features/ranking/components/RankingKeyPage/RankingKeyPageClient.tsx`: groupMembers タブを `hidden sm:flex` に変更し、`sm:hidden` の `Select` を追加。選択時は `useRouter().push()` で別 rankingKey URL に遷移 (元の `<Link>` 動作と等価)
- いずれも SSG/SSR HTML を不変に保つため `useMediaQuery` ではなく Tailwind `sm:` で出し分け (`.claude/rules/nextjs-ssg-preservation.md` に従い hydration mismatch 回避)

## バックログ登録

調査で判明した中期/長期課題を `docs/50_Issues/feature-backlog.md` に登録:

- **T2-RANKING-NORM-SSG-01**: pill 切替の派生 (人口10万人あたり等) が `?norm=` query param で CSR 限定のため SSG 対象外。e-Stat 由来の per-employee 等は別 rankingKey として SSG されており、検索流入の非対称性あり。SEO 強化のための route 再設計案 A/B/C を記載
- **T3-RANKING-NORM-DATA-CLEAN-01**: `total-population` 等の denominator 系 metric に「人口10万人あたり」のような意味のない norm option が残存。`isBaseMetric()` ガード追加前のデータ。cleanup CLI 追加案

## Test plan

- [ ] iPhone 実機 (Safari) で `/ranking/total-population` を開き、「計算方法を切替」トグルが Select で表示され、選択肢を変更できること
- [ ] 同じく `/ranking/manufacturing-shipment-amount` で pill (4 個) と group toggle (3 個) の両方が Select 化され、group Select 選択時に別 URL に遷移すること
- [ ] デスクトップ (≥640px) で従来の pill / テキストタブが表示されること
- [ ] 既存の `?norm=` URL ブックマークが pill / Select 両方で正しい初期値で起動すること

---
_Generated by [Claude Code](https://claude.ai/code/session_0119f68hKHaDjT63XmSwbMdw)_