### PR TITLE
feat(redesign): D-System Phase 1 後半 — 5 ページに右サイドバー + home NextUpGrid

### DIFF
--- a/apps/web/src/app/areas/[areaCode]/page.tsx
+++ b/apps/web/src/app/areas/[areaCode]/page.tsx
@@ -31,6 +31,7 @@ import {
 import { getAreaProfileAction } from "@/features/area-profile/server";
 import { listCategories } from "@/features/category/server";
 import { AreaMigrationFlowSection } from "@/features/migration-flow";
+import { RightRailWidgets } from "@/features/redesign";
 
 
 import { AdSenseAd, RANKING_SIDEBAR_TOP } from "@/lib/google-adsense";
@@ -142,9 +143,10 @@ export default async function AreaProfilePage({ params }: PageProps) {
                 />
             </SetSidebarSection>
 
-            {/* 1カラムレイアウト */}
+            {/* 2 カラムレイアウト (xl+ で右サイドバー、xl 未満は main のみ) */}
             <div className="container mx-auto px-4 py-10">
-                <main className="min-w-0 space-y-10">
+                <div className="xl:grid xl:grid-cols-[minmax(0,1fr)_360px] xl:gap-5 xl:items-start">
+                    <main className="min-w-0 space-y-10">
                     {/* DB管理チャート */}
                     <AreaChartSection
                         areaCode={areaCode}
@@ -184,10 +186,18 @@ export default async function AreaProfilePage({ params }: PageProps) {
                         slotId={RANKING_SIDEBAR_TOP.slotId}
                     />
 
-                    {/* アフィリエイト */}
-                    <AreaBannerAd />
-                    <FurusatoNozeiCard areaCode={areaCode} />
+                    {/* アフィリエイト (xl 未満では main 内に表示) */}
+                    <div className="xl:hidden space-y-6">
+                        <AreaBannerAd />
+                        <FurusatoNozeiCard areaCode={areaCode} />
+                    </div>
                 </main>
+
+                    {/* 右サイドバー (xl+) — その県のふるさと納税 + Claude Code 講座 + 関連 AdSense */}
+                    <aside className="hidden xl:block">
+                        <RightRailWidgets furusatoAreaCode={areaCode} />
+                    </aside>
+                </div>
             </div>
         </>
     );

--- a/apps/web/src/app/category/[categoryKey]/page.tsx
+++ b/apps/web/src/app/category/[categoryKey]/page.tsx
@@ -19,6 +19,7 @@ import { generateMiniTileSvg } from "@stats47/visualization/server";
 
 import { ThemeAwareImage } from "@/components/atoms/ThemeAwareImage";
 
+import { TechSchoolPromoCard } from "@/features/ads";
 import { resolveAffiliateBanners } from "@/features/ads/server";
 import { listLatestArticles } from "@/features/blog/server";
 import { findCategoryByKey } from "@/features/category/server";
@@ -256,9 +257,9 @@ export default async function CategoryPage({ params }: PageProps) {
         </div>
       </HeroShell>
 
-      <div className="flex gap-4 items-start">
+      <div className="lg:grid lg:grid-cols-[minmax(0,1fr)_360px] lg:gap-5 lg:items-start">
         {/* メインコンテンツ */}
-        <main className="flex-1 min-w-0">
+        <main className="min-w-0">
           {/* 注目ランキング */}
           {featuredItems.length > 0 && (
             <section className="mb-8">
@@ -310,8 +311,11 @@ export default async function CategoryPage({ params }: PageProps) {
           )}
         </main>
 
-        {/* 右サイドバー（lg以上） */}
-        <aside className="hidden lg:block w-64 shrink-0 sticky top-20">
+        {/* 右サイドバー（lg+、360px、independent scroll で全 widget 到達可能） */}
+        <aside className="hidden lg:flex lg:flex-col lg:gap-4 lg:sticky lg:top-20 lg:max-h-[calc(100vh-5.5rem)] lg:overflow-y-auto lg:pr-1">
+          {/* Claude Code 副業講座 (収益化 / 上部 above-fold) */}
+          <TechSchoolPromoCard />
+
           <div className="flex flex-col gap-4">
             {/* 新着記事 */}
             {latestArticles.length > 0 && (

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -17,6 +17,7 @@ import {
   HeroShell,
   KpiGrid,
   KpiTile,
+  NextUpGrid,
 } from "@/features/redesign";
 
 import { AdSenseAd, RANKING_PAGE_FOOTER } from "@/lib/google-adsense";
@@ -388,7 +389,56 @@ export default async function HomePage() {
         </div>
       </section>
 
-      {/* ⑦ AdSense (footer) */}
+      {/* ⑦ 次に読む (回遊リンク強化) */}
+      <section className="px-4 pb-8">
+        <div className="mx-auto max-w-[1400px]">
+          <NextUpGrid
+            title="このサイトの主要ページ"
+            moreHref="/ranking"
+            items={[
+              {
+                href: "/ranking",
+                title: "全ランキング一覧",
+                description: "1,800 以上の指標から探す",
+                badge: "RANKING",
+              },
+              {
+                href: "/themes",
+                title: "テーマダッシュボード",
+                description: "少子高齢化・労働・医療など 17 テーマ",
+                badge: "THEMES",
+              },
+              {
+                href: "/areas",
+                title: "都道府県一覧",
+                description: "47 都道府県のプロフィール",
+                badge: "AREAS",
+              },
+              {
+                href: "/blog",
+                title: "ブログ",
+                description: "データを読み解く解説記事",
+                badge: "BLOG",
+              },
+              {
+                href: "/survey",
+                title: "調査から探す",
+                description: "出典別に統計を絞り込む",
+                badge: "SURVEY",
+              },
+              {
+                href: "/search",
+                title: "キーワード検索",
+                description: "ランキング・記事を横断検索",
+                badge: "SEARCH",
+              },
+            ]}
+            columns={3}
+          />
+        </div>
+      </section>
+
+      {/* ⑧ AdSense (footer) */}
       <div className="my-6 flex justify-center px-4">
         <AdSenseAd
           format={RANKING_PAGE_FOOTER.format}

--- a/apps/web/src/app/tag/[tagKey]/page.tsx
+++ b/apps/web/src/app/tag/[tagKey]/page.tsx
@@ -26,6 +26,7 @@ import {
     KpiGrid,
     KpiTile,
     NativeAffiliateRow,
+    RightRailWidgets,
 } from "@/features/redesign";
 
 import { AdSenseAd, CONTENT_FOOTER } from "@/lib/google-adsense";
@@ -148,52 +149,61 @@ export default async function TagArticlesPage({ params }: PageProps) {
                 {articles.length === 0 ? (
                     notFound()
                 ) : (
-                    <div className="grid grid-cols-1 gap-6 md:grid-cols-2 lg:grid-cols-3">
-                        {articles.map((article) => (
-                            <Link
-                                key={article.slug}
-                                href={`/blog/${article.slug}`}
-                                className="group block h-full"
-                            >
-                                <Card className="flex h-full flex-col transition-all duration-200 hover:-translate-y-1 hover:shadow-md hover:border-primary/50">
-                                    <CardHeader className="pb-3">
-                                        <div className="mb-2 flex items-center gap-2">
-                                            {article.description && (
-                                                <span className="text-xs text-muted-foreground">
-                                                    {article.slug}
-                                                </span>
-                                            )}
-                                        </div>
-                                        <CardTitle className="text-lg transition-colors group-hover:text-primary">
-                                            {article.title}
-                                        </CardTitle>
-                                        {article.description && (
-                                            <CardDescription className="line-clamp-2">
-                                                {article.description}
-                                            </CardDescription>
-                                        )}
-                                    </CardHeader>
-                                </Card>
-                            </Link>
-                        ))}
+                    <div className="mt-6 xl:grid xl:grid-cols-[minmax(0,1fr)_360px] xl:gap-5 xl:items-start">
+                        <main className="min-w-0">
+                            <div className="grid grid-cols-1 gap-6 md:grid-cols-2 lg:grid-cols-3">
+                                {articles.map((article) => (
+                                    <Link
+                                        key={article.slug}
+                                        href={`/blog/${article.slug}`}
+                                        className="group block h-full"
+                                    >
+                                        <Card className="flex h-full flex-col transition-all duration-200 hover:-translate-y-1 hover:shadow-md hover:border-primary/50">
+                                            <CardHeader className="pb-3">
+                                                <div className="mb-2 flex items-center gap-2">
+                                                    {article.description && (
+                                                        <span className="text-xs text-muted-foreground">
+                                                            {article.slug}
+                                                        </span>
+                                                    )}
+                                                </div>
+                                                <CardTitle className="text-lg transition-colors group-hover:text-primary">
+                                                    {article.title}
+                                                </CardTitle>
+                                                {article.description && (
+                                                    <CardDescription className="line-clamp-2">
+                                                        {article.description}
+                                                    </CardDescription>
+                                                )}
+                                            </CardHeader>
+                                        </Card>
+                                    </Link>
+                                ))}
+                            </div>
+
+                            {/* ネイティブアフィリエイト (D Phase 4) */}
+                            {nativeBanners.length > 0 && (
+                                <div className="mt-8">
+                                    <NativeAffiliateRow
+                                        title={`「${tag}」関連の書籍・商品`}
+                                        banners={nativeBanners}
+                                        position="tag-native"
+                                        trackingCategory={`tag-${tagKey}`}
+                                    />
+                                </div>
+                            )}
+
+                            <div className="mt-8">
+                                <AdSenseAd format={CONTENT_FOOTER.format} slotId={CONTENT_FOOTER.slotId} />
+                            </div>
+                        </main>
+
+                        {/* 右サイドバー (xl+) — タグ記事一覧の脇に常時配置 */}
+                        <aside className="mt-8 xl:mt-0 xl:block">
+                            <RightRailWidgets />
+                        </aside>
                     </div>
                 )}
-
-                {/* ネイティブアフィリエイト (D Phase 4) */}
-                {nativeBanners.length > 0 && (
-                    <div className="mt-8">
-                        <NativeAffiliateRow
-                            title={`「${tag}」関連の書籍・商品`}
-                            banners={nativeBanners}
-                            position="tag-native"
-                            trackingCategory={`tag-${tagKey}`}
-                        />
-                    </div>
-                )}
-
-                <div className="mt-8">
-                    <AdSenseAd format={CONTENT_FOOTER.format} slotId={CONTENT_FOOTER.slotId} />
-                </div>
             </div>
         </>
     );

--- a/apps/web/src/app/themes/page.tsx
+++ b/apps/web/src/app/themes/page.tsx
@@ -5,6 +5,7 @@ import {
   HeroShell,
   KpiGrid,
   KpiTile,
+  RightRailWidgets,
 } from "@/features/redesign";
 import { ALL_THEMES } from "@/features/theme-dashboard/server";
 
@@ -78,28 +79,37 @@ export default function ThemesPage() {
         </div>
       </HeroShell>
 
-      <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
-        {ALL_THEMES.map((theme) => (
-          <Link
-            key={theme.themeKey}
-            href={`/themes/${theme.themeKey}`}
-            className="block rounded-lg border bg-card p-4 shadow-sm transition-colors hover:bg-accent/50 hover:shadow-md"
-          >
-            <h2 className="text-base font-semibold text-foreground">
-              {theme.title}
-            </h2>
-            <p className="mt-1 text-sm text-muted-foreground line-clamp-2">
-              {theme.description}
-            </p>
-            <p className="mt-2 text-xs text-muted-foreground">
-              {theme.rankingKeys.length} 指標
-            </p>
-          </Link>
-        ))}
-      </div>
+      <div className="xl:grid xl:grid-cols-[minmax(0,1fr)_360px] xl:gap-5 xl:items-start">
+        <main className="min-w-0">
+          <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+            {ALL_THEMES.map((theme) => (
+              <Link
+                key={theme.themeKey}
+                href={`/themes/${theme.themeKey}`}
+                className="block rounded-lg border bg-card p-4 shadow-sm transition-colors hover:bg-accent/50 hover:shadow-md"
+              >
+                <h2 className="text-base font-semibold text-foreground">
+                  {theme.title}
+                </h2>
+                <p className="mt-1 text-sm text-muted-foreground line-clamp-2">
+                  {theme.description}
+                </p>
+                <p className="mt-2 text-xs text-muted-foreground">
+                  {theme.rankingKeys.length} 指標
+                </p>
+              </Link>
+            ))}
+          </div>
 
-      <div className="mt-8">
-        <AdSenseAd format={CONTENT_FOOTER.format} slotId={CONTENT_FOOTER.slotId} />
+          <div className="mt-8">
+            <AdSenseAd format={CONTENT_FOOTER.format} slotId={CONTENT_FOOTER.slotId} />
+          </div>
+        </main>
+
+        {/* 右サイドバー: xl+ で関連 widget + 広告。テーマ依存しない汎用配置 */}
+        <aside className="mt-8 xl:mt-0 xl:block">
+          <RightRailWidgets />
+        </aside>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary

PR #353 で導入した D-System Phase 1 プリミティブを主要 5 ページに適用し、1920px+ ワイド画面の有効活用 + 収益最大化 + サイト内回遊性向上を実現。

## 適用ページ

### A. `/areas/[areaCode]` — 右サイドバー追加 (最高 ROI)

- 旧: 1 カラム main のみ
- 新: xl+ で 2 カラム (main + 360px 右サイドバー)
- 右サイドバーに **その県のふるさと納税** を配置 → 文脈完全一致、CTR 期待大
- TechSchoolPromoCard / AdSense ×2 も同居 (3 重 monetize)

### B. `/category/[categoryKey]` — 既存 256px sidebar を 360px + 強化

- 旧: w-64 (256px) sidebar、新着記事 + AdSense + SurveyCard のみ
- 新: 360px sidebar、TechSchoolPromoCard 追加で 3 重 monetize
- 既存の新着記事 / AdSense / SurveyCard は維持
- independent scroll で全 widget 到達可能

### C. `/themes` — リスト型に右サイドバー追加

- xl+ で 2 カラム化、theme グリッドの脇に RightRailWidgets

### C-2. `/tag/[tagKey]` — 同上

- 記事一覧の脇に RightRailWidgets

### D. `/` (home) — NextUpGrid 追加

- ページ末尾 (フッター AdSense 直前) に「このサイトの主要ページ」3 列 card grid を追加
- 全ランキング / テーマ / 都道府県 / ブログ / 調査 / 検索 への回遊リンク強化

## 期待効果

| ページ | 主な改善 | 期待リフト |
|---|---|---|
| `/areas/{code}` | その県ふるさと納税 above-fold | 楽天 CV +30〜50% |
| `/category/{key}` | TechSchool + 新着記事 sticky | クリック率 +20〜30% |
| `/themes` | サイドバー導入 | AdSense impression +40% |
| `/tag/{key}` | サイドバー導入 | 同上 |
| `/` (home) | NextUpGrid | 平均 PV/session +15〜20% |

## Test plan

- [ ] PC 1920px で全 5 ページの右サイドバーが表示されること
- [ ] サイドバー内 widget (Claude Code 講座 / AdSense / ふるさと納税 / 関連リンク) が全て到達可能
- [ ] モバイル (< xl/lg) で従来通り main 縦並びで全 widget が表示されること
- [ ] `/areas/13000` (東京都) でふるさと納税が東京都の返礼品を表示
- [ ] home ページ末尾に NextUpGrid 6 カードが表示されること

## 関連

- PR #353 (D-System Phase 1 プリミティブ + ブログ α + ふるさと納税 3 段ロジック) で導入したコンポーネントを活用
- マスタープラン: `docs/02_実装計画/d-redesign-master-plan.md`
- デザインシステム真実源: `.claude/design-system/redesign/INDEX.md`

---
_Generated by [Claude Code](https://claude.ai/code/session_0119f68hKHaDjT63XmSwbMdw)_