### PR TITLE
refactor(flow): flow JSON を R2 出力に (PR #1/2: 非破壊・パイプライン)

### DIFF
--- a/.claude/skills/db/sync-snapshots/run.sh
+++ b/.claude/skills/db/sync-snapshots/run.sh
@@ -40,6 +40,8 @@ declare -a TASKS=(
   "fishing-ports|apps/web/scripts/export-fishing-ports-snapshot.ts"
   "port-statistics|apps/web/scripts/export-port-statistics-snapshot.ts"
   "station-passengers|apps/web/scripts/export-station-passengers-snapshot.ts"
+  "migration-flow|apps/web/scripts/export-migration-flow-r2.ts"
+  "finance-flow|apps/web/scripts/generate-finance-flow.ts"
 )
 
 run_task() {

--- a/.github/workflows/commute-flow-ingest.yml
+++ b/.github/workflows/commute-flow-ingest.yml
@@ -1,17 +1,16 @@
-name: 🚇 Commute-flow Ingest (e-Stat → JSON)
+name: 🚇 Commute-flow Ingest (e-Stat → R2)
 
 # 国勢調査「従業地・通学地集計」(statsDataId 0003454526) から通勤 O-D を取得し、
-# 47 県分の per-prefecture JSON (apps/web/public/commute-flow/{NN}.json) を生成する。
+# 47 県分の per-prefecture JSON を R2 (app/commute-flow/{NN}.json) に反映する。
 #
-# e-Stat APP_ID は CI 専任 (secrets.NEXT_PUBLIC_ESTAT_APP_ID) のため取り込みは CI で行う。
-# 次元コードは未検証 → まず dry_run=true で CLASS_INF の自動検出ログを確認してから本実行する。
-# 生成 JSON は artifact で持ち帰り、Web feature と同じ PR でコミットする (git 直 push しない)。
+# e-Stat APP_ID は CI 専任 (secrets.NEXT_PUBLIC_ESTAT_APP_ID)。次元コードは名称から自動検出。
+# 国勢調査は5年に1回 → 低頻度。まず dry_run=true で検出ログを確認してから本実行する。
 
 on:
   workflow_dispatch:
     inputs:
       dry_run:
-        description: "true: 次元検出ログのみ (JSON 出力しない)"
+        description: "true: 次元検出ログのみ (R2 反映しない)"
         required: false
         default: "true"
 
@@ -20,6 +19,12 @@ permissions:
 
 env:
   NEXT_PUBLIC_ESTAT_APP_ID: ${{ secrets.NEXT_PUBLIC_ESTAT_APP_ID }}
+  R2_PUBLIC_FETCH_URL: https://storage.stats47.jp
+  NODE_OPTIONS: "--conditions react-server"
+  R2_S3_ENDPOINT: https://${{ secrets.CLOUDFLARE_ACCOUNT_ID }}.r2.cloudflarestorage.com
+  R2_ACCESS_KEY_ID: ${{ secrets.CLOUDFLARE_R2_ACCESS_KEY_ID }}
+  R2_SECRET_ACCESS_KEY: ${{ secrets.CLOUDFLARE_R2_SECRET_ACCESS_KEY }}
+  CLOUDFLARE_R2_BUCKET_NAME: stats47
 
 jobs:
   ingest:
@@ -47,13 +52,10 @@ jobs:
           else
             npx tsx packages/data-configs/scripts/ingest-commute-flow.ts
             echo "--- 生成数 ---"
-            ls apps/web/public/commute-flow/*.json | wc -l
+            ls .local/r2/app/commute-flow/*.json | wc -l
           fi
 
-      - name: ⬆️ Upload commute-flow JSON
+      - name: ☁️ Push to R2 (app/commute-flow)
         if: inputs.dry_run != 'true'
-        uses: actions/upload-artifact@v4
-        with:
-          name: commute-flow-json
-          path: apps/web/public/commute-flow/*.json
-          if-no-files-found: error
+        run: |
+          npx tsx packages/r2-storage/src/scripts/diff-push-r2.ts --prefix app/commute-flow

--- a/apps/web/scripts/export-migration-flow-r2.ts
+++ b/apps/web/scripts/export-migration-flow-r2.ts
@@ -1,0 +1,121 @@
+/**
+ * 人口移動フロー per-prefecture JSON を R2 (app/migration-flow/) に出力する exporter。
+ *
+ * - per-pref O-D: R2 観測値 `app/stats/population-migration-inter-prefecture/migration-flow-{year}.json`
+ *   を `readMigrationFlow` で読み、focus 形式 (partners/totals) に集約 → `.local/r2/app/migration-flow/{NN}.json`
+ * - municipalities: R2 に観測値が無い legacy snapshot のため、既存
+ *   `apps/remotion/public/migration-flow/municipalities/{NN}.json` (Remotion 用に残す canonical snapshot)
+ *   をそのまま `.local/r2/app/migration-flow/municipalities/{NN}.json` に seed
+ *
+ * R2 反映: diff-push-r2 --prefix app/migration-flow (CI)。
+ *
+ * 実行: R2_PUBLIC_FETCH_URL=https://storage.stats47.jp NODE_OPTIONS='--conditions react-server' \
+ *   npx tsx apps/web/scripts/export-migration-flow-r2.ts
+ */
+import { copyFileSync, existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+import { readMigrationFlow } from "@stats47/stats-r2/readers";
+
+const METRIC_KEY = "population-migration-inter-prefecture";
+const REPO_ROOT = resolve(__dirname, "../../..");
+const OUT_DIR = resolve(REPO_ROOT, ".local/r2/app/migration-flow");
+const MUNI_SRC_DIR = resolve(REPO_ROOT, "apps/remotion/public/migration-flow/municipalities");
+const MUNI_OUT_DIR = resolve(OUT_DIR, "municipalities");
+const PREF_NET_SRC = resolve(REPO_ROOT, "apps/remotion/public/migration-flow");
+
+function loadPrefNames(): Map<string, string> {
+  const raw = JSON.parse(
+    readFileSync(resolve(REPO_ROOT, "packages/area/src/data/prefectures.json"), "utf8"),
+  ) as Array<{ prefCode: string; prefName: string }>;
+  return new Map(raw.map((p) => [p.prefCode, p.prefName]));
+}
+
+interface FocusFile {
+  focusCode: string;
+  focusName: string;
+  year: number;
+  source: string;
+  partners: { code: string; name: string; inflow: number; outflow: number; net: number }[];
+  totals: { inflow: number; outflow: number; net: number };
+}
+
+async function resolveLatestYear(): Promise<number> {
+  // 引数 or 最新年を探索 (新しい順に試す)
+  const argYear = process.argv.find((a) => /^--year=\d{4}$/.test(a));
+  if (argYear) return Number(argYear.split("=")[1]);
+  for (let y = 2026; y >= 2018; y--) {
+    const p = await readMigrationFlow(METRIC_KEY, y);
+    if (p && p.rows.length) return y;
+  }
+  throw new Error("migration-flow 観測値が見つかりません (R2)");
+}
+
+async function main(): Promise<void> {
+  const year = await resolveLatestYear();
+  const payload = await readMigrationFlow(METRIC_KEY, year);
+  if (!payload) throw new Error(`no migration-flow data for ${year}`);
+  console.log(`migration-flow year=${year} rows=${payload.rows.length}`);
+
+  const prefNames = loadPrefNames();
+  mkdirSync(OUT_DIR, { recursive: true });
+
+  let written = 0;
+  for (let i = 1; i <= 47; i++) {
+    const code = String(i).padStart(2, "0");
+    const area = `${code}000`;
+    // focus F の partner = toPrefCode === F の行 (inflow=partner→F, outflow=F→partner)
+    const partners = payload.rows
+      .filter((r) => r.toPrefCode === area && r.fromPrefCode !== area)
+      .map((r) => ({
+        code: r.fromPrefCode.slice(0, 2),
+        name: prefNames.get(r.fromPrefCode) ?? "",
+        inflow: r.inflow,
+        outflow: r.outflow,
+        net: r.net,
+      }))
+      .sort((a, b) => b.inflow - a.inflow);
+    const ti = partners.reduce((s, p) => s + p.inflow, 0);
+    const to = partners.reduce((s, p) => s + p.outflow, 0);
+    const focus: FocusFile = {
+      focusCode: code,
+      focusName: prefNames.get(area) ?? area,
+      year,
+      source: `e-Stat 住民基本台帳人口移動報告 (統計表 0003423613)`,
+      partners,
+      totals: { inflow: ti, outflow: to, net: ti - to },
+    };
+    writeFileSync(resolve(OUT_DIR, `${code}.json`), JSON.stringify(focus));
+    written++;
+  }
+  console.log(`✅ per-pref: wrote ${written} to ${OUT_DIR}`);
+
+  // municipalities: legacy snapshot を seed
+  if (existsSync(MUNI_SRC_DIR)) {
+    mkdirSync(MUNI_OUT_DIR, { recursive: true });
+    let muni = 0;
+    for (let i = 1; i <= 47; i++) {
+      const code = String(i).padStart(2, "0");
+      const src = resolve(MUNI_SRC_DIR, `${code}.json`);
+      if (existsSync(src)) {
+        copyFileSync(src, resolve(MUNI_OUT_DIR, `${code}.json`));
+        muni++;
+      }
+    }
+    console.log(`✅ municipalities: seeded ${muni} to ${MUNI_OUT_DIR}`);
+  } else {
+    console.warn(`⚠️ municipalities snapshot not found at ${MUNI_SRC_DIR}`);
+  }
+
+  // pref-net (注目県の純移動一覧、あれば seed)
+  const prefNetSrc = resolve(PREF_NET_SRC, `pref-net-${year}.json`);
+  if (existsSync(prefNetSrc)) {
+    copyFileSync(prefNetSrc, resolve(OUT_DIR, `pref-net-${year}.json`));
+    console.log(`✅ pref-net-${year}.json seeded`);
+  }
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/apps/web/scripts/generate-finance-flow.ts
+++ b/apps/web/scripts/generate-finance-flow.ts
@@ -13,7 +13,8 @@ import { resolve } from "node:path";
 
 import { readStatsValues } from "@stats47/stats-r2/readers";
 
-const OUT_DIR = resolve(__dirname, "../public/finance-flow");
+// R2 SSOT: ローカル R2 FS tier に出力 → diff-push-r2 --prefix app/finance-flow で R2 反映
+const OUT_DIR = resolve(__dirname, "../../../.local/r2/app/finance-flow");
 
 /** 歳入の財源 (金額メトリクス) */
 const REVENUE: ReadonlyArray<{ metric: string; name: string }> = [

--- a/packages/data-configs/scripts/ingest-commute-flow.ts
+++ b/packages/data-configs/scripts/ingest-commute-flow.ts
@@ -16,7 +16,8 @@ import { resolve } from "node:path";
 
 const STATS_DATA_ID = "0003454526";
 const REPO_ROOT = resolve(__dirname, "../../..");
-const OUT_DIR = resolve(REPO_ROOT, "apps/web/public/commute-flow");
+// R2 SSOT: ローカル R2 FS tier に出力 → diff-push-r2 --prefix app/commute-flow で R2 反映
+const OUT_DIR = resolve(REPO_ROOT, ".local/r2/app/commute-flow");
 const DRY_RUN = process.argv.includes("--dry-run");
 
 interface ClassItem {


### PR DESCRIPTION
## 概要 (2-PR の1本目・非破壊)

`apps/web/public/` に git tracked されていた3種の flow JSON (migration/commute/finance) が doc19 正典「本番は R2 snapshot のみ読む」に違反している問題の修正。本 PR は **データパイプラインのみ** で、出力先を R2 に変更し sync-snapshots/CI で R2 push する。**public/ JSON は残すため非破壊**(Web 読み取りの切替・public 削除は PR #2)。

## 変更
- `generate-finance-flow.ts` / `ingest-commute-flow.ts`: 出力先 `apps/web/public/` → `.local/r2/app/<x>-flow/`
- **新規** `export-migration-flow-r2.ts`: R2 観測値 (`readMigrationFlow`) から per-pref O-D を再生成（東京/大阪/北海道で既存 public と **partners・totals 完全一致** を検証）。municipalities は legacy snapshot を seed
- `sync-snapshots/run.sh`: `migration-flow` / `finance-flow` を TASKS に登録
- `commute-flow-ingest.yml`: artifact → R2 push (`diff-push-r2 --prefix app/commute-flow`)

## マージ後の手順
1. `gh workflow run sync-snapshots.yml` → R2 に `app/{migration,finance}-flow/` 配置
2. `gh workflow run commute-flow-ingest.yml -f dry_run=false` → R2 に `app/commute-flow/` 配置
3. `curl https://storage.stats47.jp/app/commute-flow/13.json` で 200 確認
4. → PR #2 (API route + public 削除)

🤖 Generated with [Claude Code](https://claude.com/claude-code)