### PR TITLE
perf(cwv): Sankey placeholder の高さ予約を実SVG比率に修正 (CLS 0.5→<0.1)

### DIFF
--- a/apps/web/src/features/commute-flow/components/CommuteSankey.tsx
+++ b/apps/web/src/features/commute-flow/components/CommuteSankey.tsx
@@ -77,14 +77,14 @@ export function CommuteSankey({ code, initialData }: Props) {
 
   if (errored === code) {
     return (
-      <div className="flex aspect-[3/2] w-full items-center justify-center rounded-md border bg-slate-50 text-sm text-slate-500 dark:bg-slate-900">
+      <div className="flex aspect-[100/73] w-full items-center justify-center rounded-md border bg-slate-50 text-sm text-slate-500 dark:bg-slate-900">
         データを読み込めませんでした。
       </div>
     );
   }
   if (!view) {
     return (
-      <div className="flex aspect-[3/2] w-full items-center justify-center rounded-md border bg-slate-50 text-sm text-slate-500 dark:bg-slate-900">
+      <div className="flex aspect-[100/73] w-full items-center justify-center rounded-md border bg-slate-50 text-sm text-slate-500 dark:bg-slate-900">
         読み込み中…
       </div>
     );

--- a/apps/web/src/features/finance-flow/components/FinanceSankey.tsx
+++ b/apps/web/src/features/finance-flow/components/FinanceSankey.tsx
@@ -57,14 +57,14 @@ export function FinanceSankey({ code, initialData }: Props) {
 
   if (errored === code) {
     return (
-      <div className="flex aspect-[3/2] w-full items-center justify-center rounded-md border bg-slate-50 text-sm text-slate-500 dark:bg-slate-900">
+      <div className="flex aspect-[100/73] w-full items-center justify-center rounded-md border bg-slate-50 text-sm text-slate-500 dark:bg-slate-900">
         データを読み込めませんでした。
       </div>
     );
   }
   if (!ready || !data) {
     return (
-      <div className="flex aspect-[3/2] w-full items-center justify-center rounded-md border bg-slate-50 text-sm text-slate-500 dark:bg-slate-900">
+      <div className="flex aspect-[100/73] w-full items-center justify-center rounded-md border bg-slate-50 text-sm text-slate-500 dark:bg-slate-900">
         読み込み中…
       </div>
     );

--- a/apps/web/src/features/migration-flow/components/MigrationSankey.tsx
+++ b/apps/web/src/features/migration-flow/components/MigrationSankey.tsx
@@ -82,14 +82,14 @@ export function MigrationSankey({ code, initialData }: Props) {
 
   if (errored === code) {
     return (
-      <div className="flex aspect-[3/2] w-full items-center justify-center rounded-md border bg-slate-50 text-sm text-slate-500 dark:bg-slate-900">
+      <div className="flex aspect-[100/73] w-full items-center justify-center rounded-md border bg-slate-50 text-sm text-slate-500 dark:bg-slate-900">
         データを読み込めませんでした。
       </div>
     );
   }
   if (!view) {
     return (
-      <div className="flex aspect-[3/2] w-full items-center justify-center rounded-md border bg-slate-50 text-sm text-slate-500 dark:bg-slate-900">
+      <div className="flex aspect-[100/73] w-full items-center justify-center rounded-md border bg-slate-50 text-sm text-slate-500 dark:bg-slate-900">
         読み込み中…
       </div>
     );


### PR DESCRIPTION
## 概要

`/themes/[themeSlug]` ダッシュボードページの致命的な CLS（`population-dynamics` 0.514 / `local-economy` 0.530）を修正する。

## 原因

`MigrationSankey` / `CommuteSankey` / `FinanceSankey` のローディング placeholder が `aspect-[3/2]`（= 1.5）だが、実際の `HubSankey` は `viewBox 1000 × 最大730`（= 1000/730 ≈ **1.37**）で描画される。

クライアントの `fetch('/api/flow/...')` 完了時に placeholder → 実 SVG へ差し替わると、SVG が placeholder より**高くなり下方シフト**が発生。`population-dynamics` は migration + commute の2図を載せるためシフトが倍加し CLS 0.5 に達していた。

## 修正

3つの Sankey の placeholder アスペクト比を `aspect-[3/2]` → `aspect-[100/73]`（HubSankey の `VIEW_W=1000 / viewH最大=70+616+44=730`）に統一。データ到着前後で予約高さが一致し、シフトをほぼ排除する。

```diff
- <div className="flex aspect-[3/2] w-full ...">
+ <div className="flex aspect-[100/73] w-full ...">
```

## 想定効果

| ページ | CLS Before | CLS After(予測) |
|---|---|---|
| /themes/population-dynamics | 0.514 | < 0.1 |
| /themes/local-economy | 0.530 | < 0.1 |

4週後（2026-07-01）PSI で検証。LCP（map 由来 8s）は別途対応。

## 影響範囲

flow 系 Sankey 3コンポーネントの placeholder 1属性のみ（各2箇所、計6行）。ロジック・描画は不変。

🤖 Generated with [Claude Code](https://claude.com/claude-code)