### PR TITLE
feat(seo): ranking Dataset 構造化データ強化 + category→area 内部リンク追加

### DIFF
--- a/apps/web/src/app/category/[categoryKey]/page.tsx
+++ b/apps/web/src/app/category/[categoryKey]/page.tsx
@@ -8,6 +8,7 @@
 import Link from "next/link";
 import { notFound } from "next/navigation";
 
+import { fetchPrefectures, REGIONS } from "@stats47/area";
 import {
   readRankingValuesFromR2,
   readTopRankingValuesBatchFromR2,
@@ -206,6 +207,10 @@ export default async function CategoryPage({ params }: PageProps) {
 
   const r2Url = process.env.NEXT_PUBLIC_R2_PUBLIC_URL || "https://storage.stats47.jp";
 
+  // 都道府県プロフィール (/areas/[code]) への内部リンク用 (静的・同期読み取り。SSG-safe)
+  const prefectures = fetchPrefectures();
+  const prefMap = new Map(prefectures.map((p) => [p.prefCode, p]));
+
   if (rankingItems.length === 0) {
     notFound();
   }
@@ -309,6 +314,45 @@ export default async function CategoryPage({ params }: PageProps) {
               />
             </section>
           )}
+
+          {/* 47都道府県から探す (category→area 内部リンク。回遊性 / クロール深度の改善) */}
+          <section className="mb-8" aria-labelledby="category-area-links">
+            <SectionEyebrow number={nativeBanners.length > 0 ? "4." : "3."}>
+              <span id="category-area-links">47都道府県から探す</span>
+            </SectionEyebrow>
+            <p className="mb-4 text-sm text-muted-foreground">
+              {category.categoryName}を含む各都道府県の統計プロファイルを見る
+            </p>
+            <div className="space-y-4">
+              {REGIONS.map((region) => {
+                const regionPrefs = region.prefectures
+                  .map((code) => prefMap.get(code))
+                  .filter((p): p is NonNullable<typeof p> => p != null);
+                const headingId = `category-region-${region.regionCode}`;
+                return (
+                  <section key={region.regionCode} aria-labelledby={headingId}>
+                    <h3
+                      id={headingId}
+                      className="mb-1 text-sm font-semibold text-muted-foreground"
+                    >
+                      {region.regionName}
+                    </h3>
+                    <div className="flex flex-wrap gap-x-3 gap-y-1">
+                      {regionPrefs.map((pref) => (
+                        <Link
+                          key={pref.prefCode}
+                          href={`/areas/${pref.prefCode}`}
+                          className="text-sm text-foreground transition-colors hover:text-primary"
+                        >
+                          {pref.prefName}
+                        </Link>
+                      ))}
+                    </div>
+                  </section>
+                );
+              })}
+            </div>
+          </section>
         </main>
 
         {/* 右サイドバー（lg+、360px、independent scroll で全 widget 到達可能） */}

--- a/apps/web/src/features/ranking/utils/generate-structured-data.ts
+++ b/apps/web/src/features/ranking/utils/generate-structured-data.ts
@@ -251,7 +251,33 @@ export function generateRankingPageStructuredData({
         unitText: unit,
       },
     }),
+    // Google Dataset Search はデータカタログへの所属を強いシグナルとして扱う。
+    // 一次配信元 (e-Stat 政府統計総合窓口) を DataCatalog として明示する。
+    includedInDataCatalog: {
+      "@type": "DataCatalog",
+      name: "e-Stat 政府統計の総合窓口",
+      url: "https://www.e-stat.go.jp/",
+    },
+    // 無償アクセス可能 (Dataset Search 推奨プロパティ)
+    isAccessibleForFree: true,
+    // 正規 URL を identifier に据え、Dataset Search の重複排除を助ける
+    identifier: url,
+    // distribution: 機械可読な CSV / JSON を優先列挙する。Google Dataset Search は
+    // DataDownload (CSV/JSON 等) を HTML ページより重視する。既存のオンザフライ生成 API
+    // (/api/ranking/[key]/download) を contentUrl に指定。baseUrl + rankingKey から直接組む。
     distribution: [
+      {
+        "@type": "DataDownload",
+        name: `${itemName} (CSV)`,
+        encodingFormat: "text/csv",
+        contentUrl: `${baseUrl}/api/ranking/${rankingItem.rankingKey}/download?format=csv`,
+      },
+      {
+        "@type": "DataDownload",
+        name: `${itemName} (JSON)`,
+        encodingFormat: "application/json",
+        contentUrl: `${baseUrl}/api/ranking/${rankingItem.rankingKey}/download?format=json`,
+      },
       {
         "@type": "DataDownload",
         encodingFormat: "text/html",


### PR DESCRIPTION
## 概要

workflow で並列調査・設計した2施策（証拠ベース、検証で双方 `apply` 判定）をまとめて適用。

## 1. Schema.org Dataset 強化（`generate-structured-data.ts`）

ranking 詳細ページの Dataset JSON-LD は既存だが、Google Dataset Search が最重視する**機械可読 DataDownload** を欠いていた。

```diff
  distribution: [
+   { "@type": "DataDownload", encodingFormat: "text/csv",  contentUrl: ".../api/ranking/[key]/download?format=csv" },
+   { "@type": "DataDownload", encodingFormat: "application/json", contentUrl: "...?format=json" },
    { "@type": "DataDownload", encodingFormat: "text/html", contentUrl: url },
  ],
+ includedInDataCatalog: { "@type": "DataCatalog", name: "e-Stat 政府統計の総合窓口", url: "..." },
+ isAccessibleForFree: true,
+ identifier: url,
```

CSV/JSON は既存のオンザフライ生成 API（`/api/ranking/[key]/download`）を参照。**テスト14件通過**、既存 BreadcrumbList / variableMeasured は不変。

## 2. category→area 内部リンク（`category/[categoryKey]/page.tsx`）

内部リンク matrix 調査で、全 hub ページ（ranking/area/blog）が相互リンク済の中で **category→area だけが欠落**していた。地方ブロック別に47都道府県プロフィールへのリンクを追加し、回遊性とクロール深度を改善。

- `areas/page.tsx` と同一の同期 static 読み取り → **SSG-safe**（dynamic 化しない）
- melta-ui 準拠

## 検証

- `npx tsc --noEmit`: 両ファイル エラーなし
- `npx vitest run .../generate-structured-data.test.ts`: 14 passed
- `npx eslint category/[categoryKey]/page.tsx`: clean

## 並行編集との非競合

両対象ファイルは別セッションが編集中の ranking/ theme-dashboard/ page-components と別ファイルで競合なし。

🤖 Generated with [Claude Code](https://claude.com/claude-code)