### PR TITLE
fix: area×theme ページの middleware 410 バグ修正

### DIFF
--- a/apps/web/scripts/smoke-test.ts
+++ b/apps/web/scripts/smoke-test.ts
@@ -45,21 +45,20 @@ const testCases: SmokeTestCase[] = [
     expectedTexts: ["北海道"],
   },
   {
-    name: "都道府県ダッシュボード（北海道・人口）",
+    // 旧カテゴリ URL → テーマ URL に 301 リダイレクト (2026-06-02)
+    name: "都道府県テーマ（北海道・人口動態、旧 /population → 301）",
     path: "/areas/01000/population",
+    expectedStatus: 301,
+  },
+  {
+    name: "都道府県テーマ（北海道・人口動態）",
+    path: "/areas/01000/population-dynamics",
     expectedStatus: 200,
     expectedTexts: ["北海道"],
   },
   {
-    name: "都道府県ダッシュボード（北海道・経済）",
-    path: "/areas/01000/economy",
-    expectedStatus: 200,
-    expectedTexts: ["北海道"],
-  },
-  {
-    // Phase 9 (2026-04-26): non-indexable category は middleware で 410 化される
-    // INDEXABLE_AREA_CATEGORIES = ["population", "economy"] 以外は意図的に 410
-    name: "都道府県ダッシュボード（北海道・気象）— 410 期待",
+    // non-indexable かつ テーママップ外は 410
+    name: "都道府県カテゴリ（北海道・気象、テーマなし）— 410 期待",
     path: "/areas/01000/landweather",
     expectedStatus: 410,
   },

--- a/apps/web/src/middleware.ts
+++ b/apps/web/src/middleware.ts
@@ -266,6 +266,22 @@ function checkAreasPolicy(pathname: string, req: NextRequest): Response | null {
     );
   }
 
+  // /areas/{prefCode}/{themeSlug} — Type A テーマページは通過させる (410 対象外)
+  const TYPE_A_THEME_SLUGS = new Set([
+    "population-dynamics", "aging-society", "living-housing", "local-economy",
+    "labor-wages", "manufacturing", "healthcare", "safety", "education-culture",
+    "tourism", "consumer-prices", "foreign-residents", "occupation-salary",
+    "real-income", "labor-mobility", "local-finance", "fishery-marine", "climate",
+  ]);
+  if (
+    seg.length === 3 &&
+    /^\d{5}$/.test(seg[1]) &&
+    UrlPolicy.area.isValidPrefCode(seg[1]) &&
+    TYPE_A_THEME_SLUGS.has(seg[2])
+  ) {
+    return null; // Next.js に委譲
+  }
+
   // /areas/{prefCode}/{non-indexable-category} → 410（カテゴリマップにもない場合）
   if (
     seg.length >= 3 &&


### PR DESCRIPTION
## Summary
- /areas/[code]/[themeSlug] が middleware の non-indexable 410 に引っかかっていたバグを修正
- TYPE_A_THEME_SLUGS を 410 対象外として通過させる
- スモークテスト期待値を更新（旧 /areas/01000/population → 301 に）

## 検証
- [x] tsc pass
- [x] 本番 curl 確認: /areas/01000/population → 301 は正常、/areas/01000/population-dynamics → 410 を修正

🤖 Generated with [Claude Code](https://claude.com/claude-code)