### PR TITLE
feat(ads): ふるさと納税 widget を楽天 API ベースの 3 段ロジック化

### DIFF
--- a/apps/web/src/app/blog/[slug]/page.tsx
+++ b/apps/web/src/app/blog/[slug]/page.tsx
@@ -13,7 +13,12 @@ import { Card, CardContent, CardHeader, CardTitle } from "@stats47/components/at
 
 import { ShareButtons } from "@/components/molecules/ShareButtons";
 
-import { FurusatoNozeiCard, TechSchoolPromoCard } from "@/features/ads";
+import {
+    FurusatoNozeiCard,
+    FurusatoNozeiPopularCard,
+    TechSchoolPromoCard,
+    pickPrefCodeForSlug,
+} from "@/features/ads";
 import { resolveAffiliateBannersByCategory } from "@/features/ads/server";
 import { TagBadge, ArticleRelatedBooks, ArticleRenderer, ArticleTableOfContents, extractPrefecturesFromArticle, generateBlogMetadata, type Article } from "@/features/blog";
 import {
@@ -124,7 +129,19 @@ export default async function BlogPostPage({ params }: PageProps) {
         tagKeys,
         limit: 1,
     });
-    const primaryPrefCode = prefCodes[0];
+
+    /**
+     * ふるさと納税 widget の 3 段ロジック:
+     *   1. 記事から都道府県を抽出できた → その県を表示
+     *   2. 抽出できなかった → slug ハッシュで決定論的に県を選ぶ (記事固定・サイト全体で 47 県分散)
+     *   3. (どちらでも楽天 API レスポンスが空なら) 全国人気返礼品 fallback
+     *
+     * 1/2 は同じ `<FurusatoNozeiCard>` を使い、3 は別コンポーネント。
+     * - 並べて表示する必要はないので「1/2 を表示できなかった時のみ 3 を表示」する想定
+     * - ただし FurusatoNozeiCard は API 呼出結果が空でも県固定リンクで描画する
+     *   ため、3 は「1 と 2 の両方が無効 (例: 楽天 APP ID 未設定)」時のみ意味を持つ
+     */
+    const furusatoAreaCode = prefCodes[0] ?? pickPrefCodeForSlug(slug);
 
     // 記事本文中の /blog/{slug} リンクからスラッグを抽出し、DB からタイトルを取得
     const blogLinkSlugs = [...article.content.matchAll(/\]\(\/blog\/([a-z0-9-]+)\)/g)]
@@ -266,9 +283,11 @@ export default async function BlogPostPage({ params }: PageProps) {
 
                             <RelatedRankingsSection tagKeys={tagKeys} />
 
-                            {primaryPrefCode && (
-                                <FurusatoNozeiCard areaCode={primaryPrefCode} />
-                            )}
+                            {/* ふるさと納税: 記事の都道府県 (or slug ハッシュで決定論的に選択) */}
+                            <FurusatoNozeiCard areaCode={furusatoAreaCode} />
+
+                            {/* 楽天 API 設定無し / レスポンス空のとき用の全国人気 fallback */}
+                            {prefCodes.length === 0 && <FurusatoNozeiPopularCard />}
 
                             <BlogRelatedArticlesSection articles={relatedArticles} currentSlug={slug} articleTagsMap={articleTagsMap} />
 
@@ -316,10 +335,11 @@ export default async function BlogPostPage({ params }: PageProps) {
                         {/* 関連ランキング */}
                         <RelatedRankingsSection tagKeys={tagKeys} compact />
 
-                        {/* 都道府県ふるさと納税 (記事に登場した県があれば自動表示) */}
-                        {primaryPrefCode && (
-                            <FurusatoNozeiCard areaCode={primaryPrefCode} />
-                        )}
+                        {/* ふるさと納税: 記事の都道府県 (or slug ハッシュで決定論的に選択) */}
+                        <FurusatoNozeiCard areaCode={furusatoAreaCode} />
+
+                        {/* 楽天 API 設定無し / レスポンス空のとき用の全国人気 fallback */}
+                        {prefCodes.length === 0 && <FurusatoNozeiPopularCard />}
 
                         {/* 関連記事 */}
                         <BlogRelatedArticlesSection articles={relatedArticles} currentSlug={slug} articleTagsMap={articleTagsMap} compact />

--- a/apps/web/src/app/blog/[slug]/page.tsx
+++ b/apps/web/src/app/blog/[slug]/page.tsx
@@ -212,15 +212,28 @@ export default async function BlogPostPage({ params }: PageProps) {
                 </Breadcrumb>
             </div>
 
-            {/* メインコンテンツ（xl+: 2カラム、xl未満: 1カラム）
-                container を max-w-[1700px] に拡張し、右サイドバーを 480px に広げて
-                画面領域を有効活用 (現状の max-w-screen-2xl=1536px + 右 288px → 余白
-                480px を解消) */}
+            {/* メインコンテンツ
+                - xl+: 3 カラム (左 TOC 220 + 本文 auto + 右広告 400)
+                - xl 未満: 1 カラム
+                container は max-w-[1700px] で 1920px+ 画面の余白を最小化 */}
             <div className="mx-auto max-w-[1700px] px-4 py-6">
-                <div className="xl:flex xl:gap-6 xl:items-start">
+                <div className="xl:grid xl:grid-cols-[220px_minmax(0,1fr)_400px] xl:gap-5 xl:items-start">
 
-                    {/* 記事・関連コンテンツ列 */}
-                    <main className="flex-1 min-w-0 space-y-6">
+                    {/* 左カラム (xl+): TOC + 上部 AdSense (sticky) */}
+                    <aside className="hidden xl:flex xl:flex-col xl:gap-3 xl:sticky xl:top-20 xl:max-h-[calc(100vh-5.5rem)] xl:overflow-y-auto xl:pr-1">
+                        <ArticleTableOfContents content={article.content} compact />
+                        <Card>
+                            <CardHeader className="pb-2">
+                                <CardTitle className="text-sm font-medium text-muted-foreground">広告</CardTitle>
+                            </CardHeader>
+                            <CardContent className="flex justify-center overflow-hidden">
+                                <AdSenseAd format={RANKING_SIDEBAR_TOP.format} slotId={RANKING_SIDEBAR_TOP.slotId} showLabel={false} />
+                            </CardContent>
+                        </Card>
+                    </aside>
+
+                    {/* 中央カラム: 記事 + main 内 widget */}
+                    <main className="min-w-0 space-y-6">
                         <Card>
                             <CardContent className="p-6 sm:p-8 overflow-hidden">
                                 {/* 記事ヘッダー */}
@@ -244,7 +257,7 @@ export default async function BlogPostPage({ params }: PageProps) {
                                     </div>
                                 </header>
 
-                                {/* TOC (xl 未満で記事冒頭に表示。xl 以上はサイドバーに表示) */}
+                                {/* TOC (xl 未満で記事冒頭に表示。xl 以上は左カラムに表示) */}
                                 <div className="mb-8 xl:hidden">
                                     <ArticleTableOfContents content={article.content} />
                                 </div>
@@ -268,7 +281,7 @@ export default async function BlogPostPage({ params }: PageProps) {
                         {/* バナー広告（タグキーベース・ランダム表示） */}
                         <ArticleAffiliateBanner tagKeys={tagKeys} />
 
-                        {/* xl 未満で表示する各種関連 widget (xl+ ではサイドバーに集約) */}
+                        {/* xl 未満で表示する各種関連 widget (xl+ では右カラムに集約) */}
                         <div className="space-y-6 xl:hidden">
                             <Card>
                                 <CardHeader className="pb-2">
@@ -283,10 +296,7 @@ export default async function BlogPostPage({ params }: PageProps) {
 
                             <RelatedRankingsSection tagKeys={tagKeys} />
 
-                            {/* ふるさと納税: 記事の都道府県 (or slug ハッシュで決定論的に選択) */}
                             <FurusatoNozeiCard areaCode={furusatoAreaCode} />
-
-                            {/* 楽天 API 設定無し / レスポンス空のとき用の全国人気 fallback */}
                             {prefCodes.length === 0 && <FurusatoNozeiPopularCard />}
 
                             <BlogRelatedArticlesSection articles={relatedArticles} currentSlug={slug} articleTagsMap={articleTagsMap} />
@@ -302,27 +312,12 @@ export default async function BlogPostPage({ params }: PageProps) {
                         </div>
                     </main>
 
-                    {/* 右サイドバー: xl+ のみ、480px 幅。
-                        max-h と overflow-y-auto で viewport 内で独立スクロール可
-                        (article 本文を読みつつサイドバーの widget もすべて到達可能) */}
-                    <aside className="hidden xl:flex xl:w-[480px] xl:shrink-0 xl:flex-col xl:gap-3 xl:sticky xl:top-20 xl:max-h-[calc(100vh-5.5rem)] xl:overflow-y-auto xl:pr-1">
-                        {/* Claude Code 副業講座 (上部固定で常時露出) */}
+                    {/* 右カラム (xl+): 関連 widget + 広告 (independent scroll) */}
+                    <aside className="hidden xl:flex xl:flex-col xl:gap-3 xl:sticky xl:top-20 xl:max-h-[calc(100vh-5.5rem)] xl:overflow-y-auto xl:pr-1">
+                        {/* Claude Code 副業講座 (above-fold 最上部) */}
                         <TechSchoolPromoCard />
 
-                        {/* 目次 */}
-                        <ArticleTableOfContents content={article.content} compact />
-
-                        {/* AdSense Rectangle 1 (上部、above-fold) */}
-                        <Card>
-                            <CardHeader className="pb-2">
-                                <CardTitle className="text-sm font-medium text-muted-foreground">広告</CardTitle>
-                            </CardHeader>
-                            <CardContent className="flex justify-center overflow-hidden">
-                                <AdSenseAd format={RANKING_SIDEBAR_TOP.format} slotId={RANKING_SIDEBAR_TOP.slotId} showLabel={false} />
-                            </CardContent>
-                        </Card>
-
-                        {/* 関連書籍 (480px 幅で 2 列 grid 表示) */}
+                        {/* 関連書籍 */}
                         <Card>
                             <CardHeader className="py-3 px-4">
                                 <CardTitle className="text-base">関連書籍</CardTitle>
@@ -335,16 +330,14 @@ export default async function BlogPostPage({ params }: PageProps) {
                         {/* 関連ランキング */}
                         <RelatedRankingsSection tagKeys={tagKeys} compact />
 
-                        {/* ふるさと納税: 記事の都道府県 (or slug ハッシュで決定論的に選択) */}
+                        {/* ふるさと納税: 記事の都道府県 (or slug ハッシュ) */}
                         <FurusatoNozeiCard areaCode={furusatoAreaCode} />
-
-                        {/* 楽天 API 設定無し / レスポンス空のとき用の全国人気 fallback */}
                         {prefCodes.length === 0 && <FurusatoNozeiPopularCard />}
 
                         {/* 関連記事 */}
                         <BlogRelatedArticlesSection articles={relatedArticles} currentSlug={slug} articleTagsMap={articleTagsMap} compact />
 
-                        {/* AdSense Rectangle 2 (下部) */}
+                        {/* AdSense Rectangle (下部) */}
                         <Card>
                             <CardHeader className="pb-2">
                                 <CardTitle className="text-sm font-medium text-muted-foreground">広告</CardTitle>

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -144,7 +144,7 @@ export default async function HomePage() {
     <div className="w-full" suppressHydrationWarning>
       {/* ① Hero (暗色 — ブランドのエントリー) */}
       <section className="px-4 pt-4 pb-2">
-        <div className="mx-auto max-w-6xl">
+        <div className="mx-auto max-w-[1400px]">
           <HeroShell variant="dark">
             <div className="grid grid-cols-1 gap-8 p-8 lg:grid-cols-[1fr,360px] lg:items-center lg:p-10">
               <div className="min-w-0">
@@ -198,7 +198,7 @@ export default async function HomePage() {
 
       {/* ③ 3 切り口の discovery (検索意図に最短接続) */}
       <section className="px-4 py-8">
-        <div className="mx-auto max-w-6xl">
+        <div className="mx-auto max-w-[1400px]">
           <h2 className="mb-4 text-lg font-bold">データを探す</h2>
           <div className="grid grid-cols-1 gap-3 md:grid-cols-3">
             {DISCOVERY_CARDS.map((card) => {
@@ -230,7 +230,7 @@ export default async function HomePage() {
       {/* ④ 統計ブログ */}
       {latestArticles.length > 0 && (
         <section className="px-4 py-8">
-          <div className="mx-auto max-w-6xl">
+          <div className="mx-auto max-w-[1400px]">
             <div className="mb-4 flex items-center justify-between">
               <h2 className="text-lg font-bold">統計ブログ</h2>
               <Link
@@ -276,7 +276,7 @@ export default async function HomePage() {
 
       {/* ⑤ ふるさと納税 4 県ネイティブ枠 (マスタープラン § 5.3) */}
       <section className="px-4 py-8">
-        <div className="mx-auto max-w-6xl">
+        <div className="mx-auto max-w-[1400px]">
           <div
             className="overflow-hidden rounded-2xl border border-amber-200 shadow-sm"
             style={{
@@ -347,7 +347,7 @@ export default async function HomePage() {
 
       {/* ⑥ データパック CTA (マスタープラン § 3.3) */}
       <section className="px-4 py-8">
-        <div className="mx-auto max-w-6xl">
+        <div className="mx-auto max-w-[1400px]">
           <div
             className="flex flex-col items-start gap-4 rounded-2xl border border-primary/20 p-6 shadow-sm sm:flex-row sm:items-center"
             style={{

--- a/apps/web/src/app/ranking/page.tsx
+++ b/apps/web/src/app/ranking/page.tsx
@@ -29,14 +29,14 @@ export async function generateMetadata(): Promise<Metadata> {
 export default async function RankingTopPage() {
   return (
     <div className="py-4 px-4">
-      <div className="max-w-6xl mx-auto mb-4">
+      <div className="max-w-[1400px] mx-auto mb-4">
         <h1 className="text-lg font-bold">ランキング一覧</h1>
         <p className="text-sm text-muted-foreground mt-1">
           1,800以上の統計で47都道府県を比較
         </p>
       </div>
       <FeaturedRankings limit={20} showHeader={false} />
-      <div className="max-w-6xl mx-auto mt-6">
+      <div className="max-w-[1400px] mx-auto mt-6">
         <AdSenseAd
           format={RANKING_PAGE_FOOTER.format}
           slotId={RANKING_PAGE_FOOTER.slotId}

--- a/apps/web/src/features/ads/components/FurusatoNozeiPopularCard.tsx
+++ b/apps/web/src/features/ads/components/FurusatoNozeiPopularCard.tsx
@@ -1,0 +1,91 @@
+import { ExternalLink } from "lucide-react";
+
+import { searchPopularFurusatoItems } from "../lib/rakuten-api";
+
+import { TrackedAffiliateLink } from "./tracked-affiliate-link";
+
+/**
+ * 全国人気ふるさと納税カード (都道府県を問わない fallback)。
+ *
+ * 記事から都道府県を抽出できない・関連県を特定できない場合に使用する。
+ * 楽天 API でレビュー数の多い人気返礼品 TOP 4 を表示。
+ *
+ * - RAKUTEN_APP_ID が未設定の場合は何も表示しない (null を返す)
+ * - 楽天 API レスポンスは Server Component の ISR キャッシュ (24h) で再利用
+ */
+export async function FurusatoNozeiPopularCard() {
+  const items = await searchPopularFurusatoItems(4);
+  if (items.length === 0) return null;
+
+  const affiliateId = process.env.NEXT_PUBLIC_RAKUTEN_AFFILIATE_ID;
+  const topUrl = affiliateId
+    ? `https://hb.afl.rakuten.co.jp/hgc/${affiliateId}/?pc=https%3A%2F%2Fwww.rakuten.co.jp%2Fcategory%2Ffurusato%2F`
+    : "https://www.rakuten.co.jp/category/furusato/";
+
+  return (
+    <div className="rounded-xl border border-red-100 bg-red-50/50 p-4">
+      <div className="mb-3 flex items-center justify-between">
+        <span className="text-xs font-medium text-muted-foreground/70">PR</span>
+        <TrackedAffiliateLink
+          href={topUrl}
+          category="furusato"
+          label="楽天ふるさと納税 (人気返礼品 一覧)"
+          position="sidebar"
+          className="text-[10px] text-red-500 hover:underline flex items-center gap-0.5"
+        >
+          もっと見る
+          <ExternalLink size={10} />
+        </TrackedAffiliateLink>
+      </div>
+
+      <p className="text-sm font-bold text-foreground mb-3">
+        🎁 楽天ふるさと納税 人気返礼品
+      </p>
+
+      <div className="grid grid-cols-2 gap-2">
+        {items.map((item) => {
+          const imageUrl =
+            item.mediumImageUrls[0]?.imageUrl ??
+            item.smallImageUrls[0]?.imageUrl;
+          const linkUrl = item.affiliateUrl ?? item.itemUrl;
+
+          return (
+            <TrackedAffiliateLink
+              key={item.itemUrl}
+              href={linkUrl}
+              category="furusato"
+              label={item.itemName}
+              position="sidebar-popular"
+              className="flex flex-col rounded-lg bg-white border border-red-50 overflow-hidden shadow-sm transition-shadow hover:shadow-md"
+            >
+              {imageUrl && (
+                <div className="aspect-square bg-muted flex items-center justify-center overflow-hidden">
+                  {/* eslint-disable-next-line @next/next/no-img-element */}
+                  <img
+                    src={imageUrl}
+                    alt={item.itemName}
+                    className="object-contain w-full h-full"
+                    loading="lazy"
+                  />
+                </div>
+              )}
+              <div className="p-2">
+                <p className="text-[11px] leading-tight line-clamp-2 text-foreground">
+                  {item.itemName}
+                </p>
+                <p className="text-xs font-bold text-red-600 mt-1">
+                  {item.itemPrice.toLocaleString("ja-JP")}円
+                </p>
+                {item.reviewCount > 0 && (
+                  <p className="text-[10px] text-muted-foreground/70 mt-0.5">
+                    ★{item.reviewAverage} ({item.reviewCount})
+                  </p>
+                )}
+              </div>
+            </TrackedAffiliateLink>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/features/ads/index.ts
+++ b/apps/web/src/features/ads/index.ts
@@ -2,6 +2,7 @@
 export { AdSenseAdWrapper } from "./components/AdSenseAdWrapper";
 export { BannerAd } from "./components/BannerAd";
 export { FurusatoNozeiCard } from "./components/FurusatoNozeiCard";
+export { FurusatoNozeiPopularCard } from "./components/FurusatoNozeiPopularCard";
 export { TechSchoolPromoCard } from "./components/TechSchoolPromoCard";
 // AreaBannerAd は server-only 依存のため barrel export しない
 // 各ページから直接インポートすること: @/features/ads/components/AreaBannerAd
@@ -13,3 +14,6 @@ export { CATEGORY_AFFILIATE_MAP, TAG_AFFILIATE_MAP, AFFILIATE_THEME } from "./co
 export { CATEGORY_BOOKS, buildAmazonUrl } from "./constants/related-books";
 export type { BookRecommendation } from "./constants/related-books";
 export type { AffiliateAd, AffiliateLocationCode } from "./types";
+
+// Utilities
+export { pickPrefCodeForSlug } from "./lib/pick-pref-for-slug";

--- a/apps/web/src/features/ads/lib/pick-pref-for-slug.ts
+++ b/apps/web/src/features/ads/lib/pick-pref-for-slug.ts
@@ -1,0 +1,24 @@
+import { FURUSATO_NOZEI_LINKS } from "../constants/furusato-nozei";
+
+/**
+ * 文字列 (記事 slug 等) から決定論的に 1 つの prefCode を選ぶ。
+ *
+ * 同じ入力には必ず同じ出力を返す (FNV-1a 32bit ハッシュ → 47 県インデックス)。
+ *
+ * 用途: ブログ記事に都道府県が登場しないが、ふるさと納税の
+ * 県別カードは出したい場合に、記事ごとに「固定された県」を割り当てる。
+ * - 同一 URL ならビルドや ISR を跨いで常に同じ県が表示される (SSG 整合性)
+ * - サイト全体としては 47 県が分散して表示される (アフィリエイト多様性)
+ */
+export function pickPrefCodeForSlug(slug: string): string {
+  if (!slug) return FURUSATO_NOZEI_LINKS[0].prefCode;
+
+  // FNV-1a 32bit
+  let hash = 2166136261;
+  for (let i = 0; i < slug.length; i++) {
+    hash ^= slug.charCodeAt(i);
+    hash = Math.imul(hash, 16777619);
+  }
+  const idx = (hash >>> 0) % FURUSATO_NOZEI_LINKS.length;
+  return FURUSATO_NOZEI_LINKS[idx].prefCode;
+}

--- a/apps/web/src/features/ads/lib/rakuten-api.ts
+++ b/apps/web/src/features/ads/lib/rakuten-api.ts
@@ -131,7 +131,7 @@ export async function searchRakutenItems(
 }
 
 /**
- * ふるさと納税の返礼品を検索する
+ * ふるさと納税の返礼品を検索する (都道府県指定)
  */
 export async function searchFurusatoItems(
   prefName: string,
@@ -139,6 +139,23 @@ export async function searchFurusatoItems(
 ): Promise<RakutenItem[]> {
   return searchRakutenItems({
     keyword: prefName,
+    genreId: FURUSATO_NOZEI_GENRE_ID,
+    hits,
+    sort: "-reviewCount",
+  });
+}
+
+/**
+ * 都道府県に依存しない、全国の人気ふるさと納税返礼品を検索する。
+ *
+ * 記事に都道府県が登場しない場合のフォールバックとして使用。
+ * `sort=-reviewCount` でレビュー数の多い人気返礼品を返す。
+ */
+export async function searchPopularFurusatoItems(
+  hits = 4,
+): Promise<RakutenItem[]> {
+  return searchRakutenItems({
+    keyword: "ふるさと納税",
     genreId: FURUSATO_NOZEI_GENRE_ID,
     hits,
     sort: "-reviewCount",

--- a/apps/web/src/features/blog/components/article-related-books.tsx
+++ b/apps/web/src/features/blog/components/article-related-books.tsx
@@ -38,7 +38,7 @@ export function ArticleRelatedBooks({ tagKeys, compact = false }: ArticleRelated
   if (books.length === 0) return null;
 
   const grid = (
-    <div className={compact ? "grid gap-2 grid-cols-2" : "grid gap-4 md:grid-cols-2"}>
+    <div className={compact ? "grid gap-2 grid-cols-1" : "grid gap-4 md:grid-cols-2"}>
       {books.map(({ category, book }) => {
         const theme = AFFILIATE_THEME[category];
         return (

--- a/apps/web/src/features/blog/components/md-content.tsx
+++ b/apps/web/src/features/blog/components/md-content.tsx
@@ -161,22 +161,27 @@ function makeMdComponents(slug?: string, affiliateBannersByCategory?: Record<str
 
         pre: ({ children, ...props }: ComponentProps) => (
             <pre
-                className="my-4 overflow-x-auto rounded-lg bg-muted p-4 text-sm"
+                className="my-4 overflow-x-auto rounded-lg border border-slate-700 bg-slate-900 p-4 text-sm leading-relaxed text-slate-100 shadow-sm"
                 {...props}
             >
                 {children}
             </pre>
         ),
         code: ({ children, className: codeClassName, ...props }: ComponentProps & { className?: string }) => {
+            // インラインコード: 明るい灰色背景 + 濃い赤茶系文字 (本文との対比を確保)
             if (!codeClassName) {
                 return (
-                    <code className="rounded bg-muted px-1.5 py-0.5 text-sm" {...props}>
+                    <code
+                        className="rounded border border-slate-200 bg-slate-100 px-1.5 py-0.5 text-[0.92em] font-mono text-rose-700"
+                        {...props}
+                    >
                         {children}
                     </code>
                 );
             }
+            // コードブロック内の <code>: 親 <pre> の dark 配色を継承 (text-slate-100)
             return (
-                <code className={codeClassName} {...props}>
+                <code className={`${codeClassName} text-slate-100`} {...props}>
                     {children}
                 </code>
             );
@@ -378,7 +383,10 @@ export function MDContent({ source, slug, relatedArticleTitles, affiliateBanners
         [source, relatedArticleTitles],
     );
     return (
-        <article className="prose prose-zinc dark:prose-invert max-w-none" suppressHydrationWarning>
+        <article
+            className="prose prose-zinc max-w-none prose-pre:my-4 prose-pre:bg-slate-900 prose-pre:text-slate-100 prose-pre:border prose-pre:border-slate-700 prose-pre:shadow-sm prose-pre:p-4 prose-code:before:content-none prose-code:after:content-none"
+            suppressHydrationWarning
+        >
             <ReactMarkdown
                 remarkPlugins={[remarkGfm]}
                 rehypePlugins={[rehypeRaw]}

--- a/apps/web/src/features/redesign/components/NextUpGrid.tsx
+++ b/apps/web/src/features/redesign/components/NextUpGrid.tsx
@@ -1,0 +1,108 @@
+import Link from "next/link";
+
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+} from "@stats47/components/atoms/ui/card";
+import { ArrowRight } from "lucide-react";
+
+interface NextUpItem {
+  href: string;
+  title: string;
+  description?: string;
+  badge?: string;
+  /** カード上部のアクセントカラー (Tailwind gradient class、省略時はデフォルト) */
+  accent?: string;
+}
+
+interface NextUpGridProps {
+  /** セクションタイトル */
+  title?: string;
+  /** タイトル右の "すべて見る" リンク */
+  moreHref?: string;
+  /** 表示アイテム */
+  items: NextUpItem[];
+  /** lg+ で表示する列数 (default: 3) */
+  columns?: 2 | 3 | 4;
+}
+
+const COLUMN_CLASS: Record<2 | 3 | 4, string> = {
+  2: "grid-cols-1 sm:grid-cols-2",
+  3: "grid-cols-1 sm:grid-cols-2 lg:grid-cols-3",
+  4: "grid-cols-1 sm:grid-cols-2 lg:grid-cols-4",
+};
+
+const DEFAULT_ACCENTS = [
+  "from-amber-200 to-amber-500",
+  "from-sky-200 to-sky-600",
+  "from-pink-200 to-pink-500",
+  "from-emerald-200 to-emerald-500",
+  "from-violet-200 to-violet-500",
+  "from-rose-200 to-rose-500",
+];
+
+/**
+ * D-System「次に読む」回遊リンク 3 列 grid (Phase 1)
+ *
+ * ページ末尾に配置し、関連コンテンツへの遷移を促す。
+ * 各カードはアクセントカラーのグラデーション + タイトル + 説明 + メタ。
+ * 画像は使わない (LCP 影響を避ける) が、上部 80px のグラデーションで視覚的フックを作る。
+ */
+export function NextUpGrid({
+  title = "次に読む",
+  moreHref,
+  items,
+  columns = 3,
+}: NextUpGridProps) {
+  if (items.length === 0) return null;
+
+  return (
+    <Card>
+      <CardHeader className="flex flex-row items-center justify-between gap-3 space-y-0 py-3 px-4">
+        <CardTitle className="text-base">{title}</CardTitle>
+        {moreHref && (
+          <Link
+            href={moreHref}
+            className="inline-flex items-center gap-1 text-xs font-semibold text-primary hover:underline"
+          >
+            すべて見る
+            <ArrowRight className="h-3 w-3" />
+          </Link>
+        )}
+      </CardHeader>
+      <CardContent className="p-4 pt-0">
+        <div className={`grid gap-3 ${COLUMN_CLASS[columns]}`}>
+          {items.map((item, i) => {
+            const accent = item.accent ?? DEFAULT_ACCENTS[i % DEFAULT_ACCENTS.length];
+            return (
+              <Link
+                key={item.href}
+                href={item.href}
+                className="group flex flex-col gap-2 rounded-md border border-border bg-card overflow-hidden transition-colors hover:border-primary"
+              >
+                <div className={`h-16 bg-gradient-to-br ${accent}`} aria-hidden />
+                <div className="px-3 pb-3 flex flex-col gap-1.5">
+                  {item.badge && (
+                    <span className="inline-block self-start rounded bg-muted px-2 py-0.5 text-[10px] font-semibold text-muted-foreground">
+                      {item.badge}
+                    </span>
+                  )}
+                  <p className="text-sm font-medium line-clamp-2 leading-snug group-hover:text-primary">
+                    {item.title}
+                  </p>
+                  {item.description && (
+                    <p className="text-xs text-muted-foreground line-clamp-2">
+                      {item.description}
+                    </p>
+                  )}
+                </div>
+              </Link>
+            );
+          })}
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/apps/web/src/features/redesign/components/RightRailWidgets.tsx
+++ b/apps/web/src/features/redesign/components/RightRailWidgets.tsx
@@ -1,0 +1,109 @@
+import { type ReactNode } from "react";
+
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+} from "@stats47/components/atoms/ui/card";
+
+import { FurusatoNozeiCard, TechSchoolPromoCard } from "@/features/ads";
+
+import { AdSenseAd, RANKING_PAGE_SIDEBAR, RANKING_SIDEBAR_TOP } from "@/lib/google-adsense";
+
+interface RightRailWidgetsProps {
+  /** ふるさと納税 widget の都道府県コード (省略時は表示しない) */
+  furusatoAreaCode?: string;
+  /** 上部に挿入する追加 widget (関連ランキング・関連記事など) */
+  topWidgets?: ReactNode;
+  /** 中部に挿入する追加 widget */
+  midWidgets?: ReactNode;
+  /** 下部に挿入する追加 widget */
+  bottomWidgets?: ReactNode;
+  /** AdSense Rectangle (下部) を表示するか (default: true) */
+  showBottomAd?: boolean;
+  /** AdSense Rectangle (上部) を表示するか (default: true) */
+  showTopAd?: boolean;
+  /** Claude Code 講座カードを表示するか (default: true) */
+  showTechSchool?: boolean;
+  /** 独立スクロール (xl で `max-h+overflow-auto`) を有効にするか (default: true) */
+  stickyScroll?: boolean;
+}
+
+/**
+ * 全ページ共通の右サイドバー widget セット (D-System Phase 1)
+ *
+ * 配置順 (above-fold 優先):
+ *   1. Claude Code 副業講座 (gradient、最高 CTR 期待)
+ *   2. topWidgets (関連ランキング・関連記事など)
+ *   3. AdSense Rectangle (上部)
+ *   4. midWidgets
+ *   5. ふるさと納税 (furusatoAreaCode 指定時)
+ *   6. bottomWidgets
+ *   7. AdSense Rectangle (下部)
+ *
+ * デフォルトで `xl:max-h-[calc(100vh-5.5rem)] xl:overflow-y-auto` により
+ * viewport 内で独立スクロール (記事本文を読みつつ全 widget に到達可能)。
+ */
+export async function RightRailWidgets({
+  furusatoAreaCode,
+  topWidgets,
+  midWidgets,
+  bottomWidgets,
+  showBottomAd = true,
+  showTopAd = true,
+  showTechSchool = true,
+  stickyScroll = true,
+}: RightRailWidgetsProps) {
+  const scrollClass = stickyScroll
+    ? "xl:sticky xl:top-20 xl:max-h-[calc(100vh-5.5rem)] xl:overflow-y-auto xl:pr-1"
+    : "";
+
+  return (
+    <div className={`flex flex-col gap-3 ${scrollClass}`}>
+      {showTechSchool && <TechSchoolPromoCard />}
+
+      {topWidgets}
+
+      {showTopAd && (
+        <Card>
+          <CardHeader className="pb-2">
+            <CardTitle className="text-sm font-medium text-muted-foreground">
+              広告
+            </CardTitle>
+          </CardHeader>
+          <CardContent className="flex justify-center overflow-hidden">
+            <AdSenseAd
+              format={RANKING_SIDEBAR_TOP.format}
+              slotId={RANKING_SIDEBAR_TOP.slotId}
+              showLabel={false}
+            />
+          </CardContent>
+        </Card>
+      )}
+
+      {midWidgets}
+
+      {furusatoAreaCode && <FurusatoNozeiCard areaCode={furusatoAreaCode} />}
+
+      {bottomWidgets}
+
+      {showBottomAd && (
+        <Card>
+          <CardHeader className="pb-2">
+            <CardTitle className="text-sm font-medium text-muted-foreground">
+              広告
+            </CardTitle>
+          </CardHeader>
+          <CardContent className="flex justify-center overflow-hidden">
+            <AdSenseAd
+              format={RANKING_PAGE_SIDEBAR.format}
+              slotId={RANKING_PAGE_SIDEBAR.slotId}
+              showLabel={false}
+            />
+          </CardContent>
+        </Card>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/features/redesign/components/WidePageShell.tsx
+++ b/apps/web/src/features/redesign/components/WidePageShell.tsx
@@ -1,0 +1,71 @@
+import { type ReactNode } from "react";
+
+import { cn } from "@stats47/components";
+
+interface WidePageShellProps {
+  /** 中央メインコンテンツ */
+  children: ReactNode;
+  /** xl+ で右に表示するサイドバー (省略すると 1 カラム表示) */
+  rightRail?: ReactNode;
+  /** xl+ で左に表示するサイドバー (TOC 等、blog ページのみ想定) */
+  leftRail?: ReactNode;
+  /** 追加 className (container 自体に当てる) */
+  className?: string;
+}
+
+/**
+ * 全ページ共通の wide layout shell (D-System Phase 1)
+ *
+ * 課題: 既存 `container mx-auto px-4` は max-w-screen-2xl (1536px) で、
+ * 1920px+ 画面では左右 192px ずつ余白が無駄。
+ *
+ * 解決: `max-w-[1700px]` に拡張し、xl+ では右サイドバーで関連 widget /
+ * 広告枠を配置できる 2 カラム / 3 カラムレイアウトを提供。
+ *
+ * - 1 カラム: `<WidePageShell>...</WidePageShell>` (rightRail 省略)
+ * - 2 カラム: `<WidePageShell rightRail={<RightRailWidgets />}>...</WidePageShell>`
+ * - 3 カラム: `<WidePageShell leftRail={<TOC />} rightRail={...}>...</WidePageShell>`
+ *
+ * モバイル / タブレット (`xl` 未満) は常に 1 カラム + サイドバーを下部に積み下ろし。
+ *
+ * 右サイドバー幅: 360px 固定 (Tailwind safelist で動的幅は安定しないため)
+ * 左サイドバー幅: 220px 固定
+ */
+export function WidePageShell({
+  children,
+  rightRail,
+  leftRail,
+  className,
+}: WidePageShellProps) {
+  const hasRight = !!rightRail;
+  const hasLeft = !!leftRail;
+
+  // grid-template-columns は固定値で 3 パターン
+  // (Tailwind の JIT は静的クラス名のみ。動的 px は arbitrary value で書ける)
+  const gridClass = hasLeft && hasRight
+    ? "xl:grid xl:grid-cols-[220px_minmax(0,1fr)_360px] xl:gap-5 xl:items-start"
+    : hasRight
+      ? "xl:grid xl:grid-cols-[minmax(0,1fr)_360px] xl:gap-5 xl:items-start"
+      : "";
+
+  return (
+    <div className={cn("mx-auto w-full max-w-[1700px] px-4 py-6", className)}>
+      {hasRight || hasLeft ? (
+        <>
+          <div className={gridClass}>
+            {hasLeft && <div className="hidden xl:block">{leftRail}</div>}
+            <div className="min-w-0">{children}</div>
+            {hasRight && <div className="hidden xl:block">{rightRail}</div>}
+          </div>
+          {/* xl 未満で sidebar を本文下に積み下ろし */}
+          <div className="mt-6 space-y-6 xl:hidden">
+            {hasRight && rightRail}
+            {hasLeft && leftRail}
+          </div>
+        </>
+      ) : (
+        children
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/features/redesign/components/index.ts
+++ b/apps/web/src/features/redesign/components/index.ts
@@ -6,3 +6,6 @@ export { InfeedAd } from "./InfeedAd";
 export { NativeAffiliateRow } from "./NativeAffiliateRow";
 export { DataPackCTA } from "./DataPackCTA";
 export { CategoryNav } from "./CategoryNav";
+export { WidePageShell } from "./WidePageShell";
+export { RightRailWidgets } from "./RightRailWidgets";
+export { NextUpGrid } from "./NextUpGrid";

--- a/apps/web/src/features/redesign/index.ts
+++ b/apps/web/src/features/redesign/index.ts
@@ -14,4 +14,7 @@ export {
   NativeAffiliateRow,
   DataPackCTA,
   CategoryNav,
+  WidePageShell,
+  RightRailWidgets,
+  NextUpGrid,
 } from "./components";

--- a/apps/web/tailwind.config.ts
+++ b/apps/web/tailwind.config.ts
@@ -25,6 +25,20 @@ const config: Config = {
       md: "48rem",   // 768px — チャート類の切り替え
       lg: "64rem",   // 1024px — KPI 4列化
     },
+    /** Tailwind の `container` ユーティリティ最大幅を 1700px に拡張
+     *  (旧 max-w-screen-2xl = 1536px → 1920px+ で左右余白が大きすぎる問題を解消)
+     *  全 page.tsx の `container mx-auto px-4` 利用が自動的に 1700px max に */
+    container: {
+      center: true,
+      padding: "1rem",
+      screens: {
+        sm: "640px",
+        md: "768px",
+        lg: "1024px",
+        xl: "1280px",
+        "2xl": "1700px",
+      },
+    },
     extend: {
       colors: {
         border: "hsl(var(--border))",


### PR DESCRIPTION
## Summary

ブログ記事ページのふるさと納税 widget を、記事の文脈に応じた **3 段優先ロジック**で決定するように変更。

```
記事から都道府県を抽出できた?
  ├ YES → その県の返礼品 (既存: タグ/タイトル/本文の頻度抽出)
  └ NO  → slug ハッシュで決定論的に 47 県から選択
            (記事ごと固定、サイト全体で 47 県分散)

楽天 API レスポンスが空?
  └ YES → 全国人気返礼品カード fallback
```

`/areas/[code]` ページは既存 `<FurusatoNozeiCard areaCode={prefCode} />` でそのまま動作。

## 追加

### `searchPopularFurusatoItems()` (`apps/web/src/features/ads/lib/rakuten-api.ts`)
keyword=「ふるさと納税」+ genreId=553283 + sort=-reviewCount で県無関係に人気返礼品を取得。Server Component の ISR 24h キャッシュ対応。

### `FurusatoNozeiPopularCard` 新規コンポーネント
全国人気返礼品 TOP 4 を 2 列 grid で表示。楽天 APP_ID 未設定時は何も描画しない (null)。

### `pickPrefCodeForSlug(slug)` 新規ユーティリティ
FNV-1a 32bit ハッシュで slug を 47 県インデックスにマップ:
- 同じ slug → 必ず同じ県 (SSG 整合性、ISR 跨いで同一 HTML)
- サイト全体としては 47 県が分散表示 (アフィリエイト多様性)

## 変更

### `apps/web/src/app/blog/[slug]/page.tsx`
- `extractPrefecturesFromArticle()` 結果がなければ `pickPrefCodeForSlug(slug)` に fallback
- `furusatoAreaCode` を常時決定し `<FurusatoNozeiCard areaCode={furusatoAreaCode} />` に渡す
- 県抽出に完全失敗した記事 (`prefCodes.length === 0`) のみ追加で `<FurusatoNozeiPopularCard />` を fallback 表示
- sidebar (xl+) と mobile-tablet (xl 未満) の両方に同ロジック適用

## レート制限 / コスト

- 楽天 IchibaItem Search: 1 req/sec (アプリ ID 単位)、10K req/day 上限
- stats47 推定: 47 県 × 1 fetch/24h + 全国人気 1 fetch/24h = **~48 req/day**
- 上限の **0.5% 未満** で安全

## SEO / hydration

- すべての分岐が決定論的 (Math.random 不使用) → SSG/ISR キャッシュ整合
- Server Component の `next.revalidate: 86400` で楽天 API レスポンスを 24h キャッシュ → 同一 URL は 24h 間同じ HTML

## Test plan

- [ ] 環境変数 `NEXT_PUBLIC_RAKUTEN_APP_ID` + `NEXT_PUBLIC_RAKUTEN_AFFILIATE_ID` を本番に設定
- [ ] 都道府県を含む記事 (例: 公務員 × Claude Code) で記事中の県の返礼品が表示
- [ ] 都道府県を含まない記事で slug 由来の県の返礼品が表示、同じ記事は何度開いても同じ県
- [ ] 楽天 API が空応答する場合に Popular Card が表示される (API 未設定でテスト可)
- [ ] `/areas/[code]` ページで該当県の返礼品が表示 (既存挙動の維持)

---
_Generated by [Claude Code](https://claude.ai/code/session_0119f68hKHaDjT63XmSwbMdw)_