### PR TITLE
docs: deploy skill stale 参照修正 + develop 乖離ガード + bake 廃止の docs 反映

### DIFF
--- a/.claude/skills/dev/deploy/SKILL.md
+++ b/.claude/skills/dev/deploy/SKILL.md
@@ -34,6 +34,28 @@ git status
 - 未コミットの変更がある場合 → ユーザーに確認して中止
 - 現在のブランチ名を `$CURRENT_BRANCH` として記憶する
 
+#### develop 乖離 / 共有作業コピーの git race チェック（★必須）
+
+複数セッションが同一作業コピー/.git を共有していると `develop` が origin と乖離していることがある（2026-06-01 実際に発生: 並行セッションが develop に blog をコミットし `git pull --ff-only` が失敗）。Step 3 で乖離した develop に merge すると、未検証の他作業を巻き込んでデプロイしてしまう。push 前に確認する:
+
+```bash
+git fetch origin develop main
+git rev-list --left-right --count origin/develop...develop   # 乖離 (ahead behind) を確認
+git status -s | grep -v "^??" | head             # 自分以外の tracked 変更が無いか
+```
+
+- **develop が origin と乖離** している / **並行セッションが develop に commit 中**（想定外の untracked/commit がある）場合は、**Step 3 の develop merge を行わず**、feature ブランチを **`origin/main` に rebase して `feature → main` の PR を直接作る**（`pr-quality-check.yml` は main 宛 PR で発火するため CI は走る）。これにより乖離 develop に触れずに自分の変更だけをクリーンにデプロイできる:
+
+  ```bash
+  git fetch origin main
+  git rebase --onto origin/main <feature の分岐元 SHA> $CURRENT_BRANCH
+  git push -u origin $CURRENT_BRANCH
+  gh pr create --base main --head $CURRENT_BRANCH --title "…" --body "…"
+  ```
+
+  この場合デプロイ後に `develop` が `main` より遅れるので、別途 `main → develop` を取り込んで同期する（並行セッションが落ち着いてから）。
+- develop が origin とクリーン（乖離なし・自分のみ）なら通常どおり Step 3 へ進む。
+
 ### Step 1.5: feature ブランチ化（develop/main にいる場合）
 
 `$CURRENT_BRANCH` が `develop` or `main` の場合、未 push コミットがあるなら **feature ブランチへ移動**する。ブランチ名はユーザーに確認するか `feature/<日時>-<短い要約>` 形式で提案。
@@ -168,8 +190,8 @@ git push origin --delete $CURRENT_BRANCH 2>/dev/null || true  # リモート削�
 - `apps/web/src/middleware.ts` のルール追加・変更（特に 410 / 301 / noindex 分岐）
 - `apps/web/src/app/**/page.tsx` の `generateMetadata` で `robots` / `canonical` を変更
 - `apps/web/src/app/robots.ts` / `sitemap.ts` / `manifest.ts` の変更
-- `apps/web/src/config/gone-*.ts` / `known-*.ts` への追加・削除
-- `apps/web/src/lib/indexable-area-categories.ts` の変更
+- `apps/web/src/config/gone-*.ts` / `known-*.ts` / `legacy-category-keys.ts` への追加・削除
+- `apps/web/src/lib/url-policy.ts` の変更（indexable 判定の SSOT。area / cityCategory / ranking 等）
 
 **理由**: 本番の HTML 200 応答は `Cache-Control: s-maxage=86400` で Cloudflare エッジに最大 24 時間キャッシュされる。middleware ルール変更を即時反映するには Purge が必要。
 

--- a/docs/02_実装計画/d-redesign-master-plan.md
+++ b/docs/02_実装計画/d-redesign-master-plan.md
@@ -403,8 +403,9 @@ W21 セッションで Phase 1 (横幅最大化 + 共通プリミティブ + 右
 
 ### 運用タスク
 
-- `bash .claude/skills/db/sync-snapshots/run.sh --only ranking-download`
-  → CSV/JSON 事前生成ファイルを R2 に push (初回 15-30 分)
+- ~~`run.sh --only ranking-download` で CSV/JSON 事前生成~~ → **廃止 (2026-06-01)**。
+  download は route `/api/ranking/[key]/download` で**オンザフライ生成**に変更（事前 bake は全 metric で
+  1GB 超 / 23K files / timeout のため不採用）。運用タスク不要。詳細: memory `project_ranking_download_onthefly`。
 
 ---
 

--- a/docs/50_Issues/feature-backlog.md
+++ b/docs/50_Issues/feature-backlog.md
@@ -586,16 +586,13 @@ noindex のため SEO 流入は無いが、ブックマーク・直接アクセ�
 - プロトタイプ: `.claude/design-system/redesign/project/compare-option-d.jsx` / `search-option-d.jsx` を参照
 - 工数: 各 2-3 時間
 
-#### C. CSV ダウンロード R2 事前生成の運用反映
+#### C. ~~CSV ダウンロード R2 事前生成の運用反映~~ → 廃止 (2026-06-01, PR #391)
 
-PR #352 で実装した「事前生成ファイル」を本番に反映:
-
-```bash
-bash .claude/skills/db/sync-snapshots/run.sh --only ranking-download
-```
-
-初回生成は ~2,151 metrics × 最大 8 ファイル ≈ 17K files で 15-30 分かかる。
-その後通常の `/sync-snapshots` フルランで差分更新される。
+**事前生成 (bake) は不採用に確定。** 全 ~2,169 metrics × 最大 8 ファイル ≈ 23K files / 1GB 超 /
+CI 45 分 timeout となり、これは Phase 6 が download exporter を削除した理由 (R2 肥大化) そのものだった。
+代わりに route `/api/ranking/[key]/download` で **オンザフライ生成** (R2 観測値 → `getRankingDownloadSeries`
+→ build CSV、SJIS は iconv-lite 動的 import) に変更。運用タスク不要。詳細: memory
+`project_ranking_download_onthefly` / `feedback_check_why_removed_before_reviving`。
 
 #### D. 環境変数の本番設定
 


### PR DESCRIPTION
セッション振り返りで見つかったスキル/ドキュメントの不整合を修正 (markdown のみ・コード変更なし)。

- /deploy SKILL: 削除済み `indexable-area-categories.ts` 参照 → `url-policy.ts` / develop 乖離 git race ガード追加
- docs 2件: 廃止した `--only ranking-download` 事前 bake → オンザフライ生成へ更新

マージは任意のタイミングで (docs のみだがマージで Cloudflare deploy が走ります)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)