### PR TITLE
feat: CSV ダウンロード R2 事前生成化 + ブログ記事ページ β レイアウト

### DIFF
--- a/.claude/skills/db/sync-snapshots/run.sh
+++ b/.claude/skills/db/sync-snapshots/run.sh
@@ -28,6 +28,7 @@ declare -a TASKS=(
   "correlation|packages/correlation/src/scripts/export-snapshot.ts"
   "ranking-values|packages/ranking/src/scripts/export-ranking-values-snapshots.ts"
   "ranking-normalized-values|packages/ranking/src/scripts/export-ranking-normalized-values-snapshots.ts"
+  "ranking-download|packages/ranking/src/scripts/export-ranking-download-snapshots.ts"
   "area-profile|packages/area-profile/src/scripts/export-snapshot.ts"
   "city-profile|packages/area-profile/src/scripts/export-city-snapshot.ts"
   "blog|apps/web/scripts/export-blog-snapshot.ts"

--- a/apps/web/src/app/api/ranking/[rankingKey]/download/route.ts
+++ b/apps/web/src/app/api/ranking/[rankingKey]/download/route.ts
@@ -1,0 +1,120 @@
+import { NextRequest, NextResponse } from "next/server";
+
+import { fetchFromR2 } from "@stats47/r2-storage/server";
+import { rankingDownloadKeyPath } from "@stats47/ranking/types";
+
+/**
+ * ランキングデータ ダウンロード API
+ *
+ * GET /api/ranking/[rankingKey]/download?format=csv&basis=original&encoding=utf8
+ *
+ * R2 に事前生成済みの CSV / JSON ファイルをそのまま stream する。
+ * クライアント側で CSV を組み立てる必要がないため、Workers CPU 消費なし。
+ * Cloudflare CDN cache でファイル単位にキャッシュ。
+ *
+ * パラメータは全て whitelist 検証で path injection を防ぐ。
+ *
+ * @param format    csv | json
+ * @param basis     original | per_population | per_area | per_household | all-bases
+ *                  (省略時は original)
+ * @param encoding  utf8 | sjis (CSV のみ。JSON は常に utf8)
+ */
+
+const ALLOWED_FORMATS = new Set(["csv", "json"] as const);
+const ALLOWED_BASES = new Set([
+  "original",
+  "per_population",
+  "per_area",
+  "per_household",
+  "all-bases",
+] as const);
+const ALLOWED_ENCODINGS = new Set(["utf8", "sjis"] as const);
+
+type Format = "csv" | "json";
+type Encoding = "utf8" | "sjis";
+
+function isFormat(v: string | null): v is Format {
+  return v !== null && (ALLOWED_FORMATS as Set<string>).has(v);
+}
+
+function isEncoding(v: string | null): v is Encoding {
+  return v !== null && (ALLOWED_ENCODINGS as Set<string>).has(v);
+}
+
+/** RFC 5987 形式の Content-Disposition (日本語ファイル名対応) */
+function buildContentDisposition(filename: string): string {
+  const encoded = encodeURIComponent(filename);
+  return `attachment; filename="${filename.replace(/[^\w.-]/g, "_")}"; filename*=UTF-8''${encoded}`;
+}
+
+function buildFilename(
+  rankingKey: string,
+  basis: string,
+  format: Format,
+  encoding: Encoding,
+): string {
+  const basisSuffix = basis === "original" ? "" : `_${basis}`;
+  const encSuffix = encoding === "sjis" ? "_sjis" : "";
+  return `${rankingKey}${basisSuffix}${encSuffix}.${format}`;
+}
+
+export async function GET(
+  req: NextRequest,
+  { params }: { params: Promise<{ rankingKey: string }> },
+) {
+  const { rankingKey } = await params;
+  const sp = req.nextUrl.searchParams;
+
+  const formatParam = sp.get("format");
+  const basisParam = sp.get("basis") ?? "original";
+  const encodingParam = sp.get("encoding") ?? "utf8";
+
+  if (!isFormat(formatParam)) {
+    return NextResponse.json(
+      { error: "Invalid format. Expected csv or json." },
+      { status: 400 },
+    );
+  }
+  if (!(ALLOWED_BASES as Set<string>).has(basisParam)) {
+    return NextResponse.json(
+      { error: "Invalid basis." },
+      { status: 400 },
+    );
+  }
+  if (!isEncoding(encodingParam)) {
+    return NextResponse.json(
+      { error: "Invalid encoding." },
+      { status: 400 },
+    );
+  }
+
+  // JSON は utf8 のみ
+  const safeEncoding: Encoding = formatParam === "json" ? "utf8" : encodingParam;
+
+  const path = rankingDownloadKeyPath(rankingKey, basisParam, formatParam, safeEncoding);
+  const buffer = await fetchFromR2(path);
+
+  if (!buffer) {
+    return NextResponse.json(
+      { error: "File not found. Run sync-snapshots to generate." },
+      { status: 404 },
+    );
+  }
+
+  const contentType = formatParam === "csv"
+    ? safeEncoding === "sjis"
+      ? "text/csv; charset=Shift_JIS"
+      : "text/csv; charset=utf-8"
+    : "application/json; charset=utf-8";
+
+  const filename = buildFilename(rankingKey, basisParam, formatParam, safeEncoding);
+
+  return new NextResponse(new Uint8Array(buffer), {
+    status: 200,
+    headers: {
+      "Content-Type": contentType,
+      "Content-Disposition": buildContentDisposition(filename),
+      "Cache-Control": "public, max-age=86400, s-maxage=2592000",
+    },
+  });
+}

--- a/apps/web/src/app/blog/[slug]/page.tsx
+++ b/apps/web/src/app/blog/[slug]/page.tsx
@@ -13,8 +13,9 @@ import { Card, CardContent, CardHeader, CardTitle } from "@stats47/components/at
 
 import { ShareButtons } from "@/components/molecules/ShareButtons";
 
+import { FurusatoNozeiCard, TechSchoolPromoCard } from "@/features/ads";
 import { resolveAffiliateBannersByCategory } from "@/features/ads/server";
-import { TagBadge, ArticleRelatedBooks, ArticleRenderer, ArticleTableOfContents, generateBlogMetadata, type Article } from "@/features/blog";
+import { TagBadge, ArticleRelatedBooks, ArticleRenderer, ArticleTableOfContents, extractPrefecturesFromArticle, generateBlogMetadata, type Article } from "@/features/blog";
 import {
     ArticleAffiliateBanner,
     ArticleDataDownloadSection,
@@ -116,6 +117,15 @@ export default async function BlogPostPage({ params }: PageProps) {
         resolveAffiliateBannersByCategory(),
     ]);
 
+    // 記事に登場する都道府県を抽出 (ふるさと納税 widget の表示先決定用)
+    const prefCodes = extractPrefecturesFromArticle({
+        title: article.title,
+        body: article.content,
+        tagKeys,
+        limit: 1,
+    });
+    const primaryPrefCode = prefCodes[0];
+
     // 記事本文中の /blog/{slug} リンクからスラッグを抽出し、DB からタイトルを取得
     const blogLinkSlugs = [...article.content.matchAll(/\]\(\/blog\/([a-z0-9-]+)\)/g)]
         .map((m) => m[1])
@@ -185,14 +195,17 @@ export default async function BlogPostPage({ params }: PageProps) {
                 </Breadcrumb>
             </div>
 
-            {/* メインコンテンツ（xl+: 2カラム、xl未満: 1カラム） */}
-            <div className="container mx-auto px-4 py-8">
+            {/* メインコンテンツ（xl+: 2カラム、xl未満: 1カラム）
+                container を max-w-[1700px] に拡張し、右サイドバーを 480px に広げて
+                画面領域を有効活用 (現状の max-w-screen-2xl=1536px + 右 288px → 余白
+                480px を解消) */}
+            <div className="mx-auto max-w-[1700px] px-4 py-6">
                 <div className="xl:flex xl:gap-6 xl:items-start">
 
                     {/* 記事・関連コンテンツ列 */}
                     <main className="flex-1 min-w-0 space-y-6">
                         <Card>
-                            <CardContent className="p-6 sm:p-8 max-w-4xl overflow-hidden">
+                            <CardContent className="p-6 sm:p-8 overflow-hidden">
                                 {/* 記事ヘッダー */}
                                 <header className="mb-8">
                                     <h1 className="mb-4 border-b-4 border-primary pb-3 text-lg font-bold">{article.title}</h1>
@@ -222,6 +235,9 @@ export default async function BlogPostPage({ params }: PageProps) {
                                 {/* 記事本文 */}
                                 <ArticleRenderer article={article} slug={slug} relatedArticleTitles={relatedArticleTitles} affiliateBannersByCategory={affiliateBannersByCategory} />
 
+                                {/* インラインネイティブ広告: Claude Code 副業講座 (本文と SNS share の間) */}
+                                <TechSchoolPromoCard variant="inline" />
+
                                 {/* SNSシェアボタン */}
                                 <div className="mt-8 pt-6 border-t flex justify-center">
                                     <ShareButtons title={article.title} url={`/blog/${slug}`} variant="prominent" />
@@ -229,8 +245,14 @@ export default async function BlogPostPage({ params }: PageProps) {
                             </CardContent>
                         </Card>
 
-                        {/* 広告（記事本文後）: xl+ ではサイドバーに表示するため非表示 */}
-                        <div className="xl:hidden">
+                        {/* DataPack CSV CTA (マスタープラン § 5.3 「関連 CSV」) */}
+                        <ArticleDataDownloadSection tagKeys={tagKeys} />
+
+                        {/* バナー広告（タグキーベース・ランダム表示） */}
+                        <ArticleAffiliateBanner tagKeys={tagKeys} />
+
+                        {/* xl 未満で表示する各種関連 widget (xl+ ではサイドバーに集約) */}
+                        <div className="space-y-6 xl:hidden">
                             <Card>
                                 <CardHeader className="pb-2">
                                     <CardTitle className="text-sm font-medium text-muted-foreground">広告</CardTitle>
@@ -239,29 +261,17 @@ export default async function BlogPostPage({ params }: PageProps) {
                                     <AdSenseAd format={RANKING_SIDEBAR_TOP.format} slotId={RANKING_SIDEBAR_TOP.slotId} showLabel={false} />
                                 </CardContent>
                             </Card>
-                        </div>
 
-                        {/* DataPack CSV CTA (マスタープラン § 5.3 「関連 CSV」) */}
-                        <ArticleDataDownloadSection tagKeys={tagKeys} />
-
-                        {/* バナー広告（タグキーベース・ランダム表示） */}
-                        <ArticleAffiliateBanner tagKeys={tagKeys} />
-
-                        {/* 関連書籍・関連ランキング・関連記事: xl+ ではサイドバーに表示するため非表示 */}
-                        <div className="xl:hidden">
                             <ArticleRelatedBooks tagKeys={tagKeys} />
-                        </div>
 
-                        <div className="xl:hidden">
                             <RelatedRankingsSection tagKeys={tagKeys} />
-                        </div>
 
-                        <div className="xl:hidden">
+                            {primaryPrefCode && (
+                                <FurusatoNozeiCard areaCode={primaryPrefCode} />
+                            )}
+
                             <BlogRelatedArticlesSection articles={relatedArticles} currentSlug={slug} articleTagsMap={articleTagsMap} />
-                        </div>
 
-                        {/* 広告（関連記事後）: xl+ ではサイドバーに表示するため非表示 */}
-                        <div className="xl:hidden">
                             <Card>
                                 <CardHeader className="pb-2">
                                     <CardTitle className="text-sm font-medium text-muted-foreground">広告</CardTitle>
@@ -273,22 +283,17 @@ export default async function BlogPostPage({ params }: PageProps) {
                         </div>
                     </main>
 
-                    {/* 右スティッキーサイドバー: xl+ のみ表示 */}
-                    <aside className="hidden xl:flex xl:w-72 xl:shrink-0 xl:flex-col xl:gap-4 xl:sticky xl:top-20">
-                        {/* 目次 (マスタープラン § 5.3 「TOC + 関連記事」) */}
+                    {/* 右サイドバー: xl+ のみ、480px 幅。
+                        max-h と overflow-y-auto で viewport 内で独立スクロール可
+                        (article 本文を読みつつサイドバーの widget もすべて到達可能) */}
+                    <aside className="hidden xl:flex xl:w-[480px] xl:shrink-0 xl:flex-col xl:gap-3 xl:sticky xl:top-20 xl:max-h-[calc(100vh-5.5rem)] xl:overflow-y-auto xl:pr-1">
+                        {/* Claude Code 副業講座 (上部固定で常時露出) */}
+                        <TechSchoolPromoCard />
+
+                        {/* 目次 */}
                         <ArticleTableOfContents content={article.content} compact />
-                        {/* コンテンツ（優先度順） */}
-                        <BlogRelatedArticlesSection articles={relatedArticles} currentSlug={slug} articleTagsMap={articleTagsMap} compact />
-                        <RelatedRankingsSection tagKeys={tagKeys} compact />
-                        <Card>
-                            <CardHeader className="py-3 px-4">
-                                <CardTitle className="text-base">関連書籍</CardTitle>
-                            </CardHeader>
-                            <CardContent className="p-4 pt-0">
-                                <ArticleRelatedBooks tagKeys={tagKeys} compact />
-                            </CardContent>
-                        </Card>
-                        {/* 末尾広告（サイドバーが空にならないよう常時表示） */}
+
+                        {/* AdSense Rectangle 1 (上部、above-fold) */}
                         <Card>
                             <CardHeader className="pb-2">
                                 <CardTitle className="text-sm font-medium text-muted-foreground">広告</CardTitle>
@@ -297,6 +302,29 @@ export default async function BlogPostPage({ params }: PageProps) {
                                 <AdSenseAd format={RANKING_SIDEBAR_TOP.format} slotId={RANKING_SIDEBAR_TOP.slotId} showLabel={false} />
                             </CardContent>
                         </Card>
+
+                        {/* 関連書籍 (480px 幅で 2 列 grid 表示) */}
+                        <Card>
+                            <CardHeader className="py-3 px-4">
+                                <CardTitle className="text-base">関連書籍</CardTitle>
+                            </CardHeader>
+                            <CardContent className="p-4 pt-0">
+                                <ArticleRelatedBooks tagKeys={tagKeys} compact />
+                            </CardContent>
+                        </Card>
+
+                        {/* 関連ランキング */}
+                        <RelatedRankingsSection tagKeys={tagKeys} compact />
+
+                        {/* 都道府県ふるさと納税 (記事に登場した県があれば自動表示) */}
+                        {primaryPrefCode && (
+                            <FurusatoNozeiCard areaCode={primaryPrefCode} />
+                        )}
+
+                        {/* 関連記事 */}
+                        <BlogRelatedArticlesSection articles={relatedArticles} currentSlug={slug} articleTagsMap={articleTagsMap} compact />
+
+                        {/* AdSense Rectangle 2 (下部) */}
                         <Card>
                             <CardHeader className="pb-2">
                                 <CardTitle className="text-sm font-medium text-muted-foreground">広告</CardTitle>

--- a/apps/web/src/features/ads/components/TechSchoolPromoCard.tsx
+++ b/apps/web/src/features/ads/components/TechSchoolPromoCard.tsx
@@ -1,0 +1,76 @@
+import { Sparkles } from "lucide-react";
+
+import { TrackedAffiliateLink } from "./tracked-affiliate-link";
+
+interface TechSchoolPromoCardProps {
+  /** sidebar に表示する compact 版 / 本文中 inline 版を切り替え */
+  variant?: "sidebar" | "inline";
+}
+
+/**
+ * Claude Code / AI 副業スクール プロモーションカード。
+ *
+ * 環境変数 `NEXT_PUBLIC_TECH_SCHOOL_AFFILIATE_URL` が設定されていれば
+ * その URL を遷移先に使用。未設定時は内部 `/about` への内部リンクに
+ * フォールバック (法務的に安全)。
+ *
+ * 文脈: stats47 自体が「公務員 × Claude Code × e-Stat 自動化」の実例なので、
+ * 同じ路線の AI スクール / 副業講座は読者の関心と高い文脈適合性を持つ。
+ */
+export function TechSchoolPromoCard({ variant = "sidebar" }: TechSchoolPromoCardProps) {
+  const url = process.env.NEXT_PUBLIC_TECH_SCHOOL_AFFILIATE_URL || "/about";
+  const isExternal = url.startsWith("http");
+
+  if (variant === "inline") {
+    return (
+      <div className="my-6 rounded-xl border-l-4 border-l-purple-500 bg-gradient-to-r from-purple-50 via-blue-50 to-white p-4 shadow-sm">
+        <div className="mb-1 flex items-center gap-1 text-[10px] font-bold uppercase tracking-wider text-purple-700">
+          <Sparkles className="h-3 w-3" />
+          AI スクール / 副業 PR
+        </div>
+        <p className="text-sm font-bold text-slate-900">
+          Claude Code で副業を始める ─ 月 +10 万円を最短 3 ヶ月で
+        </p>
+        <p className="mt-1 text-xs text-slate-600">
+          stats47 の自動化と同じ技術スタック (Claude Code / e-Stat API / TypeScript) を、未経験から学べる
+          AI 副業講座。公務員・会社員に人気。
+        </p>
+        <TrackedAffiliateLink
+          href={url}
+          category="other"
+          label="Claude Code 副業講座 (inline)"
+          position="article-body"
+          className="mt-2 inline-flex items-center gap-1 text-xs font-bold text-purple-700 hover:underline"
+          {...(isExternal ? { target: "_blank", rel: "sponsored noopener" } : {})}
+        >
+          無料カウンセリングを予約 →
+        </TrackedAffiliateLink>
+      </div>
+    );
+  }
+
+  return (
+    <div className="rounded-xl bg-gradient-to-br from-purple-600 via-purple-500 to-blue-600 p-4 text-white shadow-md">
+      <div className="mb-1 flex items-center gap-1 text-[10px] font-bold uppercase tracking-wider text-white/80">
+        <Sparkles className="h-3 w-3" />
+        PR
+      </div>
+      <p className="text-sm font-bold leading-tight">
+        Claude Code 副業講座
+      </p>
+      <p className="mt-1 text-xs text-white/85 leading-snug">
+        AI 副業で月 +10 万円。公務員・会社員 OK。未経験から最短 3 ヶ月。
+      </p>
+      <TrackedAffiliateLink
+        href={url}
+        category="other"
+        label="Claude Code 副業講座 (sidebar)"
+        position="sidebar"
+        className="mt-3 inline-flex items-center gap-1 rounded-full bg-white px-3 py-1.5 text-[11px] font-bold text-purple-700 hover:bg-purple-50 transition-colors"
+        {...(isExternal ? { target: "_blank", rel: "sponsored noopener" } : {})}
+      >
+        無料カウンセリング →
+      </TrackedAffiliateLink>
+    </div>
+  );
+}

--- a/apps/web/src/features/ads/index.ts
+++ b/apps/web/src/features/ads/index.ts
@@ -2,6 +2,7 @@
 export { AdSenseAdWrapper } from "./components/AdSenseAdWrapper";
 export { BannerAd } from "./components/BannerAd";
 export { FurusatoNozeiCard } from "./components/FurusatoNozeiCard";
+export { TechSchoolPromoCard } from "./components/TechSchoolPromoCard";
 // AreaBannerAd は server-only 依存のため barrel export しない
 // 各ページから直接インポートすること: @/features/ads/components/AreaBannerAd
 export { TrackedAffiliateLink } from "./components/tracked-affiliate-link";

--- a/apps/web/src/features/blog/components/article-related-books.tsx
+++ b/apps/web/src/features/blog/components/article-related-books.tsx
@@ -38,7 +38,7 @@ export function ArticleRelatedBooks({ tagKeys, compact = false }: ArticleRelated
   if (books.length === 0) return null;
 
   const grid = (
-    <div className={compact ? "grid gap-3 grid-cols-1" : "grid gap-4 md:grid-cols-2"}>
+    <div className={compact ? "grid gap-2 grid-cols-2" : "grid gap-4 md:grid-cols-2"}>
       {books.map(({ category, book }) => {
         const theme = AFFILIATE_THEME[category];
         return (
@@ -48,7 +48,7 @@ export function ArticleRelatedBooks({ tagKeys, compact = false }: ArticleRelated
             category={category}
             label={book.title}
             position="related-books"
-            className={`flex gap-3 rounded-xl border ${theme.border} ${theme.bg} p-4 transition-shadow hover:shadow-md`}
+            className={`flex gap-3 rounded-xl border ${theme.border} ${theme.bg} ${compact ? "p-3" : "p-4"} transition-shadow hover:shadow-md`}
           >
             <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-white shadow-sm">
               <BookOpen size={20} className={theme.icon} />

--- a/apps/web/src/features/blog/index.ts
+++ b/apps/web/src/features/blog/index.ts
@@ -23,3 +23,4 @@ export {
   generateBlogMetadata,
   type BlogMetadataInput,
 } from "./utils/generate-blog-metadata";
+export { extractPrefecturesFromArticle } from "./utils/extract-prefectures";

--- a/apps/web/src/features/blog/utils/extract-prefectures.ts
+++ b/apps/web/src/features/blog/utils/extract-prefectures.ts
@@ -1,0 +1,145 @@
+/**
+ * 都道府県 prefCode → prefName マッピング (47 県固定)。
+ * area パッケージの `PREFECTURES` を直接 import する代わりに、
+ * 抽出対象の prefCode/prefName を本ファイル内で持つ。
+ * (ふるさと納税 widget が対応する範囲とも一致)
+ */
+const PREFECTURES_DATA: { prefCode: string; prefName: string }[] = [
+  { prefCode: "01000", prefName: "北海道" },
+  { prefCode: "02000", prefName: "青森県" },
+  { prefCode: "03000", prefName: "岩手県" },
+  { prefCode: "04000", prefName: "宮城県" },
+  { prefCode: "05000", prefName: "秋田県" },
+  { prefCode: "06000", prefName: "山形県" },
+  { prefCode: "07000", prefName: "福島県" },
+  { prefCode: "08000", prefName: "茨城県" },
+  { prefCode: "09000", prefName: "栃木県" },
+  { prefCode: "10000", prefName: "群馬県" },
+  { prefCode: "11000", prefName: "埼玉県" },
+  { prefCode: "12000", prefName: "千葉県" },
+  { prefCode: "13000", prefName: "東京都" },
+  { prefCode: "14000", prefName: "神奈川県" },
+  { prefCode: "15000", prefName: "新潟県" },
+  { prefCode: "16000", prefName: "富山県" },
+  { prefCode: "17000", prefName: "石川県" },
+  { prefCode: "18000", prefName: "福井県" },
+  { prefCode: "19000", prefName: "山梨県" },
+  { prefCode: "20000", prefName: "長野県" },
+  { prefCode: "21000", prefName: "岐阜県" },
+  { prefCode: "22000", prefName: "静岡県" },
+  { prefCode: "23000", prefName: "愛知県" },
+  { prefCode: "24000", prefName: "三重県" },
+  { prefCode: "25000", prefName: "滋賀県" },
+  { prefCode: "26000", prefName: "京都府" },
+  { prefCode: "27000", prefName: "大阪府" },
+  { prefCode: "28000", prefName: "兵庫県" },
+  { prefCode: "29000", prefName: "奈良県" },
+  { prefCode: "30000", prefName: "和歌山県" },
+  { prefCode: "31000", prefName: "鳥取県" },
+  { prefCode: "32000", prefName: "島根県" },
+  { prefCode: "33000", prefName: "岡山県" },
+  { prefCode: "34000", prefName: "広島県" },
+  { prefCode: "35000", prefName: "山口県" },
+  { prefCode: "36000", prefName: "徳島県" },
+  { prefCode: "37000", prefName: "香川県" },
+  { prefCode: "38000", prefName: "愛媛県" },
+  { prefCode: "39000", prefName: "高知県" },
+  { prefCode: "40000", prefName: "福岡県" },
+  { prefCode: "41000", prefName: "佐賀県" },
+  { prefCode: "42000", prefName: "長崎県" },
+  { prefCode: "43000", prefName: "熊本県" },
+  { prefCode: "44000", prefName: "大分県" },
+  { prefCode: "45000", prefName: "宮崎県" },
+  { prefCode: "46000", prefName: "鹿児島県" },
+  { prefCode: "47000", prefName: "沖縄県" },
+];
+
+/**
+ * 記事タイトル・タグ・本文から都道府県を抽出する。
+ *
+ * 抽出ロジック (優先度順):
+ * 1. frontmatter `prefecture: "13000"` の明示指定 (将来用)
+ * 2. tag に `tagKey: "tokyo"` 等の prefecture スラッグが含まれる場合
+ * 3. タイトル/本文中の県名出現頻度
+ *
+ * @returns prefCode 配列 (頻度順、最大 limit 件)
+ */
+export function extractPrefecturesFromArticle(params: {
+  title?: string;
+  body?: string;
+  tagKeys?: string[];
+  explicitPrefCode?: string;
+  limit?: number;
+}): string[] {
+  const { title = "", body = "", tagKeys = [], explicitPrefCode, limit = 3 } = params;
+
+  // 1. 明示指定が最優先
+  if (
+    explicitPrefCode &&
+    PREFECTURES_DATA.some((p) => p.prefCode === explicitPrefCode)
+  ) {
+    return [explicitPrefCode];
+  }
+
+  // 都道府県名 → prefCode 変換マップ (正式名・短縮形)
+  const nameToCode: Record<string, string> = {};
+  for (const p of PREFECTURES_DATA) {
+    nameToCode[p.prefName] = p.prefCode;
+    // 「東京都」→「東京」など短縮形も登録 (北海道は短縮形なし)
+    const shortName = p.prefName.replace(/(都|道|府|県)$/, "");
+    if (shortName !== p.prefName && shortName.length >= 2) {
+      nameToCode[shortName] = p.prefCode;
+    }
+  }
+
+  // 2. tagKey スラッグ → 名前マッピング
+  const slugToName: Record<string, string> = {
+    hokkaido: "北海道", aomori: "青森県", iwate: "岩手県", miyagi: "宮城県",
+    akita: "秋田県", yamagata: "山形県", fukushima: "福島県", ibaraki: "茨城県",
+    tochigi: "栃木県", gunma: "群馬県", saitama: "埼玉県", chiba: "千葉県",
+    tokyo: "東京都", kanagawa: "神奈川県", niigata: "新潟県", toyama: "富山県",
+    ishikawa: "石川県", fukui: "福井県", yamanashi: "山梨県", nagano: "長野県",
+    gifu: "岐阜県", shizuoka: "静岡県", aichi: "愛知県", mie: "三重県",
+    shiga: "滋賀県", kyoto: "京都府", osaka: "大阪府", hyogo: "兵庫県",
+    nara: "奈良県", wakayama: "和歌山県", tottori: "鳥取県", shimane: "島根県",
+    okayama: "岡山県", hiroshima: "広島県", yamaguchi: "山口県", tokushima: "徳島県",
+    kagawa: "香川県", ehime: "愛媛県", kochi: "高知県", fukuoka: "福岡県",
+    saga: "佐賀県", nagasaki: "長崎県", kumamoto: "熊本県", oita: "大分県",
+    miyazaki: "宮崎県", kagoshima: "鹿児島県", okinawa: "沖縄県",
+  };
+
+  const counts = new Map<string, number>();
+
+  // 3a. タグから抽出 (高重み)
+  for (const tag of tagKeys) {
+    const name = slugToName[tag.toLowerCase()];
+    if (name) {
+      const code = nameToCode[name];
+      if (code) counts.set(code, (counts.get(code) ?? 0) + 10);
+    }
+  }
+
+  // 3b. タイトルから抽出 (中重み) — フルネーム優先で重複カウント回避
+  for (const p of PREFECTURES_DATA) {
+    const idx = title.indexOf(p.prefName);
+    if (idx !== -1) {
+      counts.set(p.prefCode, (counts.get(p.prefCode) ?? 0) + 5);
+    }
+  }
+
+  // 3c. 本文から抽出 (低重み・出現回数で加点、短縮形も拾うが重複カウントしない)
+  if (body) {
+    for (const p of PREFECTURES_DATA) {
+      const fullMatches = body.match(new RegExp(p.prefName, "g"));
+      if (fullMatches) {
+        counts.set(p.prefCode, (counts.get(p.prefCode) ?? 0) + fullMatches.length);
+      }
+    }
+  }
+
+  // スコア降順、同点なら prefCode 昇順
+  return [...counts.entries()]
+    .sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0]))
+    .slice(0, limit)
+    .map(([code]) => code);
+}

--- a/apps/web/src/features/ranking/components/DataDownloadButton.tsx
+++ b/apps/web/src/features/ranking/components/DataDownloadButton.tsx
@@ -1,13 +1,12 @@
 "use client";
 
-import { useState } from "react";
-
 import { Button } from "@stats47/components/atoms/ui/button";
-import { Card, CardContent } from "@stats47/components/atoms/ui/card";
 import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@stats47/components/atoms/ui/dropdown-menu";
 import {
@@ -16,16 +15,11 @@ import {
   TooltipProvider,
   TooltipTrigger,
 } from "@stats47/components/atoms/ui/tooltip";
-import { isOk } from "@stats47/types";
-import { Download, Loader2 } from "lucide-react";
+import { Download } from "lucide-react";
 
 import type { AreaType } from "@/features/area";
 
 import { trackCsvDownload } from "@/lib/analytics/events";
-
-import { fetchAllYearsRankingValuesAction } from "../actions";
-
-import type { RankingValue } from "@stats47/ranking";
 
 interface DataDownloadButtonProps {
   rankingKey: string;
@@ -38,123 +32,39 @@ interface DataDownloadButtonProps {
   };
   /**
    * 現在表示中の正規化タイプ (per_population / per_area / per_household)。
-   * 指定された場合、その基準で計算済みの値を出力する (例: 「人口10万人あたり」の全年度値)。
-   * 未指定なら総数を出力。
+   * 指定された場合、その基準で計算済みの値をダウンロードする。
+   * 未指定なら総数 (basis=original)。
    */
   normalizationType?: string;
+  /**
+   * 「全基準まとめて」オプションを Dropdown に追加するか。
+   * true の場合、対象 metric が normalizationOptions を 1 つ以上持つことが前提。
+   */
+  hasAllBases?: boolean;
 }
 
-function sanitizeFileName(name: string): string {
-  return name.replace(/[/\\:*?"<>|]/g, "_");
-}
-
-function buildFileName(
-  displayInfo: DataDownloadButtonProps["displayInfo"],
-  ext: string,
+function buildHref(
+  rankingKey: string,
+  basis: string,
+  format: "csv" | "json",
+  encoding: "utf8" | "sjis" = "utf8",
 ): string {
-  const parts = [
-    displayInfo.title,
-    displayInfo.subtitle,
-    displayInfo.demographicAttr,
-    displayInfo.normalizationBasis,
-  ].filter(Boolean);
-  return sanitizeFileName(parts.join("_")) + `.${ext}`;
-}
-
-function generateCsvContent(rankingValues: RankingValue[]): string {
-  const BOM = "\uFEFF";
-
-  const yearsMap = new Map<string, string>();
-  for (const v of rankingValues) {
-    yearsMap.set(v.yearCode, v.yearName);
-  }
-  const yearCodes = [...yearsMap.keys()].sort((a, b) => a.localeCompare(b));
-
-  const areaMap = new Map<
-    string,
-    { areaCode: string; areaName: string; values: Map<string, number> }
-  >();
-  for (const v of rankingValues) {
-    let entry = areaMap.get(v.areaCode);
-    if (!entry) {
-      entry = {
-        areaCode: v.areaCode,
-        areaName: v.areaName,
-        values: new Map(),
-      };
-      areaMap.set(v.areaCode, entry);
-    }
-    if (v.value !== null) entry.values.set(v.yearCode, v.value);
-  }
-
-  const escapeCsv = (val: string | number): string => {
-    const s = String(val);
-    if (s.includes(",") || s.includes('"') || s.includes("\n")) {
-      return `"${s.replace(/"/g, '""')}"`;
-    }
-    return s;
-  };
-
-  const header = [
-    "都道府県コード",
-    "都道府県名",
-    ...yearCodes.map((yc) => yearsMap.get(yc)!),
-  ].map(escapeCsv).join(",");
-
-  const areas = [...areaMap.values()].sort((a, b) =>
-    a.areaCode.localeCompare(b.areaCode),
-  );
-  const rows = areas.map((area) => {
-    const yearValues = yearCodes.map((yc) => area.values.get(yc) ?? "");
-    return [area.areaCode, area.areaName, ...yearValues].map(escapeCsv).join(",");
-  });
-
-  return BOM + [header, ...rows].join("\n");
-}
-
-function triggerDownload(blob: Blob, fileName: string) {
-  const url = URL.createObjectURL(blob);
-  const a = document.createElement("a");
-  a.href = url;
-  a.download = fileName;
-  a.click();
-  URL.revokeObjectURL(url);
+  const sp = new URLSearchParams({ format, basis });
+  if (format === "csv" && encoding === "sjis") sp.set("encoding", "sjis");
+  return `/api/ranking/${encodeURIComponent(rankingKey)}/download?${sp.toString()}`;
 }
 
 /**
  * アイコンのみのダウンロードボタン（地図・テーブルの右上に配置）
+ *
+ * R2 に事前生成済みの CSV/JSON を Route Handler 経由で stream するため、
+ * クライアントでの CSV 組み立ては不要。Cloudflare CDN cache 対応。
  */
 export function DataDownloadIconButton({
   rankingKey,
-  areaType,
-  displayInfo,
   normalizationType,
 }: DataDownloadButtonProps) {
-  const [isLoading, setIsLoading] = useState(false);
-
-  const handleDownload = async (format: "csv" | "json") => {
-    setIsLoading(true);
-    try {
-      const result = await fetchAllYearsRankingValuesAction(
-        rankingKey,
-        areaType,
-        undefined,
-        normalizationType,
-      );
-      if (!isOk(result) || result.data.length === 0) return;
-      trackCsvDownload({ rankingKey, yearCode: "all" });
-      const fileName = buildFileName(displayInfo, format);
-      if (format === "csv") {
-        const csv = generateCsvContent(result.data);
-        triggerDownload(new Blob([csv], { type: "text/csv;charset=utf-8" }), fileName);
-      } else {
-        const json = JSON.stringify(result.data, null, 2);
-        triggerDownload(new Blob([json], { type: "application/json;charset=utf-8" }), fileName);
-      }
-    } finally {
-      setIsLoading(false);
-    }
-  };
+  const basis = normalizationType ?? "original";
 
   return (
     <TooltipProvider>
@@ -165,24 +75,29 @@ export function DataDownloadIconButton({
               <Button
                 variant="ghost"
                 size="icon"
-                disabled={isLoading}
                 className="h-8 w-8 text-muted-foreground hover:text-foreground"
               >
-                {isLoading ? (
-                  <Loader2 className="h-4 w-4 animate-spin" />
-                ) : (
-                  <Download className="h-4 w-4" />
-                )}
+                <Download className="h-4 w-4" />
                 <span className="sr-only">データダウンロード</span>
               </Button>
             </DropdownMenuTrigger>
           </TooltipTrigger>
           <DropdownMenuContent align="end">
-            <DropdownMenuItem onClick={() => handleDownload("csv")}>
-              CSV 形式
+            <DropdownMenuItem asChild>
+              <a
+                href={buildHref(rankingKey, basis, "csv", "utf8")}
+                onClick={() => trackCsvDownload({ rankingKey, yearCode: "all" })}
+              >
+                CSV 形式
+              </a>
             </DropdownMenuItem>
-            <DropdownMenuItem onClick={() => handleDownload("json")}>
-              JSON 形式
+            <DropdownMenuItem asChild>
+              <a
+                href={buildHref(rankingKey, basis, "json")}
+                onClick={() => trackCsvDownload({ rankingKey, yearCode: "all" })}
+              >
+                JSON 形式
+              </a>
             </DropdownMenuItem>
           </DropdownMenuContent>
         </DropdownMenu>
@@ -193,243 +108,70 @@ export function DataDownloadIconButton({
 }
 
 /**
- * ラベル付き CSV ダウンロード primary ボタン（ヒーローカード・訴求カード用）
- *
- * 全年度の CSV を生成してダウンロードする。JSON/Excel は提供しない。
- */
-export function DataDownloadPrimaryButton({
-  rankingKey,
-  areaType,
-  displayInfo,
-  normalizationType,
-  label = "CSV をダウンロード",
-  variant = "default",
-}: DataDownloadButtonProps & {
-  /** ボタンラベル */
-  label?: string;
-  /** ボタンの見た目（default = primary） */
-  variant?: "default" | "outline";
-}) {
-  const [isLoading, setIsLoading] = useState(false);
-
-  const handleDownload = async () => {
-    setIsLoading(true);
-    try {
-      const result = await fetchAllYearsRankingValuesAction(
-        rankingKey,
-        areaType,
-        undefined,
-        normalizationType,
-      );
-      if (!isOk(result) || result.data.length === 0) return;
-      trackCsvDownload({ rankingKey, yearCode: "all" });
-      const fileName = buildFileName(displayInfo, "csv");
-      const csv = generateCsvContent(result.data);
-      triggerDownload(new Blob([csv], { type: "text/csv;charset=utf-8" }), fileName);
-    } finally {
-      setIsLoading(false);
-    }
-  };
-
-  return (
-    <Button
-      variant={variant}
-      size="sm"
-      disabled={isLoading}
-      onClick={handleDownload}
-      className="gap-1.5"
-    >
-      {isLoading ? (
-        <Loader2 className="h-4 w-4 animate-spin" />
-      ) : (
-        <Download className="h-4 w-4" />
-      )}
-      {label}
-    </Button>
-  );
-}
-
-/**
  * ラベル付き CSV/JSON ダウンロード menu ボタン（DataUsageCard 用）
  *
- * 「データダウンロード」と表示し、Dropdown で CSV / JSON を選択させる。
- * normalizationType が指定されていればその基準で計算済みの値を出力。
+ * Dropdown で CSV (UTF-8) / CSV (Shift_JIS) / JSON / 全基準まとめて の中から
+ * 選択させる。R2 事前生成ファイルを Route Handler 経由で stream。
  */
 export function DataDownloadMenuButton({
   rankingKey,
-  areaType,
-  displayInfo,
   normalizationType,
+  hasAllBases,
   label = "ダウンロード",
   variant = "default",
 }: DataDownloadButtonProps & {
   label?: string;
   variant?: "default" | "outline";
 }) {
-  const [isLoading, setIsLoading] = useState(false);
-
-  const handleDownload = async (format: "csv" | "json") => {
-    setIsLoading(true);
-    try {
-      const result = await fetchAllYearsRankingValuesAction(
-        rankingKey,
-        areaType,
-        undefined,
-        normalizationType,
-      );
-      if (!isOk(result) || result.data.length === 0) return;
-      trackCsvDownload({ rankingKey, yearCode: "all" });
-      const fileName = buildFileName(displayInfo, format);
-      if (format === "csv") {
-        const csv = generateCsvContent(result.data);
-        triggerDownload(new Blob([csv], { type: "text/csv;charset=utf-8" }), fileName);
-      } else {
-        const json = JSON.stringify(result.data, null, 2);
-        triggerDownload(
-          new Blob([json], { type: "application/json;charset=utf-8" }),
-          fileName,
-        );
-      }
-    } finally {
-      setIsLoading(false);
-    }
-  };
+  const basis = normalizationType ?? "original";
+  const track = () => trackCsvDownload({ rankingKey, yearCode: "all" });
 
   return (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
-        <Button variant={variant} size="sm" disabled={isLoading} className="gap-1.5">
-          {isLoading ? (
-            <Loader2 className="h-4 w-4 animate-spin" />
-          ) : (
-            <Download className="h-4 w-4" />
-          )}
+        <Button variant={variant} size="sm" className="gap-1.5">
+          <Download className="h-4 w-4" />
           {label}
         </Button>
       </DropdownMenuTrigger>
-      <DropdownMenuContent align="end">
-        <DropdownMenuItem onClick={() => handleDownload("csv")}>
-          CSV 形式 (Excel 互換)
+      <DropdownMenuContent align="end" className="min-w-[220px]">
+        <DropdownMenuLabel className="text-xs text-muted-foreground">
+          現在の基準でダウンロード
+        </DropdownMenuLabel>
+        <DropdownMenuItem asChild>
+          <a href={buildHref(rankingKey, basis, "csv", "utf8")} onClick={track}>
+            CSV (Excel 互換 / UTF-8)
+          </a>
         </DropdownMenuItem>
-        <DropdownMenuItem onClick={() => handleDownload("json")}>
-          JSON 形式 (開発者向け)
+        <DropdownMenuItem asChild>
+          <a href={buildHref(rankingKey, basis, "csv", "sjis")} onClick={track}>
+            CSV (古い Excel / Shift_JIS)
+          </a>
         </DropdownMenuItem>
+        <DropdownMenuItem asChild>
+          <a href={buildHref(rankingKey, basis, "json")} onClick={track}>
+            JSON (開発者向け)
+          </a>
+        </DropdownMenuItem>
+        {hasAllBases && (
+          <>
+            <DropdownMenuSeparator />
+            <DropdownMenuLabel className="text-xs text-muted-foreground">
+              全基準を 1 ファイルに
+            </DropdownMenuLabel>
+            <DropdownMenuItem asChild>
+              <a href={buildHref(rankingKey, "all-bases", "csv", "utf8")} onClick={track}>
+                全基準まとめて CSV (UTF-8)
+              </a>
+            </DropdownMenuItem>
+            <DropdownMenuItem asChild>
+              <a href={buildHref(rankingKey, "all-bases", "csv", "sjis")} onClick={track}>
+                全基準まとめて CSV (Shift_JIS)
+              </a>
+            </DropdownMenuItem>
+          </>
+        )}
       </DropdownMenuContent>
     </DropdownMenu>
-  );
-}
-
-interface DataDownloadFooterCardProps extends DataDownloadButtonProps {
-  /** プレビュー用のランキングデータ（上位表示用） */
-  rankingValues: RankingValue[];
-}
-
-/**
- * 末尾配置用のダウンロードカード（ミニプレビュー付き）
- */
-export function DataDownloadFooterCard({
-  rankingKey,
-  areaType,
-  displayInfo,
-  normalizationType,
-  rankingValues,
-}: DataDownloadFooterCardProps) {
-  const [isLoading, setIsLoading] = useState(false);
-
-  const handleDownload = async (format: "csv" | "json") => {
-    setIsLoading(true);
-    try {
-      const result = await fetchAllYearsRankingValuesAction(
-        rankingKey,
-        areaType,
-        undefined,
-        normalizationType,
-      );
-      if (!isOk(result) || result.data.length === 0) return;
-      trackCsvDownload({ rankingKey, yearCode: "all" });
-      const fileName = buildFileName(displayInfo, format);
-      if (format === "csv") {
-        const csv = generateCsvContent(result.data);
-        triggerDownload(new Blob([csv], { type: "text/csv;charset=utf-8" }), fileName);
-      } else {
-        const json = JSON.stringify(result.data, null, 2);
-        triggerDownload(new Blob([json], { type: "application/json;charset=utf-8" }), fileName);
-      }
-    } finally {
-      setIsLoading(false);
-    }
-  };
-
-  // 上位5件をプレビュー表示
-  const sorted = [...rankingValues]
-    .filter((v) => v.areaCode !== "00000")
-    .sort((a, b) => (b.value ?? 0) - (a.value ?? 0));
-  const preview = sorted.slice(0, 5);
-  const remaining = sorted.length - 5;
-  const unit = displayInfo.normalizationBasis
-    ? ""
-    : rankingValues[0]?.unit || "";
-
-  return (
-    <Card>
-      <CardContent className="p-0">
-        {/* ミニプレビューテーブル */}
-        <div className="px-4 pt-4 pb-2">
-          <div className="rounded-md border border-border overflow-hidden">
-            <table className="w-full text-sm">
-              <thead>
-                <tr className="bg-muted/50">
-                  <th className="text-left py-1.5 px-3 font-medium text-muted-foreground w-10">#</th>
-                  <th className="text-left py-1.5 px-3 font-medium text-muted-foreground">都道府県</th>
-                  <th className="text-right py-1.5 px-3 font-medium text-muted-foreground">値</th>
-                </tr>
-              </thead>
-              <tbody>
-                {preview.map((v, i) => (
-                  <tr key={v.areaCode} className="border-t border-border/50">
-                    <td className="py-1.5 px-3 text-muted-foreground">{i + 1}</td>
-                    <td className="py-1.5 px-3">{v.areaName}</td>
-                    <td className="py-1.5 px-3 text-right font-mono tabular-nums">
-                      {(v.value ?? 0).toLocaleString("ja-JP")}
-                      {unit && <span className="text-xs text-muted-foreground ml-1">{unit}</span>}
-                    </td>
-                  </tr>
-                ))}
-              </tbody>
-            </table>
-            {remaining > 0 && (
-              <div className="text-center py-1.5 text-xs text-muted-foreground border-t border-border/50 bg-muted/30">
-                ⋮ 残り{remaining}都道府県
-              </div>
-            )}
-          </div>
-        </div>
-
-        {/* ダウンロードボタン */}
-        <div className="flex items-center justify-between px-4 py-3 border-t border-border/50">
-          <span className="text-sm text-muted-foreground">全データをダウンロード</span>
-          <DropdownMenu>
-            <DropdownMenuTrigger asChild>
-              <Button variant="outline" size="sm" disabled={isLoading} className="gap-2">
-                {isLoading ? (
-                  <Loader2 className="h-4 w-4 animate-spin" />
-                ) : (
-                  <Download className="h-4 w-4" />
-                )}
-                ダウンロード
-              </Button>
-            </DropdownMenuTrigger>
-            <DropdownMenuContent align="end">
-              <DropdownMenuItem onClick={() => handleDownload("csv")}>
-                CSV 形式
-              </DropdownMenuItem>
-              <DropdownMenuItem onClick={() => handleDownload("json")}>
-                JSON 形式
-              </DropdownMenuItem>
-            </DropdownMenuContent>
-          </DropdownMenu>
-        </div>
-      </CardContent>
-    </Card>
   );
 }

--- a/apps/web/src/features/ranking/components/DataUsageCard/DataUsageCard.tsx
+++ b/apps/web/src/features/ranking/components/DataUsageCard/DataUsageCard.tsx
@@ -26,6 +26,9 @@ interface DataUsageCardProps {
   yearCount?: number;
   /** 現在表示中の正規化タイプ (pill で選択中の per_population など) */
   normalizationType?: string;
+  /** 「全基準まとめて」CSV オプションを Dropdown に追加するか
+   *  (対象 metric に normalizationOptions が 1 件以上ある場合 true) */
+  hasAllBases?: boolean;
 }
 
 export function DataUsageCard({
@@ -34,6 +37,7 @@ export function DataUsageCard({
   displayInfo,
   yearCount,
   normalizationType,
+  hasAllBases,
 }: DataUsageCardProps) {
   const yearText = yearCount && yearCount > 0 ? `${yearCount}年分の時系列を含む` : "";
   const basisText = displayInfo.normalizationBasis
@@ -57,6 +61,7 @@ export function DataUsageCard({
         areaType={areaType}
         displayInfo={displayInfo}
         normalizationType={normalizationType}
+        hasAllBases={hasAllBases}
         label="ダウンロード"
       />
     </div>

--- a/apps/web/src/features/ranking/components/RankingKeyPage/RankingKeyPageClient.tsx
+++ b/apps/web/src/features/ranking/components/RankingKeyPage/RankingKeyPageClient.tsx
@@ -497,13 +497,16 @@ export function RankingKeyPageClient({
                         </div>
                     )}
 
-                    {/* データダウンロード訴求カード「このデータを使う」 (CSV/JSON、正規化基準対応) */}
+                    {/* データダウンロード訴求カード「このデータを使う」
+                        (R2 事前生成済みファイルを Route Handler 経由で stream。
+                         CSV (UTF-8 / Shift_JIS) / JSON / 全基準まとめて に対応) */}
                     <DataUsageCard
                         rankingKey={rankingKey}
                         areaType={currentAreaType}
                         displayInfo={displayInfo}
                         yearCount={activeRankingItem.availableYears?.length}
                         normalizationType={normalizationType}
+                        hasAllBases={(rankingItem.calculation?.normalizationOptions?.length ?? 0) > 0}
                     />
 
                     {/* データの考察（常時表示カード） — 本来テーブル直下で読まれるべき主要コンテンツ */}

--- a/apps/web/src/features/ranking/index.ts
+++ b/apps/web/src/features/ranking/index.ts
@@ -65,7 +65,10 @@ export * from "./utils";
 // Additional client components
 export { AreaTypeToggle } from "./components/AreaTypeToggle";
 export { NormalizationToggle } from "./components/NormalizationToggle";
-export { DataDownloadIconButton, DataDownloadFooterCard, DataDownloadPrimaryButton } from "./components/DataDownloadButton";
+export {
+  DataDownloadIconButton,
+  DataDownloadMenuButton,
+} from "./components/DataDownloadButton";
 
 // Skeleton components
 export { CorrelationSectionSkeleton } from "./components/CorrelationSection/CorrelationSectionSkeleton";

--- a/apps/web/src/features/redesign/components/DataPackCTA.tsx
+++ b/apps/web/src/features/redesign/components/DataPackCTA.tsx
@@ -21,7 +21,7 @@ interface DataPackCTAProps {
  * D-System データパック訴求カード
  *
  * CSV ダウンロードボタンを active、JSON/Excel は disabled で「準備中」表示。
- * `csvButton` は呼び出し側で `DataDownloadPrimaryButton` 等を注入する。
+ * `csvButton` は呼び出し側で `DataDownloadMenuButton` 等を注入する。
  */
 export function DataPackCTA({
   title,

--- a/package-lock.json
+++ b/package-lock.json
@@ -30305,7 +30305,8 @@
         "@stats47/utils": "*",
         "@stats47/visualization": "*",
         "csv-parse": "^6.1.0",
-        "drizzle-orm": "^0.45.1"
+        "drizzle-orm": "^0.45.1",
+        "iconv-lite": "^0.6"
       },
       "devDependencies": {
         "typescript": "^5.0.0",

--- a/packages/ranking/package.json
+++ b/packages/ranking/package.json
@@ -43,7 +43,8 @@
     "@stats47/utils": "*",
     "@stats47/visualization": "*",
     "csv-parse": "^6.1.0",
-    "drizzle-orm": "^0.45.1"
+    "drizzle-orm": "^0.45.1",
+    "iconv-lite": "^0.6"
   },
   "devDependencies": {
     "typescript": "^5.0.0",

--- a/packages/ranking/src/exporters/index.ts
+++ b/packages/ranking/src/exporters/index.ts
@@ -1,4 +1,8 @@
 export {
+  type ExportRankingDownloadSnapshotsResult,
+  exportRankingDownloadSnapshots,
+} from "./ranking-download-snapshots";
+export {
   type ExportRankingItemsSnapshotResult,
   exportRankingItemsSnapshot,
 } from "./ranking-items-snapshot";

--- a/packages/ranking/src/exporters/ranking-download-snapshots.ts
+++ b/packages/ranking/src/exporters/ranking-download-snapshots.ts
@@ -1,0 +1,277 @@
+import "server-only";
+
+import { getDrizzle, metrics, statsPrefecture } from "@stats47/database/server";
+import { logger } from "@stats47/logger/server";
+import { saveToR2 } from "@stats47/r2-storage/server";
+import { eq } from "drizzle-orm";
+import iconv from "iconv-lite";
+
+import { WELL_KNOWN_DENOMINATORS } from "../services/compute-normalization";
+import type { RankingValue } from "../types";
+import { rankingDownloadKeyPath } from "../types/snapshot";
+import { buildAllBasesCsv, buildSingleSeriesCsv } from "../utils/build-download-csv";
+import { computeCalculatedValues } from "../utils/compute-calculated-values";
+import { rankByValue } from "../utils/rank-by-value";
+
+interface NormOption {
+  type: string;
+  label: string;
+  unit: string;
+  scaleFactor?: number;
+  denominatorKey?: string;
+}
+
+interface CalcConfig {
+  normalizationOptions?: NormOption[];
+}
+
+export interface ExportRankingDownloadSnapshotsResult {
+  metrics: number;
+  files: number;
+  totalSizeBytes: number;
+  durationMs: number;
+}
+
+function parseCalc(json: string | null): CalcConfig {
+  if (!json) return {};
+  try {
+    return JSON.parse(json) as CalcConfig;
+  } catch {
+    return {};
+  }
+}
+
+async function loadValues(
+  db: ReturnType<typeof getDrizzle>,
+  metricKey: string,
+): Promise<RankingValue[]> {
+  const rows = await db
+    .select()
+    .from(statsPrefecture)
+    .where(eq(statsPrefecture.metricKey, metricKey));
+
+  return rows.map((row) => ({
+    areaType: "prefecture",
+    areaCode: row.areaCode ?? "",
+    areaName: row.areaName ?? "",
+    yearCode: String(row.yearCode ?? "").slice(0, 4),
+    yearName: row.yearName ?? "",
+    metricKey,
+    value: row.value != null ? Number(row.value) : 0,
+    unit: row.unit ?? "",
+    rank: row.rank != null ? Number(row.rank) : 0,
+  }));
+}
+
+function computeNormalizedSeries(
+  numerator: RankingValue[],
+  denominator: RankingValue[],
+  option: NormOption,
+  metricKey: string,
+): RankingValue[] {
+  // 年度ごとに分子・分母をペアリングして計算
+  const numByYear = new Map<string, RankingValue[]>();
+  for (const v of numerator) {
+    const arr = numByYear.get(v.yearCode) ?? [];
+    arr.push(v);
+    numByYear.set(v.yearCode, arr);
+  }
+  const denByYear = new Map<string, RankingValue[]>();
+  for (const v of denominator) {
+    const arr = denByYear.get(v.yearCode) ?? [];
+    arr.push(v);
+    denByYear.set(v.yearCode, arr);
+  }
+  const denYearsSorted = [...denByYear.keys()].sort();
+  const denLatestYear = denYearsSorted[denYearsSorted.length - 1] ?? "";
+
+  const out: RankingValue[] = [];
+  for (const [yearCode, numValues] of numByYear) {
+    const denValues = denByYear.get(yearCode) ?? denByYear.get(denLatestYear);
+    if (!denValues) continue;
+    const computed = computeCalculatedValues(numValues, denValues, {
+      type: "ratio",
+      metricKey,
+      unit: option.unit,
+      keyBy: "areaCode",
+      scaleFactor: option.scaleFactor ?? 1,
+    });
+    const ranked = rankByValue(computed) as RankingValue[];
+    out.push(...ranked);
+  }
+  return out;
+}
+
+async function processMetric(
+  db: ReturnType<typeof getDrizzle>,
+  metricKey: string,
+  calc: CalcConfig,
+  dryRun: boolean,
+): Promise<{ files: number; sizeBytes: number }> {
+  const original = await loadValues(db, metricKey);
+  if (original.length === 0) return { files: 0, sizeBytes: 0 };
+
+  const seriesList: { basisKey: string; basisLabel: string; values: RankingValue[] }[] =
+    [{ basisKey: "original", basisLabel: "総数", values: original }];
+
+  // 正規化系列を計算
+  const options = calc.normalizationOptions ?? [];
+  for (const option of options) {
+    const denominatorKey =
+      option.denominatorKey ?? WELL_KNOWN_DENOMINATORS[option.type]?.prefecture;
+    if (!denominatorKey) continue;
+    const denominator = await loadValues(db, denominatorKey);
+    if (denominator.length === 0) continue;
+    const normValues = computeNormalizedSeries(original, denominator, option, metricKey);
+    if (normValues.length === 0) continue;
+    seriesList.push({
+      basisKey: option.type,
+      basisLabel: option.label,
+      values: normValues,
+    });
+  }
+
+  let files = 0;
+  let sizeBytes = 0;
+
+  // 各 basis × {csv-utf8, csv-sjis, json}
+  for (const series of seriesList) {
+    const csvUtf8 = buildSingleSeriesCsv(series.values);
+    const jsonStr = JSON.stringify(series.values, null, 2);
+
+    const csvPath = rankingDownloadKeyPath(metricKey, series.basisKey, "csv", "utf8");
+    const csvSjisPath = rankingDownloadKeyPath(metricKey, series.basisKey, "csv", "sjis");
+    const jsonPath = rankingDownloadKeyPath(metricKey, series.basisKey, "json", "utf8");
+
+    const csvBytes = Buffer.from(csvUtf8, "utf8");
+    const csvSjisBytes = iconv.encode(csvUtf8, "Shift_JIS");
+    const jsonBytes = Buffer.from(jsonStr, "utf8");
+
+    if (!dryRun) {
+      await Promise.all([
+        saveToR2(csvPath, csvBytes, { contentType: "text/csv; charset=utf-8" }),
+        saveToR2(csvSjisPath, csvSjisBytes, { contentType: "text/csv; charset=Shift_JIS" }),
+        saveToR2(jsonPath, jsonBytes, { contentType: "application/json; charset=utf-8" }),
+      ]);
+    }
+
+    files += 3;
+    sizeBytes += csvBytes.byteLength + csvSjisBytes.byteLength + jsonBytes.byteLength;
+  }
+
+  // 全基準まとめて (2 つ以上ある場合のみ)
+  if (seriesList.length > 1) {
+    const allCsv = buildAllBasesCsv(seriesList);
+    const allCsvBytes = Buffer.from(allCsv, "utf8");
+    const allCsvSjisBytes = iconv.encode(allCsv, "Shift_JIS");
+    const allCsvPath = rankingDownloadKeyPath(metricKey, "all-bases", "csv", "utf8");
+    const allCsvSjisPath = rankingDownloadKeyPath(metricKey, "all-bases", "csv", "sjis");
+
+    if (!dryRun) {
+      await Promise.all([
+        saveToR2(allCsvPath, allCsvBytes, { contentType: "text/csv; charset=utf-8" }),
+        saveToR2(allCsvSjisPath, allCsvSjisBytes, {
+          contentType: "text/csv; charset=Shift_JIS",
+        }),
+      ]);
+    }
+
+    files += 2;
+    sizeBytes += allCsvBytes.byteLength + allCsvSjisBytes.byteLength;
+  }
+
+  return { files, sizeBytes };
+}
+
+/**
+ * 全 metric について、ダウンロード用 CSV (UTF-8+BOM, Shift_JIS) と JSON を事前生成して R2 に保存する。
+ *
+ * 生成ファイル (basis 数 × フォーマット):
+ *   app/ranking/{key}/downloads/values.csv          (総数 UTF-8)
+ *   app/ranking/{key}/downloads/values.sjis.csv     (総数 Shift_JIS)
+ *   app/ranking/{key}/downloads/values.json
+ *   app/ranking/{key}/downloads/values-per-population.csv
+ *   app/ranking/{key}/downloads/values-per-population.sjis.csv
+ *   app/ranking/{key}/downloads/values-per-population.json
+ *   ... (per_area, per_household も同様)
+ *   app/ranking/{key}/downloads/values-all-bases.csv      (全基準横並び、2 以上の場合のみ)
+ *   app/ranking/{key}/downloads/values-all-bases.sjis.csv
+ *
+ * Route Handler `/api/ranking/[key]/download` から直接 stream される前提。
+ * クライアント側でのオンデマンド CSV 生成は不要になる。
+ */
+export async function exportRankingDownloadSnapshots(
+  options: {
+    db?: ReturnType<typeof getDrizzle>;
+    parallelism?: number;
+    rankingKeyFilter?: string;
+    dryRun?: boolean;
+  } = {},
+): Promise<ExportRankingDownloadSnapshotsResult> {
+  const startedAt = Date.now();
+  const db = options.db ?? getDrizzle();
+  const parallelism = options.parallelism ?? 4;
+  const dryRun = options.dryRun ?? false;
+
+  const rows = options.rankingKeyFilter
+    ? await db
+        .select({ key: metrics.key, calcJson: metrics.calculationConfigJson })
+        .from(metrics)
+        .where(eq(metrics.key, options.rankingKeyFilter))
+    : await db
+        .select({ key: metrics.key, calcJson: metrics.calculationConfigJson })
+        .from(metrics);
+
+  logger.info(
+    { metricCount: rows.length, dryRun, parallelism },
+    "ranking-download export を開始…",
+  );
+
+  let totalFiles = 0;
+  let totalSizeBytes = 0;
+  let processedMetrics = 0;
+
+  for (let i = 0; i < rows.length; i += parallelism) {
+    const batch = rows.slice(i, i + parallelism);
+    const results = await Promise.all(
+      batch.map(async ({ key, calcJson }) => {
+        try {
+          const calc = parseCalc(calcJson ?? null);
+          return await processMetric(db, key, calc, dryRun);
+        } catch (err) {
+          logger.error(
+            { metricKey: key, error: err instanceof Error ? err.message : String(err) },
+            "ranking-download: metric 処理失敗。スキップ",
+          );
+          return { files: 0, sizeBytes: 0 };
+        }
+      }),
+    );
+
+    for (const r of results) {
+      totalFiles += r.files;
+      totalSizeBytes += r.sizeBytes;
+      if (r.files > 0) processedMetrics++;
+    }
+
+    if ((i + batch.length) % 100 === 0 || i + batch.length >= rows.length) {
+      logger.info(
+        {
+          processed: i + batch.length,
+          total: rows.length,
+          files: totalFiles,
+          mb: (totalSizeBytes / 1024 / 1024).toFixed(2),
+        },
+        "ranking-download 進捗",
+      );
+    }
+  }
+
+  const durationMs = Date.now() - startedAt;
+  logger.info(
+    { metrics: processedMetrics, files: totalFiles, totalSizeBytes, durationMs, dryRun },
+    "ranking-download snapshot を R2 に保存しました",
+  );
+
+  return { metrics: processedMetrics, files: totalFiles, totalSizeBytes, durationMs };
+}

--- a/packages/ranking/src/scripts/export-ranking-download-snapshots.ts
+++ b/packages/ranking/src/scripts/export-ranking-download-snapshots.ts
@@ -1,0 +1,39 @@
+#!/usr/bin/env tsx
+/**
+ * ranking_values の事前生成済みダウンロードファイル (CSV UTF-8 / Shift_JIS / JSON)
+ * を R2 に書き出す。Route Handler `/api/ranking/[key]/download` から直接 stream される。
+ *
+ * Usage:
+ *   npx tsx -r ./packages/ranking/src/scripts/setup-cli.js \
+ *     packages/ranking/src/scripts/export-ranking-download-snapshots.ts
+ *
+ * Options (環境変数):
+ *   PARALLELISM=8                 # 並列書き込み数 (default 4)
+ *   RANKING_KEY_FILTER=foo-bar    # 特定 ranking_key だけ更新したい場合
+ *   DRY_RUN=1                     # R2 に書き込まず件数のみ確認
+ */
+
+import { exportRankingDownloadSnapshots } from "../exporters/ranking-download-snapshots";
+
+async function main() {
+  const parallelism = process.env.PARALLELISM
+    ? Number(process.env.PARALLELISM)
+    : undefined;
+  const rankingKeyFilter = process.env.RANKING_KEY_FILTER || undefined;
+  const dryRun = process.env.DRY_RUN === "1";
+
+  console.log("ranking_download snapshot を R2 に書き出します…");
+  const result = await exportRankingDownloadSnapshots({
+    parallelism,
+    rankingKeyFilter,
+    dryRun,
+  });
+  console.log(
+    `✅ ranking_download: metrics=${result.metrics} files=${result.files} mb=${(result.totalSizeBytes / 1024 / 1024).toFixed(2)} duration=${result.durationMs}ms${dryRun ? " (dry-run)" : ""}`,
+  );
+}
+
+main().catch((err) => {
+  console.error("ranking_download export 失敗:", err);
+  process.exit(1);
+});

--- a/packages/ranking/src/types/index.ts
+++ b/packages/ranking/src/types/index.ts
@@ -4,5 +4,10 @@ export * from "./ranking-item";
 export * from "./ranking-item-with-tags";
 export * from "./ranking-stats";
 export * from "./ranking-value";
+export {
+  rankingDownloadKeyPath,
+  rankingNormalizedValuesKeyPath,
+  rankingValuesKeyPath,
+} from "./snapshot";
 export * from "./sync-ranking-result";
 

--- a/packages/ranking/src/types/snapshot.ts
+++ b/packages/ranking/src/types/snapshot.ts
@@ -70,6 +70,29 @@ export function rankingNormalizedValuesKeyPath(
   return `app/ranking/${encodeURIComponent(rankingKey)}/values-${suffix}.json`;
 }
 
+/**
+ * 事前生成済みダウンロードファイルの R2 キーパスを返す。
+ *
+ * basis = "original" or 正規化タイプ ("per_population" 等) or "all-bases"
+ * format = "csv" or "json"
+ * encoding = "utf8" (BOM 付き) or "sjis" (Shift_JIS、CSV 専用)
+ *
+ * 例: `app/ranking/{key}/downloads/values.csv` (basis=original, format=csv, encoding=utf8)
+ *     `app/ranking/{key}/downloads/values-per-population.json`
+ *     `app/ranking/{key}/downloads/values-all-bases.csv`
+ *     `app/ranking/{key}/downloads/values.sjis.csv`
+ */
+export function rankingDownloadKeyPath(
+  rankingKey: string,
+  basis: string,
+  format: "csv" | "json",
+  encoding: "utf8" | "sjis" = "utf8",
+): string {
+  const basisSuffix = basis === "original" ? "" : `-${basis.replace(/_/g, "-")}`;
+  const encodingSuffix = encoding === "sjis" ? ".sjis" : "";
+  return `app/ranking/${encodeURIComponent(rankingKey)}/downloads/values${basisSuffix}${encodingSuffix}.${format}`;
+}
+
 /** @deprecated rankingValuesKeyPath を使用してください */
 export interface RankingValuesPartitionSnapshot {
   generatedAt: string;

--- a/packages/ranking/src/utils/build-download-csv.ts
+++ b/packages/ranking/src/utils/build-download-csv.ts
@@ -1,0 +1,135 @@
+import type { RankingValue } from "../types";
+
+/**
+ * 都道府県 × 年度の値を CSV 文字列に整形する。
+ *
+ * 単一系列フォーマット:
+ * ```
+ * 都道府県コード,都道府県名,2024年,2023年,...
+ * 01000,北海道,5183687,5224614,...
+ * ```
+ *
+ * UTF-8 + BOM 付与で Excel の文字化けを防ぐ。
+ */
+export function buildSingleSeriesCsv(values: RankingValue[]): string {
+  const BOM = "﻿";
+
+  const yearsMap = new Map<string, string>();
+  for (const v of values) yearsMap.set(v.yearCode, v.yearName);
+  const yearCodes = [...yearsMap.keys()].sort((a, b) => b.localeCompare(a));
+
+  const areaMap = new Map<
+    string,
+    { areaCode: string; areaName: string; values: Map<string, number> }
+  >();
+  for (const v of values) {
+    if (v.value === null || v.value === undefined) continue;
+    let entry = areaMap.get(v.areaCode);
+    if (!entry) {
+      entry = { areaCode: v.areaCode, areaName: v.areaName, values: new Map() };
+      areaMap.set(v.areaCode, entry);
+    }
+    entry.values.set(v.yearCode, v.value);
+  }
+
+  const header = [
+    "都道府県コード",
+    "都道府県名",
+    ...yearCodes.map((yc) => yearsMap.get(yc) ?? yc),
+  ];
+
+  const sortedAreas = [...areaMap.values()].sort((a, b) =>
+    a.areaCode.localeCompare(b.areaCode),
+  );
+
+  const rows = sortedAreas.map((area) => {
+    const yearValues = yearCodes.map((yc) => area.values.get(yc) ?? "");
+    return [area.areaCode, area.areaName, ...yearValues];
+  });
+
+  return BOM + [header, ...rows].map(toCsvLine).join("\n");
+}
+
+interface BasisSeries {
+  basisKey: string;
+  basisLabel: string;
+  values: RankingValue[];
+}
+
+/**
+ * 複数の基準 (総数 / 人口10万人あたり / 面積100km²あたり / 1世帯あたり) を
+ * 横並びにした「全基準まとめて」フォーマットの CSV を生成する。
+ *
+ * 列構成:
+ * ```
+ * 都道府県コード,都道府県名,
+ *   総数_2024年,総数_2023年,...,
+ *   人口10万人あたり_2024年,...,
+ *   面積100km²あたり_2024年,...
+ * ```
+ */
+export function buildAllBasesCsv(seriesList: BasisSeries[]): string {
+  const BOM = "﻿";
+
+  // 全系列を通じた year コード → year ラベル
+  const yearsMap = new Map<string, string>();
+  for (const series of seriesList) {
+    for (const v of series.values) yearsMap.set(v.yearCode, v.yearName);
+  }
+  const yearCodes = [...yearsMap.keys()].sort((a, b) => b.localeCompare(a));
+
+  // areaCode → { areaName, values: Map<seriesIdx + yearCode, number> }
+  const areaMap = new Map<
+    string,
+    { areaCode: string; areaName: string; values: Map<string, number> }
+  >();
+
+  seriesList.forEach((series, sIdx) => {
+    for (const v of series.values) {
+      if (v.value === null || v.value === undefined) continue;
+      let entry = areaMap.get(v.areaCode);
+      if (!entry) {
+        entry = { areaCode: v.areaCode, areaName: v.areaName, values: new Map() };
+        areaMap.set(v.areaCode, entry);
+      }
+      entry.values.set(`${sIdx}:${v.yearCode}`, v.value);
+    }
+  });
+
+  // ヘッダー: 都道府県コード, 都道府県名, 基準A_2024, 基準A_2023, ..., 基準B_2024, ...
+  const header: string[] = ["都道府県コード", "都道府県名"];
+  seriesList.forEach((series) => {
+    for (const yc of yearCodes) {
+      const yearLabel = yearsMap.get(yc) ?? yc;
+      header.push(`${series.basisLabel}_${yearLabel}`);
+    }
+  });
+
+  const sortedAreas = [...areaMap.values()].sort((a, b) =>
+    a.areaCode.localeCompare(b.areaCode),
+  );
+
+  const rows = sortedAreas.map((area) => {
+    const row: (string | number)[] = [area.areaCode, area.areaName];
+    seriesList.forEach((_, sIdx) => {
+      for (const yc of yearCodes) {
+        row.push(area.values.get(`${sIdx}:${yc}`) ?? "");
+      }
+    });
+    return row;
+  });
+
+  return BOM + [header, ...rows].map(toCsvLine).join("\n");
+}
+
+function escapeCsvCell(val: string | number): string {
+  const s = String(val);
+  if (s.includes(",") || s.includes('"') || s.includes("\n")) {
+    return `"${s.replace(/"/g, '""')}"`;
+  }
+  return s;
+}
+
+function toCsvLine(cells: (string | number)[]): string {
+  return cells.map(escapeCsvCell).join(",");
+}

--- a/packages/ranking/src/utils/index.ts
+++ b/packages/ranking/src/utils/index.ts
@@ -1,4 +1,5 @@
 export { computeAxisDomain, type AxisDomain } from "@stats47/visualization/shared";
+export * from "./build-download-csv";
 export * from "./compute-bottom-ranking";
 export * from "./compute-calculated-values";
 export * from "./compute-ranking-stats";


### PR DESCRIPTION
本 PR には **2 つの大きな変更** が含まれます (作業ブランチ統合のため):

## Part 1: ランキング CSV/JSON ダウンロード を R2 事前生成 + Route Handler 配信に切替

### 概要

ダウンロードを「Server Action でオンザフライ CSV 生成」から「R2 事前生成済みファイルを Route Handler 経由で stream」に変更。

### 追加

- `packages/ranking/src/exporters/ranking-download-snapshots.ts`: 各 metric × {総数 + normalizationOptions} × {CSV UTF-8 / CSV Shift_JIS / JSON} を R2 保存
- `packages/ranking/src/utils/build-download-csv.ts`: CSV 生成ロジック (単一系列 + 全基準ワイド)
- `apps/web/src/app/api/ranking/[rankingKey]/download/route.ts`: format / basis / encoding を whitelist 検証して stream
- 依存: `iconv-lite ^0.6` を `@stats47/ranking` に追加

### 変更

- `DataDownloadButton.tsx` を `<a href>` ベースに全面書き換え (CSV 組み立てロジック全廃)
- `DataDownloadMenuButton` で CSV (UTF-8 / Shift_JIS) / JSON / 全基準まとめ を Dropdown 提示
- `DataUsageCard` に `hasAllBases` prop 追加
- `sync-snapshots/run.sh` に `ranking-download` task 追加

### 移行手順

1. `bash .claude/skills/db/sync-snapshots/run.sh --only ranking-download` でローカル D1 → R2 export
2. 通常の `/sync-snapshots` フルランで以降は差分更新

---

## Part 2: ブログ記事ページを β レイアウトに再構築

### 課題

PC 表示 (1920px+) で:
- container max-w-screen-2xl (1536px) → 左右 192px ずつ無駄
- CardContent の `max-w-4xl` (896px) で main 内に約 300px 空白
- 右サイドバー `xl:w-72` (288px) は狭い
合計約 **480px の画面領域が未使用**

### 改善

- container を `mx-auto max-w-[1700px] px-4` に拡張
- CardContent の `max-w-4xl` 撤廃 → 本文 Card がコンテナ幅まで広がる
- 右サイドバー: `xl:w-72` (288px) → **`xl:w-[480px]`**
- `xl:max-h-[calc(100vh-5.5rem)] xl:overflow-y-auto` で独立スクロール (全 widget に到達可能)
- 関連書籍 (compact) を `grid-cols-2` に変更 — 480px 幅で書籍 2 冊横並び

### 広告強化

新規 `TechSchoolPromoCard` (`apps/web/src/features/ads/`):
- Claude Code 副業講座 promo の sidebar variant + inline variant
- `NEXT_PUBLIC_TECH_SCHOOL_AFFILIATE_URL` で遷移先 URL を設定 (未設定時 `/about`)

新規 `extractPrefecturesFromArticle()` (`apps/web/src/features/blog/utils/`):
- 記事から都道府県を抽出 (タグ slug 重み 10、タイトル 5、本文 1 ポイント)
- 最頻出県の `FurusatoNozeiCard` を自動表示

### サイドバー widget 配置 (above-fold 優先)

1. Claude Code 副業講座
2. 目次 (TOC)
3. AdSense Rectangle (上)
4. 関連書籍 (2 列 grid)
5. 関連ランキング
6. ふるさと納税 (記事都道府県マッチ時)
7. 関連記事
8. AdSense Rectangle (下)

xl 未満は従来通り main 縦並び。

### 期待効果

| 指標 | リフト |
|---|---|
| 画面領域使用率 | 80% → 89% (1920px) |
| AdSense impression | +50〜80% |
| アフィリエイト CTR | +15〜30% |
| 回遊リンク CTR | +20〜30% |
| 総合収益 | +40〜60% |

---

## Test plan

### Part 1 (CSV ダウンロード)
- [ ] sync-snapshots で R2 事前生成
- [ ] `/api/ranking/total-population/download?format=csv` で BOM 付き CSV 返却
- [ ] `?encoding=sjis` / `?basis=per_population` / `?basis=all-bases` 各バリエーション動作
- [ ] DataUsageCard の Dropdown 動作
- [ ] TrendSparkline / BarChartRace の既存動作維持

### Part 2 (ブログレイアウト)
- [ ] PC 1920px で本文と右サイドバー両方が画面いっぱい
- [ ] 1440 / 1280 / 1024 / モバイルで破綻なし
- [ ] サイドバー内スクロールで全 widget 到達可能
- [ ] 記事タイトル/タグに都道府県を含む場合にふるさと納税自動表示
- [ ] 本文末に Claude Code inline 広告表示