### PR TITLE
fix: public-phone 記事の published フラグ修正 + 再デプロイ (2026-05-29)

### DIFF
--- a/docs/20_ブログ記事企画/backlog/cloud-plan-2026-05-29.md
+++ b/docs/20_ブログ記事企画/backlog/cloud-plan-2026-05-29.md
@@ -25,6 +25,9 @@ note: トピック dedup 済 / GSC需要起点 上位 5 本を公開済 (2026-05
 >
 > 注: 公衆電話の企画仮説「北海道だけ突出」は実データ(東京#1・北海道#6)と矛盾したため reframe 済。
 > OGP 画像は未生成 (後日 Remotion render)。tags は frontmatter 由来で all.json に直接反映 (sync の list-tags 取りこぼしを回避)。
+>
+> **公開後 fix (2026-05-29)**: public-phone-prefecture-vanishing は執筆時 frontmatter に `published: true` 漏れ → all.json published:false → 本番で not-found。frontmatter / DB / all.json を published:true に修正し再 push。ISR incremental cache は Cloudflare edge purge では消えないため、本 PR の main マージ (再デプロイ) で ISR cache をリセットして解消する。
+> 教訓: 新規記事 frontmatter には `published: true` 必須 (article-writer の必須チェック項目に追加すべき)。
 
 環境制約により DB query 不可。指標は `packages/data-configs/src/metrics/*.ts` (実在 key を検証済)、
 需要は GSC 2026-W21 queries.csv、トレンドははてブ hotentry RSS、affiliate は `plan-blog-affiliate` の


### PR DESCRIPTION
## 概要

新規公開 5 本のうち `public-phone-prefecture-vanishing` が本番で「記事が見つかりません」になる問題の修正 + 再デプロイトリガー。

## 原因

執筆時に frontmatter の **`published: true` が漏れていた**（他 4 本は記載あり）。結果:
- DB `published=0` → all.json `published:false` → 本番でページが notFound

## 対処（済み）

- `.local/r2/.../article.md` の frontmatter に `published: true` 追加
- DB を sync で `published=1` に整合
- R2 `app/blog/all.json` の該当エントリを `published:true` に修正して再 push

## 本 PR（main マージ）の目的

`published:false` 時に一度アクセスされた public-phone は **OpenNext の ISR incremental cache に not-found がキャッシュ**されている。これは Cloudflare の Cache Purge API（edge purge）では消えない別レイヤーのため、**main マージで Cloudflare Pages を再デプロイ → ISR cache をリセット**して正しい記事を表示させる。

修正済み all.json は既に R2 にあるため、再ビルドで public-phone は published:true として正しく描画される。

## 検証状況

- ✅ 他 4 本（inpatient / height / bed-utilization / natto）は本番で正常表示確認済（各 3/3）
- ⏳ public-phone は本 PR マージ後のデプロイで解消予定 → マージ後に検証する

## 教訓（残課題）

- 新規記事 frontmatter に `published: true` を必須化（article-writer の必須チェックに追加すべき）

https://claude.ai/code/session_01N9ypXdknhCoi8ev6utbvVu

---
_Generated by [Claude Code](https://claude.ai/code/session_01N9ypXdknhCoi8ev6utbvVu)_