### PR TITLE
perf(cwv): ranking mobile LCP 修正 — map tile preload を lg以上に限定

### DIFF
--- a/apps/web/src/app/ranking/[rankingKey]/page.tsx
+++ b/apps/web/src/app/ranking/[rankingKey]/page.tsx
@@ -256,10 +256,13 @@ export default async function RankingKeyPage({
   //     この Server Component 内でレンダリングし ReactNode として注入する。
   //   - RankingKeyPageClient 内の Client Component（RankingHighlights 等）は
   //     Client Component 同士なので直接 import して使用している。
-  // LCP 対策（#101 EXP-003）:
-  // ランキング詳細ページの LCP 要素は Leaflet map の中心 tile。
-  // Leaflet JS 実行後に tile URL が判明すると resourceLoadDelay が 4.3s と支配的なため、
-  // 初期ビュー (日本中心・zoom 5) の 4 タイルを SSR で preload して LCP を短縮する。
+  // LCP 対策（#101 EXP-003 → EXP-006 改良）:
+  // デスクトップ: LCP 要素 = Leaflet map 中心 tile。
+  //   Leaflet JS 実行後に tile URL が判明すると resourceLoadDelay が 4.3s と支配的なため
+  //   初期ビュー (日本中心・zoom 5) の 4 タイルを SSR で preload → LCP 短縮。
+  // モバイル: デフォルトタブは table（地図は非表示）のため tile preload が逆効果。
+  //   fetchPriority="high" の tile が帯域を専有し、可視コンテンツ(table 行/見出し)の
+  //   ロードを遅延させ LCP 9s を引き起こす。media query でデスクトップ限定にする。
   const initialTileUrls = getInitialMapTileUrls({ theme: "light_all", retina: true });
 
   return (
@@ -273,6 +276,7 @@ export default async function RankingKeyPage({
         type="application/ld+json"
         dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumbStructuredData) }}
       />
+      {/* map tile preload: lg(1024px)以上のみ。モバイルは table がデフォルト表示のため不要 */}
       {initialTileUrls.map((url, idx) => (
         <link
           key={url}
@@ -280,6 +284,7 @@ export default async function RankingKeyPage({
           as="image"
           href={url}
           fetchPriority={idx === 0 ? "high" : "auto"}
+          media="(min-width: 1024px)"
         />
       ))}
 


### PR DESCRIPTION
## 問題

`/ranking/[rankingKey]` のモバイル LCP が **9,079ms**（PSI 2026-05-30 計測）。×100インプレッション計画 Phase 0 の最大ボトルネック。

## 原因

EXP-003（PR #101 相当）で追加した map tile preload が **モバイルでも無条件に実行**されていた。

```tsx
// Before: media 指定なし → mobile でも tile 4枚を fetchPriority="high" でダウンロード
{initialTileUrls.map((url, idx) => (
  <link rel="preload" as="image" href={url} fetchPriority={idx === 0 ? "high" : "auto"} />
))}
```

モバイルはデフォルトタブが `table`（地図は非表示）のため、この tile fetch は:
- **帯域を専有**（fetchPriority="high" が可視コンテンツより優先される）
- **LCP を悪化**（実際に表示される table 行・見出しのロードを遅延）

## 修正

```tsx
// After: lg(1024px)以上でのみ preload
<link
  rel="preload" as="image" href={url}
  fetchPriority={idx === 0 ? "high" : "auto"}
  media="(min-width: 1024px)"   ← 追加
/>
```

デスクトップ（lg以上）では map がサイドバーに表示されるため従来通り preload を維持。

## 期待効果（EXP-006）

| 指標 | Before | After(予測) |
|---|---|---|
| Mobile LCP | 9,079ms | ~4,000ms |
| Desktop LCP | 1,811ms | 変化なし |
| 対象ページ | ranking 1,992P | 全件 |

PSI 計測で 4 週後（2026-07-01）に効果検証。

## 影響範囲

- `apps/web/src/app/ranking/[rankingKey]/page.tsx` 1 ファイルのみ
- SSG/SSR の挙動変化なし（`<link>` タグの属性追加のみ）

🤖 Generated with [Claude Code](https://claude.com/claude-code)