### PR TITLE
fix: energy/ict/infrastructure カテゴリ URL をエリアプロフィールへ 301

### DIFF
--- a/apps/web/scripts/smoke-test.ts
+++ b/apps/web/scripts/smoke-test.ts
@@ -63,10 +63,10 @@ const testCases: SmokeTestCase[] = [
     expectedStatus: 301,
   },
   {
-    // テーママップ外かつ非 indexable は 410
-    name: "都道府県カテゴリ（北海道・エネルギー）— 410 期待",
+    // テーマ未対応カテゴリ → エリアプロフィールへ 301 (2026-06-02)
+    name: "都道府県カテゴリ（北海道・エネルギー）→ エリアプロフィールへ 301",
     path: "/areas/01000/energy",
-    expectedStatus: 410,
+    expectedStatus: 301,
   },
   {
     name: "ランキング一覧（廃止 2026-05-28 → / に 301）",

--- a/apps/web/src/middleware.ts
+++ b/apps/web/src/middleware.ts
@@ -250,6 +250,10 @@ function checkAreasPolicy(pathname: string, req: NextRequest): Response | null {
     landweather: "climate",
     international: "foreign-residents",
     administrativefinancial: "local-finance",
+    // テーマ未対応カテゴリ → エリアプロフィールへ
+    energy: "",
+    ict: "",
+    infrastructure: "",
   };
   if (
     seg.length === 3 &&
@@ -260,10 +264,9 @@ function checkAreasPolicy(pathname: string, req: NextRequest): Response | null {
     Object.prototype.hasOwnProperty.call(CATEGORY_TO_THEME, seg[2])
   ) {
     const themeSlug = CATEGORY_TO_THEME[seg[2]];
-    return NextResponse.redirect(
-      new URL(`/areas/${seg[1]}/${themeSlug}`, req.url),
-      { status: 301 }
-    );
+    // テーマスラグ空文字 = 対応テーマなし → エリアプロフィールへ
+    const dest = themeSlug ? `/areas/${seg[1]}/${themeSlug}` : `/areas/${seg[1]}`;
+    return NextResponse.redirect(new URL(dest, req.url), { status: 301 });
   }
 
   // /areas/{prefCode}/{themeSlug} — Type A テーマページは通過させる (410 対象外)


### PR DESCRIPTION
## Summary
全17カテゴリが indexable になった結果、テーマ未対応カテゴリ（energy/ict/infrastructure）が
middleware の 410 を素通りして 200 を返していた問題を修正。

## 変更点
- middleware: energy/ict/infrastructure → `/areas/[prefCode]` へ 301
- smoke-test: 期待値を 410 → 301 に更新

## 検証
- [x] tsc pass
- [x] `curl https://stats47.jp/areas/01000/energy` → 301 に変わる予定

🤖 Generated with [Claude Code](https://claude.com/claude-code)