### PR TITLE
fix(seo): タイトル double-suffix を3ページで修正 (SEO-TITLE-FIX-01 残件)

### DIFF
--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -49,7 +49,7 @@ export async function generateMetadata(): Promise<Metadata> {
   const baseUrl =
     process.env.NEXT_PUBLIC_BASE_URL || "https://stats47.jp";
 
-  const title = "統計で見る都道府県 | 47都道府県ランキング・データ比較";
+  const title = { absolute: "統計で見る都道府県 | 47都道府県ランキング・データ比較" };
   const description =
     "あなたの県は何位？年収・人口・消費量から教育・医療まで、1,800以上の統計で47都道府県をランキング。地図やグラフで地域の特徴をわかりやすく可視化します。";
 

--- a/apps/web/src/app/tag/[tagKey]/page.tsx
+++ b/apps/web/src/app/tag/[tagKey]/page.tsx
@@ -52,7 +52,7 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
     const articles = await listArticleSummariesByTagKey(tagKey, 2);
     const indexable = articles.length >= 2;
 
-    const title = `「${tag}」の記事一覧 | ブログ | stats47`;
+    const title = `「${tag}」タグの記事一覧`;
     const description = `「${tag}」タグが付いた都道府県統計ブログの記事一覧。`;
 
     return {

--- a/apps/web/src/app/themes/page.tsx
+++ b/apps/web/src/app/themes/page.tsx
@@ -16,7 +16,7 @@ import type { Metadata } from "next";
 
 
 export function generateMetadata(): Metadata {
-  const title = "テーマダッシュボード一覧 - 統計で見る都道府県";
+  const title = "テーマダッシュボード一覧";
   const description =
     "少子高齢化・労働・医療・観光・物価・外国人など、テーマ別に都道府県の統計データをダッシュボードで比較分析";
   return {


### PR DESCRIPTION
## 概要

PR #334 で 31 ページを修正したが、以下 3 ページが残存していたため修正。

## 修正内容

| ページ | 修正前 (SERP 表示) | 修正後 |
|---|---|---|
| `/themes` | テーマダッシュボード一覧 - 統計で見る都道府県 \| 統計で見る都道府県 | テーマダッシュボード一覧 \| 統計で見る都道府県 |
| `/tag/[tagKey]` | 「タグ」の記事一覧 \| ブログ \| stats47 \| 統計で見る都道府県 | 「タグ」タグの記事一覧 \| 統計で見る都道府県 |
| `/` (home) | 統計で見る都道府県 \| 47都道府県ランキング・データ比較 \| 統計で見る都道府県 | 統計で見る都道府県 \| 47都道府県ランキング・データ比較 (`absolute` でtemplate bypass) |

## 改善効果

- タイトル文字数が SERP 表示上限 (60文字) 以内に収まる
- 重複キーワードが消え CTR 改善を期待
- SEO-TITLE-FIX-01 (docs/05_改善ログ/gsc.md) を完了

🤖 Generated with [Claude Code](https://claude.com/claude-code)