### PR TITLE
feat(ranking): 詳細ページの UX/SEO 改善 6 件まとめて適用 (A-F)

### DIFF
--- a/apps/web/src/features/ranking/actions/fetch-all-years-ranking-values.ts
+++ b/apps/web/src/features/ranking/actions/fetch-all-years-ranking-values.ts
@@ -37,6 +37,17 @@ const fetchAllYearsCore = cache(async (
 });
 
 /**
+ * 受け入れ可能な正規化タイプの whitelist。
+ * R2 オブジェクトキー (`app/ranking/{key}/values-{type}.json`) に流入するため、
+ * path traversal 対策としてサーバ側で固定値以外を弾く。
+ */
+const ALLOWED_NORMALIZATION_TYPES = new Set([
+  "per_population",
+  "per_area",
+  "per_household",
+]);
+
+/**
  * 全年分のランキングデータを取得する（TrendSparkline・データダウンロード用）
  *
  * DB キャッシュを確認し、不足分があれば e-Stat API から一括取得する。
@@ -52,11 +63,17 @@ export async function fetchAllYearsRankingValuesAction(
   normalizationType?: string,
 ): Promise<Result<RankingValue[], Error>> {
   let result: Result<RankingValue[], Error>;
-  if (normalizationType) {
+  // normalizationType は ?norm= query param 由来でユーザー制御値。
+  // 後続の R2 キーパス生成に流入するため、固定 whitelist でのみ受理する。
+  const safeNormalizationType =
+    normalizationType && ALLOWED_NORMALIZATION_TYPES.has(normalizationType)
+      ? normalizationType
+      : undefined;
+  if (safeNormalizationType) {
     const normResult = await readAllYearsNormalizedRankingValuesFromR2(
       rankingKey,
       areaType,
-      normalizationType,
+      safeNormalizationType,
     );
     // 正規化スナップショットが見つからなければ総数で fallback
     result = isOk(normResult) && normResult.data.length > 0

--- a/apps/web/src/features/ranking/actions/fetch-all-years-ranking-values.ts
+++ b/apps/web/src/features/ranking/actions/fetch-all-years-ranking-values.ts
@@ -2,7 +2,11 @@
 
 import { cache } from "react";
 
-import { fetchAllYearsRankingValuesOnDemand, readRankingItemFromR2 } from "@stats47/ranking/server";
+import {
+  fetchAllYearsRankingValuesOnDemand,
+  readAllYearsNormalizedRankingValuesFromR2,
+  readRankingItemFromR2,
+} from "@stats47/ranking/server";
 import { err, ok, isOk, type Result } from "@stats47/types";
 
 import type { AreaType } from "@stats47/area";
@@ -36,6 +40,8 @@ const fetchAllYearsCore = cache(async (
  * 全年分のランキングデータを取得する（TrendSparkline・データダウンロード用）
  *
  * DB キャッシュを確認し、不足分があれば e-Stat API から一括取得する。
+ * normalizationType を指定した場合は事前計算済みの正規化スナップショットを返す
+ * (例: per_population なら 人口10万人あたりの全年度値)。
  *
  * @param parentAreaCode 都道府県コード（市区町村フィルタ用、例: "13000"）
  */
@@ -43,8 +49,22 @@ export async function fetchAllYearsRankingValuesAction(
   rankingKey: string,
   areaType: AreaType,
   parentAreaCode?: string,
+  normalizationType?: string,
 ): Promise<Result<RankingValue[], Error>> {
-  const result = await fetchAllYearsCore(rankingKey, areaType);
+  let result: Result<RankingValue[], Error>;
+  if (normalizationType) {
+    const normResult = await readAllYearsNormalizedRankingValuesFromR2(
+      rankingKey,
+      areaType,
+      normalizationType,
+    );
+    // 正規化スナップショットが見つからなければ総数で fallback
+    result = isOk(normResult) && normResult.data.length > 0
+      ? normResult
+      : await fetchAllYearsCore(rankingKey, areaType);
+  } else {
+    result = await fetchAllYearsCore(rankingKey, areaType);
+  }
   if (!isOk(result)) return result;
 
   if (!parentAreaCode) return result;

--- a/apps/web/src/features/ranking/actions/fetch-ranking-values.ts
+++ b/apps/web/src/features/ranking/actions/fetch-ranking-values.ts
@@ -13,6 +13,17 @@ import type { AreaType } from "@stats47/area";
 import type { RankingValue } from "@stats47/ranking";
 
 /**
+ * 受け入れ可能な正規化タイプの whitelist。
+ * R2 オブジェクトキー (`app/ranking/{key}/values-{type}.json`) に流入するため、
+ * path traversal 対策としてサーバ側で固定値以外を弾く。
+ */
+const ALLOWED_NORMALIZATION_TYPES = new Set([
+  "per_population",
+  "per_area",
+  "per_household",
+]);
+
+/**
  * ランキングデータを取得する（正規化対応）
  *
  * @param parentAreaCode 都道府県コード（市区町村フィルタ用、例: "13000"）
@@ -34,20 +45,27 @@ export async function fetchRankingValuesAction(
 
     let values: RankingValue[];
 
+    // normalizationType は ?norm= query param 由来でユーザー制御値。
+    // 後続の R2 キーパス生成に流入するため、固定 whitelist でのみ受理する。
+    const safeNormalizationType =
+      normalizationType && ALLOWED_NORMALIZATION_TYPES.has(normalizationType)
+        ? normalizationType
+        : undefined;
+
     // 正規化が指定されている場合
-    if (normalizationType) {
+    if (safeNormalizationType) {
       // 事前計算済み R2 スナップショットを優先使用
       const normResult = await readNormalizedRankingValuesFromR2(
         rankingKey,
         areaType,
         yearCode,
-        normalizationType,
+        safeNormalizationType,
       );
       if (isOk(normResult) && normResult.data.length > 0) {
         values = normResult.data;
       } else {
         // フォールバック: 実行時計算（カスタム denominatorKey 等）
-        values = await computeNormalization(rankingItem, yearCode, normalizationType);
+        values = await computeNormalization(rankingItem, yearCode, safeNormalizationType);
       }
     } else {
       // DB から取得（なければ e-Stat API からオンデマンド取得 + キャッシュ）

--- a/apps/web/src/features/ranking/components/DataDownloadButton.tsx
+++ b/apps/web/src/features/ranking/components/DataDownloadButton.tsx
@@ -36,6 +36,12 @@ interface DataDownloadButtonProps {
     demographicAttr: string | null;
     normalizationBasis: string | null;
   };
+  /**
+   * 現在表示中の正規化タイプ (per_population / per_area / per_household)。
+   * 指定された場合、その基準で計算済みの値を出力する (例: 「人口10万人あたり」の全年度値)。
+   * 未指定なら総数を出力。
+   */
+  normalizationType?: string;
 }
 
 function sanitizeFileName(name: string): string {
@@ -122,13 +128,19 @@ export function DataDownloadIconButton({
   rankingKey,
   areaType,
   displayInfo,
+  normalizationType,
 }: DataDownloadButtonProps) {
   const [isLoading, setIsLoading] = useState(false);
 
   const handleDownload = async (format: "csv" | "json") => {
     setIsLoading(true);
     try {
-      const result = await fetchAllYearsRankingValuesAction(rankingKey, areaType);
+      const result = await fetchAllYearsRankingValuesAction(
+        rankingKey,
+        areaType,
+        undefined,
+        normalizationType,
+      );
       if (!isOk(result) || result.data.length === 0) return;
       trackCsvDownload({ rankingKey, yearCode: "all" });
       const fileName = buildFileName(displayInfo, format);
@@ -189,6 +201,7 @@ export function DataDownloadPrimaryButton({
   rankingKey,
   areaType,
   displayInfo,
+  normalizationType,
   label = "CSV をダウンロード",
   variant = "default",
 }: DataDownloadButtonProps & {
@@ -202,7 +215,12 @@ export function DataDownloadPrimaryButton({
   const handleDownload = async () => {
     setIsLoading(true);
     try {
-      const result = await fetchAllYearsRankingValuesAction(rankingKey, areaType);
+      const result = await fetchAllYearsRankingValuesAction(
+        rankingKey,
+        areaType,
+        undefined,
+        normalizationType,
+      );
       if (!isOk(result) || result.data.length === 0) return;
       trackCsvDownload({ rankingKey, yearCode: "all" });
       const fileName = buildFileName(displayInfo, "csv");
@@ -231,6 +249,76 @@ export function DataDownloadPrimaryButton({
   );
 }
 
+/**
+ * ラベル付き CSV/JSON ダウンロード menu ボタン（DataUsageCard 用）
+ *
+ * 「データダウンロード」と表示し、Dropdown で CSV / JSON を選択させる。
+ * normalizationType が指定されていればその基準で計算済みの値を出力。
+ */
+export function DataDownloadMenuButton({
+  rankingKey,
+  areaType,
+  displayInfo,
+  normalizationType,
+  label = "ダウンロード",
+  variant = "default",
+}: DataDownloadButtonProps & {
+  label?: string;
+  variant?: "default" | "outline";
+}) {
+  const [isLoading, setIsLoading] = useState(false);
+
+  const handleDownload = async (format: "csv" | "json") => {
+    setIsLoading(true);
+    try {
+      const result = await fetchAllYearsRankingValuesAction(
+        rankingKey,
+        areaType,
+        undefined,
+        normalizationType,
+      );
+      if (!isOk(result) || result.data.length === 0) return;
+      trackCsvDownload({ rankingKey, yearCode: "all" });
+      const fileName = buildFileName(displayInfo, format);
+      if (format === "csv") {
+        const csv = generateCsvContent(result.data);
+        triggerDownload(new Blob([csv], { type: "text/csv;charset=utf-8" }), fileName);
+      } else {
+        const json = JSON.stringify(result.data, null, 2);
+        triggerDownload(
+          new Blob([json], { type: "application/json;charset=utf-8" }),
+          fileName,
+        );
+      }
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button variant={variant} size="sm" disabled={isLoading} className="gap-1.5">
+          {isLoading ? (
+            <Loader2 className="h-4 w-4 animate-spin" />
+          ) : (
+            <Download className="h-4 w-4" />
+          )}
+          {label}
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end">
+        <DropdownMenuItem onClick={() => handleDownload("csv")}>
+          CSV 形式 (Excel 互換)
+        </DropdownMenuItem>
+        <DropdownMenuItem onClick={() => handleDownload("json")}>
+          JSON 形式 (開発者向け)
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}
+
 interface DataDownloadFooterCardProps extends DataDownloadButtonProps {
   /** プレビュー用のランキングデータ（上位表示用） */
   rankingValues: RankingValue[];
@@ -243,6 +331,7 @@ export function DataDownloadFooterCard({
   rankingKey,
   areaType,
   displayInfo,
+  normalizationType,
   rankingValues,
 }: DataDownloadFooterCardProps) {
   const [isLoading, setIsLoading] = useState(false);
@@ -250,7 +339,12 @@ export function DataDownloadFooterCard({
   const handleDownload = async (format: "csv" | "json") => {
     setIsLoading(true);
     try {
-      const result = await fetchAllYearsRankingValuesAction(rankingKey, areaType);
+      const result = await fetchAllYearsRankingValuesAction(
+        rankingKey,
+        areaType,
+        undefined,
+        normalizationType,
+      );
       if (!isOk(result) || result.data.length === 0) return;
       trackCsvDownload({ rankingKey, yearCode: "all" });
       const fileName = buildFileName(displayInfo, format);

--- a/apps/web/src/features/ranking/components/DataUsageCard/DataUsageCard.tsx
+++ b/apps/web/src/features/ranking/components/DataUsageCard/DataUsageCard.tsx
@@ -4,13 +4,13 @@ import { Download } from "lucide-react";
 
 import type { AreaType } from "@/features/area";
 
-import { DataDownloadPrimaryButton } from "../DataDownloadButton";
+import { DataDownloadMenuButton } from "../DataDownloadButton";
 
 /**
- * CSV 訴求カード「このデータを使う」（Option D / Phase 1）
+ * データダウンロード訴求カード「このデータを使う」
  *
- * 地図 + 順位表の下に配置。CSV ダウンロードボタンのみを提供する
- * （JSON/Excel エクスポートは未実装機能のため出さない）。
+ * 地図 + 順位表の下に配置。CSV / JSON 両形式のダウンロードを提供する。
+ * 現在表示中の正規化基準 (per_population 等) に対応した値をダウンロードできる。
  */
 
 interface DataUsageCardProps {
@@ -24,6 +24,8 @@ interface DataUsageCardProps {
   };
   /** 利用可能な年度数（説明文に表示） */
   yearCount?: number;
+  /** 現在表示中の正規化タイプ (pill で選択中の per_population など) */
+  normalizationType?: string;
 }
 
 export function DataUsageCard({
@@ -31,8 +33,12 @@ export function DataUsageCard({
   areaType,
   displayInfo,
   yearCount,
+  normalizationType,
 }: DataUsageCardProps) {
   const yearText = yearCount && yearCount > 0 ? `${yearCount}年分の時系列を含む` : "";
+  const basisText = displayInfo.normalizationBasis
+    ? `「${displayInfo.normalizationBasis}」の値で`
+    : "";
 
   return (
     <div className="flex items-center gap-4 rounded-xl border border-primary/20 bg-primary/5 p-4 shadow-sm">
@@ -42,15 +48,16 @@ export function DataUsageCard({
       <div className="min-w-0 flex-1">
         <h2 className="text-sm font-bold text-primary">このデータを使う</h2>
         <p className="mt-0.5 text-xs text-muted-foreground">
-          47都道府県{yearText ? ` × ${yearText}` : "の"} CSV
-          を、クレジット表記すれば無料で商用利用できます。
+          47都道府県{yearText ? ` × ${yearText}` : "の"}データを{basisText}
+          CSV / JSON でダウンロード。クレジット表記すれば無料で商用利用できます。
         </p>
       </div>
-      <DataDownloadPrimaryButton
+      <DataDownloadMenuButton
         rankingKey={rankingKey}
         areaType={areaType}
         displayInfo={displayInfo}
-        label="CSV"
+        normalizationType={normalizationType}
+        label="ダウンロード"
       />
     </div>
   );

--- a/apps/web/src/features/ranking/components/RankingKeyPage/RankingKeyPageClient.tsx
+++ b/apps/web/src/features/ranking/components/RankingKeyPage/RankingKeyPageClient.tsx
@@ -38,7 +38,6 @@ import {
     RankingSourceCard,
     RankingYearSelector,
     AreaTypeToggle,
-    DataDownloadPrimaryButton,
     RankingHeroCard,
     DataUsageCard,
 } from "@/features/ranking";
@@ -288,14 +287,6 @@ export function RankingKeyPageClient({
         </span>
     ) : undefined;
 
-    const downloadButton = (
-        <DataDownloadPrimaryButton
-            rankingKey={rankingKey}
-            areaType={areaType}
-            displayInfo={displayInfo}
-        />
-    );
-
     // ヒーローカードのメタ操作行: 年度 select + 都道府県/市区町村 seg
     const metaControls = (
         <>
@@ -386,7 +377,6 @@ export function RankingKeyPageClient({
                 onNormalizationChange={handleNormalizationChange}
                 normalizationDisabled={isPending}
                 metaControls={metaControls}
-                downloadButton={downloadButton}
                 shareButton={
                     <ShareButtons title={displayInfo.title} shareText={shareText} />
                 }
@@ -507,27 +497,16 @@ export function RankingKeyPageClient({
                         </div>
                     )}
 
-                    {/* CSV 訴求カード「このデータを使う」 */}
+                    {/* データダウンロード訴求カード「このデータを使う」 (CSV/JSON、正規化基準対応) */}
                     <DataUsageCard
                         rankingKey={rankingKey}
                         areaType={currentAreaType}
                         displayInfo={displayInfo}
                         yearCount={activeRankingItem.availableYears?.length}
+                        normalizationType={normalizationType}
                     />
 
-                    {/* 広告: テーブル読了後 */}
-                    <AdSenseAd
-                        format={RANKING_PAGE_FOOTER.format}
-                        slotId={RANKING_PAGE_FOOTER.slotId}
-                    />
-
-                    {/* ネイティブアフィリエイト枠 (D Phase 2) */}
-                    {nativeAffiliateSection}
-
-                    {/* 同カテゴリ関連ランキング grid (内部リンク密度↑) */}
-                    {relatedRankingsSection}
-
-                    {/* データの考察（常時表示カード） */}
+                    {/* データの考察（常時表示カード） — 本来テーブル直下で読まれるべき主要コンテンツ */}
                     {insightsSection}
 
                     {/* よくある質問（折りたたみ）+ JSON-LD */}
@@ -573,6 +552,18 @@ export function RankingKeyPageClient({
                     {rankingItem?.source && (
                         <RankingSourceCard source={rankingItem.source} />
                     )}
+
+                    {/* 広告: 解析・本文を読了後、関連ランキングの直前に配置 */}
+                    <AdSenseAd
+                        format={RANKING_PAGE_FOOTER.format}
+                        slotId={RANKING_PAGE_FOOTER.slotId}
+                    />
+
+                    {/* ネイティブアフィリエイト枠 (D Phase 2) */}
+                    {nativeAffiliateSection}
+
+                    {/* 同カテゴリ関連ランキング grid (内部リンク密度↑、ページ末尾の回遊導線) */}
+                    {relatedRankingsSection}
 
                 </main>
 

--- a/apps/web/src/features/ranking/components/RelatedRankingsGrid/RelatedRankingsGrid.tsx
+++ b/apps/web/src/features/ranking/components/RelatedRankingsGrid/RelatedRankingsGrid.tsx
@@ -65,7 +65,7 @@ export async function RelatedRankingsGrid({
           </Link>
         )}
       </CardHeader>
-      <CardContent className="px-5 pb-5 pt-0">
+      <CardContent className="px-5 pb-5 pt-4">
         <div className="grid grid-cols-1 gap-2 sm:grid-cols-2 lg:grid-cols-2 xl:grid-cols-3">
           {items.map((item) => {
             const title = item.subtitle

--- a/packages/ranking/src/repositories/ranking-value/index.ts
+++ b/packages/ranking/src/repositories/ranking-value/index.ts
@@ -3,6 +3,7 @@ export { getAllAvailableYears } from "./get-all-available-years";
 export { getAvailableYears } from "./get-available-years";
 export { listRankingValues } from "./list-ranking-values";
 export {
+  readAllYearsNormalizedRankingValuesFromR2,
   readNormalizedRankingValuesFromR2,
   readRankingValuesByPrefectureFromR2,
   readRankingValuesFromR2,

--- a/packages/ranking/src/repositories/ranking-value/read-ranking-values-from-r2.ts
+++ b/packages/ranking/src/repositories/ranking-value/read-ranking-values-from-r2.ts
@@ -121,6 +121,35 @@ export async function readNormalizedRankingValuesFromR2(
 }
 
 /**
+ * 正規化済み R2 snapshot から全年度の ranking_values を取得 (ダウンロード用)。
+ *
+ * ファイルが存在しない場合は ok([]) を返す。
+ */
+export async function readAllYearsNormalizedRankingValuesFromR2(
+  rankingKey: string,
+  _areaType: AreaType,
+  normType: string,
+): Promise<Result<RankingValue[], Error>> {
+  try {
+    const path = rankingNormalizedValuesKeyPath(rankingKey, normType);
+    const snapshot = await fetchFromR2AsJson<RankingValuesKeySnapshot>(path);
+    if (!snapshot) return ok([]);
+
+    const all: RankingValue[] = [];
+    for (const partition of snapshot.partitions) {
+      all.push(...partition.values);
+    }
+    return ok(all);
+  } catch (error) {
+    logger.error(
+      { rankingKey, normType, error: error instanceof Error ? error.message : String(error) },
+      "readAllYearsNormalizedRankingValuesFromR2: failed",
+    );
+    return err(error instanceof Error ? error : new Error(String(error)));
+  }
+}
+
+/**
  * 指定都道府県の市区町村ランキング値を取得。
  * city partition から areaCode の先頭 2 桁が prefCode と一致する行をフィルタ。
  */


### PR DESCRIPTION
## Summary

ランキング詳細ページの UX/SEO 改善 6 件まとめて適用。pill で選んだ正規化基準が CSV/JSON に反映されない機能バグも修正。

## Changes

### A. 機能バグ修正: ダウンロードに正規化基準が反映されない
- `fetchAllYearsRankingValuesAction` に `normalizationType` を追加
- `readAllYearsNormalizedRankingValuesFromR2` (R2 snapshot 全年度版) を新設
- 「人口10万人あたり」を pill で選択中に出力される CSV/JSON が常に総数だったバグを修正

### B. RelatedRankingsGrid の Card 内余白を解消
- `CardContent` の `pt-0` → `pt-4`
- タイトル下線とアイテムグリッドが直接くっついていた問題を修正

### C. データの考察 (insightsSection) をテーブル直下に上げる
旧順序:
```
メイン → CSV訴求 → 広告 → アフィリエイト → 関連ランキング → 考察 → FAQ → 地域別 → 都道府県別 → 相関 → ...
```
新順序:
```
メイン → CSV訴求 → 考察 → FAQ → 地域別 → 都道府県別 → 相関 → (mobile 広告) → 補足 → 定義 → 出典 → 広告 → アフィリエイト → 関連ランキング
```

### D. CSV ダウンロードボタンを 1 箇所に集約
HeroCard 上部の「CSV をダウンロード」ボタンを削除。DataUsageCard 1 箇所に統一。

### E. CSV/JSON 両対応の「データダウンロード」Dropdown
新コンポーネント `DataDownloadMenuButton` を新設し、Dropdown で「CSV 形式 (Excel 互換)」「JSON 形式 (開発者向け)」を選択可能に。

### F. 広告位置を関連ランキングの直前に移動
旧: テーブル直下に rectangle 広告 (min-height 280px 予約) → 関連ランキングとの間に大きな余白
新: 解析・本文・出典まで読了後の自然なブレークポイントに配置

## Test plan

- [ ] `/ranking/total-population` モバイル/PC 両方で表示確認
- [ ] pill で「人口10万人あたり」を選択 → DataUsageCard の「ダウンロード」ボタン押下 → CSV/JSON が正規化済みの値で出力されること
- [ ] 関連ランキング Card のタイトル下線と中身に間隔があること
- [ ] テーブル直下に「データの考察」が表示され、広告は本文を読了後の位置に移動していること
- [ ] HeroCard 上部に CSV ダウンロードボタンが消えていること
- [ ] 既存の sparkline / bar-chart-race など `fetchAllYearsRankingValuesAction` 呼び出し箇所が引き続き動作すること (引数省略の後方互換)

## バックログ
G/H (全基準まとめてダウンロード / Shift_JIS 版 CSV) は使用ケース限定のため今回は見送り。必要になれば backlog 化検討。

---
_Generated by [Claude Code](https://claude.ai/code/session_0119f68hKHaDjT63XmSwbMdw)_