### PR TITLE
feat(ads): STRATEGY CAREER バナー+テキストリンク追加 + ランキングサイドバー展開

### DIFF
--- a/apps/web/scripts/affiliate-ads-data.ts
+++ b/apps/web/scripts/affiliate-ads-data.ts
@@ -786,4 +786,204 @@ export const AFFILIATE_ADS: AffiliateAd[] = [
     "createdAt": "2026-03-26 09:01:57",
     "updatedAt": "2026-06-01 00:00:00"
   },
+  // ── STRATEGY CAREER 320×100バナー — 全8カテゴリ blog-bottom (priority 80) ────
+  // エンジニア転職（年収1000万以上・リモート・残業30h以下）
+  {
+    "id": "af_strategy_career_economy_001",
+    "title": "STRATEGY CAREER｜エンジニア転職",
+    "htmlContent": "https://px.a8.net/svt/ejp?a8mat=4B5LK5+5YC2K2+5P1E+5ZEMP",
+    "areaCode": null, "categoryKey": "economy", "locationCode": "blog-bottom",
+    "isActive": true, "priority": 80, "startDate": null, "endDate": null, "targetCategories": null,
+    "adType": "banner",
+    "imageUrl": "https://www29.a8.net/svt/bgt?aid=260601701360&wid=001&eno=01&mid=s00000026573001005000&mc=1",
+    "trackingPixelUrl": "https://www10.a8.net/0.gif?a8mat=4B5LK5+5YC2K2+5P1E+5ZEMP",
+    "width": 320, "height": 100,
+    "createdAt": "2026-06-01 00:00:00", "updatedAt": "2026-06-01 00:00:00"
+  },
+  {
+    "id": "af_strategy_career_labor_001",
+    "title": "STRATEGY CAREER｜エンジニア転職",
+    "htmlContent": "https://px.a8.net/svt/ejp?a8mat=4B5LK5+5YC2K2+5P1E+5ZEMP",
+    "areaCode": null, "categoryKey": "laborwage", "locationCode": "blog-bottom",
+    "isActive": true, "priority": 80, "startDate": null, "endDate": null, "targetCategories": null,
+    "adType": "banner",
+    "imageUrl": "https://www29.a8.net/svt/bgt?aid=260601701360&wid=001&eno=01&mid=s00000026573001005000&mc=1",
+    "trackingPixelUrl": "https://www10.a8.net/0.gif?a8mat=4B5LK5+5YC2K2+5P1E+5ZEMP",
+    "width": 320, "height": 100,
+    "createdAt": "2026-06-01 00:00:00", "updatedAt": "2026-06-01 00:00:00"
+  },
+  {
+    "id": "af_strategy_career_population_001",
+    "title": "STRATEGY CAREER｜エンジニア転職",
+    "htmlContent": "https://px.a8.net/svt/ejp?a8mat=4B5LK5+5YC2K2+5P1E+5ZEMP",
+    "areaCode": null, "categoryKey": "population", "locationCode": "blog-bottom",
+    "isActive": true, "priority": 80, "startDate": null, "endDate": null, "targetCategories": null,
+    "adType": "banner",
+    "imageUrl": "https://www29.a8.net/svt/bgt?aid=260601701360&wid=001&eno=01&mid=s00000026573001005000&mc=1",
+    "trackingPixelUrl": "https://www10.a8.net/0.gif?a8mat=4B5LK5+5YC2K2+5P1E+5ZEMP",
+    "width": 320, "height": 100,
+    "createdAt": "2026-06-01 00:00:00", "updatedAt": "2026-06-01 00:00:00"
+  },
+  {
+    "id": "af_strategy_career_tourism_001",
+    "title": "STRATEGY CAREER｜エンジニア転職",
+    "htmlContent": "https://px.a8.net/svt/ejp?a8mat=4B5LK5+5YC2K2+5P1E+5ZEMP",
+    "areaCode": null, "categoryKey": "tourism", "locationCode": "blog-bottom",
+    "isActive": true, "priority": 80, "startDate": null, "endDate": null, "targetCategories": null,
+    "adType": "banner",
+    "imageUrl": "https://www29.a8.net/svt/bgt?aid=260601701360&wid=001&eno=01&mid=s00000026573001005000&mc=1",
+    "trackingPixelUrl": "https://www10.a8.net/0.gif?a8mat=4B5LK5+5YC2K2+5P1E+5ZEMP",
+    "width": 320, "height": 100,
+    "createdAt": "2026-06-01 00:00:00", "updatedAt": "2026-06-01 00:00:00"
+  },
+  {
+    "id": "af_strategy_career_housing_001",
+    "title": "STRATEGY CAREER｜エンジニア転職",
+    "htmlContent": "https://px.a8.net/svt/ejp?a8mat=4B5LK5+5YC2K2+5P1E+5ZEMP",
+    "areaCode": null, "categoryKey": "construction", "locationCode": "blog-bottom",
+    "isActive": true, "priority": 80, "startDate": null, "endDate": null, "targetCategories": null,
+    "adType": "banner",
+    "imageUrl": "https://www29.a8.net/svt/bgt?aid=260601701360&wid=001&eno=01&mid=s00000026573001005000&mc=1",
+    "trackingPixelUrl": "https://www10.a8.net/0.gif?a8mat=4B5LK5+5YC2K2+5P1E+5ZEMP",
+    "width": 320, "height": 100,
+    "createdAt": "2026-06-01 00:00:00", "updatedAt": "2026-06-01 00:00:00"
+  },
+  {
+    "id": "af_strategy_career_health_001",
+    "title": "STRATEGY CAREER｜エンジニア転職",
+    "htmlContent": "https://px.a8.net/svt/ejp?a8mat=4B5LK5+5YC2K2+5P1E+5ZEMP",
+    "areaCode": null, "categoryKey": "socialsecurity", "locationCode": "blog-bottom",
+    "isActive": true, "priority": 80, "startDate": null, "endDate": null, "targetCategories": null,
+    "adType": "banner",
+    "imageUrl": "https://www29.a8.net/svt/bgt?aid=260601701360&wid=001&eno=01&mid=s00000026573001005000&mc=1",
+    "trackingPixelUrl": "https://www10.a8.net/0.gif?a8mat=4B5LK5+5YC2K2+5P1E+5ZEMP",
+    "width": 320, "height": 100,
+    "createdAt": "2026-06-01 00:00:00", "updatedAt": "2026-06-01 00:00:00"
+  },
+  {
+    "id": "af_strategy_career_energy_001",
+    "title": "STRATEGY CAREER｜エンジニア転職",
+    "htmlContent": "https://px.a8.net/svt/ejp?a8mat=4B5LK5+5YC2K2+5P1E+5ZEMP",
+    "areaCode": null, "categoryKey": "energy", "locationCode": "blog-bottom",
+    "isActive": true, "priority": 80, "startDate": null, "endDate": null, "targetCategories": null,
+    "adType": "banner",
+    "imageUrl": "https://www29.a8.net/svt/bgt?aid=260601701360&wid=001&eno=01&mid=s00000026573001005000&mc=1",
+    "trackingPixelUrl": "https://www10.a8.net/0.gif?a8mat=4B5LK5+5YC2K2+5P1E+5ZEMP",
+    "width": 320, "height": 100,
+    "createdAt": "2026-06-01 00:00:00", "updatedAt": "2026-06-01 00:00:00"
+  },
+  {
+    "id": "af_strategy_career_furusato_001",
+    "title": "STRATEGY CAREER｜エンジニア転職",
+    "htmlContent": "https://px.a8.net/svt/ejp?a8mat=4B5LK5+5YC2K2+5P1E+5ZEMP",
+    "areaCode": null, "categoryKey": "administrativefinancial", "locationCode": "blog-bottom",
+    "isActive": true, "priority": 80, "startDate": null, "endDate": null, "targetCategories": null,
+    "adType": "banner",
+    "imageUrl": "https://www29.a8.net/svt/bgt?aid=260601701360&wid=001&eno=01&mid=s00000026573001005000&mc=1",
+    "trackingPixelUrl": "https://www10.a8.net/0.gif?a8mat=4B5LK5+5YC2K2+5P1E+5ZEMP",
+    "width": 320, "height": 100,
+    "createdAt": "2026-06-01 00:00:00", "updatedAt": "2026-06-01 00:00:00"
+  },
+  // ── STRATEGY CAREER テキストリンク — 全カテゴリキー sidebar-bottom (priority 100) ─
+  // ランキングページサイドバー AffiliateAdSlot で表示。
+  // categoryKey は CATEGORY_AFFILIATE_MAP のキーと完全一致させる（9キー）。
+  {
+    "id": "af_strategy_career_text_economy",
+    "title": "自分らしく働けるエンジニア転職を目指すなら【strategy career】",
+    "htmlContent": "https://px.a8.net/svt/ejp?a8mat=4B5LK5+5YC2K2+5P1E+5YJRM",
+    "areaCode": null, "categoryKey": "economy", "locationCode": "sidebar-bottom",
+    "isActive": true, "priority": 100, "startDate": null, "endDate": null, "targetCategories": null,
+    "adType": "text", "imageUrl": null,
+    "trackingPixelUrl": "https://www13.a8.net/0.gif?a8mat=4B5LK5+5YC2K2+5P1E+5YJRM",
+    "width": null, "height": null,
+    "createdAt": "2026-06-01 00:00:00", "updatedAt": "2026-06-01 00:00:00"
+  },
+  {
+    "id": "af_strategy_career_text_laborwage",
+    "title": "自分らしく働けるエンジニア転職を目指すなら【strategy career】",
+    "htmlContent": "https://px.a8.net/svt/ejp?a8mat=4B5LK5+5YC2K2+5P1E+5YJRM",
+    "areaCode": null, "categoryKey": "laborwage", "locationCode": "sidebar-bottom",
+    "isActive": true, "priority": 100, "startDate": null, "endDate": null, "targetCategories": null,
+    "adType": "text", "imageUrl": null,
+    "trackingPixelUrl": "https://www13.a8.net/0.gif?a8mat=4B5LK5+5YC2K2+5P1E+5YJRM",
+    "width": null, "height": null,
+    "createdAt": "2026-06-01 00:00:00", "updatedAt": "2026-06-01 00:00:00"
+  },
+  {
+    "id": "af_strategy_career_text_population",
+    "title": "自分らしく働けるエンジニア転職を目指すなら【strategy career】",
+    "htmlContent": "https://px.a8.net/svt/ejp?a8mat=4B5LK5+5YC2K2+5P1E+5YJRM",
+    "areaCode": null, "categoryKey": "population", "locationCode": "sidebar-bottom",
+    "isActive": true, "priority": 100, "startDate": null, "endDate": null, "targetCategories": null,
+    "adType": "text", "imageUrl": null,
+    "trackingPixelUrl": "https://www13.a8.net/0.gif?a8mat=4B5LK5+5YC2K2+5P1E+5YJRM",
+    "width": null, "height": null,
+    "createdAt": "2026-06-01 00:00:00", "updatedAt": "2026-06-01 00:00:00"
+  },
+  {
+    "id": "af_strategy_career_text_tourism",
+    "title": "自分らしく働けるエンジニア転職を目指すなら【strategy career】",
+    "htmlContent": "https://px.a8.net/svt/ejp?a8mat=4B5LK5+5YC2K2+5P1E+5YJRM",
+    "areaCode": null, "categoryKey": "tourism", "locationCode": "sidebar-bottom",
+    "isActive": true, "priority": 100, "startDate": null, "endDate": null, "targetCategories": null,
+    "adType": "text", "imageUrl": null,
+    "trackingPixelUrl": "https://www13.a8.net/0.gif?a8mat=4B5LK5+5YC2K2+5P1E+5YJRM",
+    "width": null, "height": null,
+    "createdAt": "2026-06-01 00:00:00", "updatedAt": "2026-06-01 00:00:00"
+  },
+  {
+    "id": "af_strategy_career_text_construction",
+    "title": "自分らしく働けるエンジニア転職を目指すなら【strategy career】",
+    "htmlContent": "https://px.a8.net/svt/ejp?a8mat=4B5LK5+5YC2K2+5P1E+5YJRM",
+    "areaCode": null, "categoryKey": "construction", "locationCode": "sidebar-bottom",
+    "isActive": true, "priority": 100, "startDate": null, "endDate": null, "targetCategories": null,
+    "adType": "text", "imageUrl": null,
+    "trackingPixelUrl": "https://www13.a8.net/0.gif?a8mat=4B5LK5+5YC2K2+5P1E+5YJRM",
+    "width": null, "height": null,
+    "createdAt": "2026-06-01 00:00:00", "updatedAt": "2026-06-01 00:00:00"
+  },
+  {
+    "id": "af_strategy_career_text_socialsecurity",
+    "title": "自分らしく働けるエンジニア転職を目指すなら【strategy career】",
+    "htmlContent": "https://px.a8.net/svt/ejp?a8mat=4B5LK5+5YC2K2+5P1E+5YJRM",
+    "areaCode": null, "categoryKey": "socialsecurity", "locationCode": "sidebar-bottom",
+    "isActive": true, "priority": 100, "startDate": null, "endDate": null, "targetCategories": null,
+    "adType": "text", "imageUrl": null,
+    "trackingPixelUrl": "https://www13.a8.net/0.gif?a8mat=4B5LK5+5YC2K2+5P1E+5YJRM",
+    "width": null, "height": null,
+    "createdAt": "2026-06-01 00:00:00", "updatedAt": "2026-06-01 00:00:00"
+  },
+  {
+    "id": "af_strategy_career_text_energy",
+    "title": "自分らしく働けるエンジニア転職を目指すなら【strategy career】",
+    "htmlContent": "https://px.a8.net/svt/ejp?a8mat=4B5LK5+5YC2K2+5P1E+5YJRM",
+    "areaCode": null, "categoryKey": "energy", "locationCode": "sidebar-bottom",
+    "isActive": true, "priority": 100, "startDate": null, "endDate": null, "targetCategories": null,
+    "adType": "text", "imageUrl": null,
+    "trackingPixelUrl": "https://www13.a8.net/0.gif?a8mat=4B5LK5+5YC2K2+5P1E+5YJRM",
+    "width": null, "height": null,
+    "createdAt": "2026-06-01 00:00:00", "updatedAt": "2026-06-01 00:00:00"
+  },
+  {
+    "id": "af_strategy_career_text_administrativefinancial",
+    "title": "自分らしく働けるエンジニア転職を目指すなら【strategy career】",
+    "htmlContent": "https://px.a8.net/svt/ejp?a8mat=4B5LK5+5YC2K2+5P1E+5YJRM",
+    "areaCode": null, "categoryKey": "administrativefinancial", "locationCode": "sidebar-bottom",
+    "isActive": true, "priority": 100, "startDate": null, "endDate": null, "targetCategories": null,
+    "adType": "text", "imageUrl": null,
+    "trackingPixelUrl": "https://www13.a8.net/0.gif?a8mat=4B5LK5+5YC2K2+5P1E+5YJRM",
+    "width": null, "height": null,
+    "createdAt": "2026-06-01 00:00:00", "updatedAt": "2026-06-01 00:00:00"
+  },
+  {
+    "id": "af_strategy_career_text_landweather",
+    "title": "自分らしく働けるエンジニア転職を目指すなら【strategy career】",
+    "htmlContent": "https://px.a8.net/svt/ejp?a8mat=4B5LK5+5YC2K2+5P1E+5YJRM",
+    "areaCode": null, "categoryKey": "landweather", "locationCode": "sidebar-bottom",
+    "isActive": true, "priority": 100, "startDate": null, "endDate": null, "targetCategories": null,
+    "adType": "text", "imageUrl": null,
+    "trackingPixelUrl": "https://www13.a8.net/0.gif?a8mat=4B5LK5+5YC2K2+5P1E+5YJRM",
+    "width": null, "height": null,
+    "createdAt": "2026-06-01 00:00:00", "updatedAt": "2026-06-01 00:00:00"
+  },
 ];

--- a/apps/web/src/app/ranking/[rankingKey]/page.tsx
+++ b/apps/web/src/app/ranking/[rankingKey]/page.tsx
@@ -54,7 +54,7 @@ import {
 import { isOk } from "@stats47/types";
 import { getInitialMapTileUrls } from "@stats47/visualization/leaflet/constants";
 
-import { resolveAffiliateBanners } from "@/features/ads/server";
+import { AffiliateAdSlot, resolveAffiliateBanners } from "@/features/ads/server";
 import { findCategoryByKey } from "@/features/category/server";
 import {
   generateRankingBreadcrumbStructuredData,
@@ -329,6 +329,7 @@ export default async function RankingKeyPage({
             <RankingItemsSidebar rankingKey={rankingKey} areaType={areaType} categoryKey={rankingItem.categoryKey} />
             <AdSenseAd format={RANKING_SIDEBAR_TOP.format} slotId={RANKING_SIDEBAR_TOP.slotId} />
             <RelatedArticlesCard rankingKey={rankingKey} areaType={areaType} />
+            <AffiliateAdSlot categoryKey={rankingItem.categoryKey ?? ""} position="sidebar" />
             <SurveyCard surveys={allSurveys.map((s: { id: string; name: string }) => ({ id: s.id, name: s.name }))} currentSurveyId={rankingItem.surveyId ?? undefined} />
             <PortStatisticsMapCard rankingKey={rankingKey} groupKey={rankingItem.groupKey} />
           </Suspense>

--- a/apps/web/src/features/ads/__tests__/resolve-affiliate-ad.test.ts
+++ b/apps/web/src/features/ads/__tests__/resolve-affiliate-ad.test.ts
@@ -49,6 +49,7 @@ describe("resolveAffiliateAd", () => {
     expect(result).toEqual({
       title: "テスト広告",
       href: "https://example.com/ad",
+      trackingPixelUrl: null,
     });
   });
 });

--- a/apps/web/src/features/ads/components/AffiliateAdSlot.tsx
+++ b/apps/web/src/features/ads/components/AffiliateAdSlot.tsx
@@ -69,6 +69,11 @@ export async function AffiliateAdSlot({
             className={`shrink-0 ${theme?.icon ?? "text-muted-foreground/70"}`}
           />
         </TrackedAffiliateLink>
+        {ad.trackingPixelUrl && (
+          // eslint-disable-next-line @next/next/no-img-element
+          <img src={ad.trackingPixelUrl} width={1} height={1} alt=""
+            className="absolute opacity-0 pointer-events-none" />
+        )}
       </div>
     );
   }

--- a/apps/web/src/features/ads/services/resolve-affiliate-ad.ts
+++ b/apps/web/src/features/ads/services/resolve-affiliate-ad.ts
@@ -13,6 +13,7 @@ import type { AffiliateLocationCode } from "../types";
 export interface ResolvedAffiliateAd {
   title: string;
   href: string;
+  trackingPixelUrl?: string | null;
 }
 
 export interface ResolvedAffiliateBanner {
@@ -38,6 +39,7 @@ export async function resolveAffiliateAd(
   return {
     title: dbAd.title,
     href: dbAd.htmlContent,
+    trackingPixelUrl: dbAd.trackingPixelUrl,
   };
 }
 

--- a/apps/web/src/features/blog/components/article-affiliate-banner.tsx
+++ b/apps/web/src/features/blog/components/article-affiliate-banner.tsx
@@ -6,19 +6,19 @@ interface ArticleAffiliateBannerProps {
 }
 
 /**
- * 記事タグキーからカテゴリを判定し、DB からバナー広告を最大2つ表示。
- * PC: 2列並び / モバイル: 1つだけ表示。
+ * 記事タグキーからカテゴリを判定し、DB からバナー広告を最大3つ表示。
+ * PC: 3列並び / モバイル: 1つだけ表示。
  * バナー未登録のカテゴリの場合は何も表示しない。
  */
 export async function ArticleAffiliateBanner({ tagKeys }: ArticleAffiliateBannerProps) {
-  const banners = await resolveAffiliateBanners(tagKeys, 2);
+  const banners = await resolveAffiliateBanners(tagKeys, 3);
 
   if (banners.length === 0) return null;
 
   return (
     <div className="mt-6">
       <div className="rounded-xl border border-border bg-card p-4">
-        <div className="grid grid-cols-1 md:grid-cols-2 gap-4 justify-items-center">
+        <div className="grid grid-cols-1 md:grid-cols-3 gap-4 justify-items-center">
           {banners.map((banner, i) => (
             <div key={i} className={`flex justify-center ${i > 0 ? "hidden md:flex" : ""}`}>
               <BannerAd


### PR DESCRIPTION
## 概要

A8.net「STRATEGY CAREER」(エンジニア転職、年収1000万以上・リモート) を追加し、最大インプレッション獲得を狙う。バナー(320×100) + テキストリンクの2形式を全カテゴリに展開し、ランキングサイドバー (~500P) でのテキスト広告表示を初めて実現する。

## 変更詳細

### データ追加 (17件)

| 種別 | locationCode | categoryKey | priority | 件数 |
|---|---|---|---|---|
| 320×100バナー | blog-bottom | 全8カテゴリ | 80 | 8 |
| テキストリンク | sidebar-bottom | 全9キー(CATEGORY_AFFILIATE_MAP) | 100 | 9 |

バナー表示順: 合宿免許(100) → AI Agent Camp(90) → **STRATEGY CAREER(80)** の3枚目

### コード変更 (4ファイル)

- **article-affiliate-banner.tsx**: limit 2→3 / grid 2col→3col — 記事フッター3枚同時表示
- **ranking/[rankingKey]/page.tsx**: `AffiliateAdSlot` をサイドバーに追加 → 全ランキングページでテキスト広告が出る (テキスト広告なし→AdSense フォールバック)
- **resolve-affiliate-ad.ts**: `ResolvedAffiliateAd.trackingPixelUrl` を追加
- **AffiliateAdSlot.tsx**: tracking pixel 1×1 img を render (A8 インプレッション計測)

### 展開先まとめ

| 面 | インプレッション機会 |
|---|---|
| ブログ記事フッター (全カテゴリ) | 3枚目に表示 |
| ランキングページサイドバー (~500P) | テキストリンクが初めて表示 |
| カテゴリ/タグ/surveyページ (limit=4) | 3枚目以降に表示 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)