### PR TITLE
feat(data): ranking metric 122件を活性化 (config SSOT / 410→200 復活の基盤)

### DIFF
--- a/packages/data-configs/src/metrics/acupuncture-moxibustion-count.ts
+++ b/packages/data-configs/src/metrics/acupuncture-moxibustion-count.ts
@@ -35,7 +35,7 @@ export const acupunctureMoxibustionCount: MetricConfig = {
   "calculation": {
     "isCalculated": false,
   },
-  "isActive": false,
+  "isActive": true,
   "isFeatured": false,
   "featuredOrder": 0,
 };

--- a/packages/data-configs/src/metrics/agricultural-employment-population.ts
+++ b/packages/data-configs/src/metrics/agricultural-employment-population.ts
@@ -33,7 +33,7 @@ export const agriculturalEmploymentPopulation: MetricConfig = {
     "isCalculated": false,
   },
   "seoTitle": "農業就業人口（販売農家）",
-  "isActive": false,
+  "isActive": true,
   "isFeatured": false,
   "featuredOrder": 0,
 };

--- a/packages/data-configs/src/metrics/agricultural-output-per-employed-person.ts
+++ b/packages/data-configs/src/metrics/agricultural-output-per-employed-person.ts
@@ -33,7 +33,7 @@ export const agriculturalOutputPerEmployedPerson: MetricConfig = {
     "isCalculated": false,
   },
   "seoTitle": "就業者1人当たり農業産出額（販売農家）",
-  "isActive": false,
+  "isActive": true,
   "isFeatured": false,
   "featuredOrder": 0,
 };

--- a/packages/data-configs/src/metrics/anma-massage-count.ts
+++ b/packages/data-configs/src/metrics/anma-massage-count.ts
@@ -35,7 +35,7 @@ export const anmaMassageCount: MetricConfig = {
   "calculation": {
     "isCalculated": false,
   },
-  "isActive": false,
+  "isActive": true,
   "isFeatured": false,
   "featuredOrder": 0,
 };

--- a/packages/data-configs/src/metrics/annual-minimum-relative-humidity.ts
+++ b/packages/data-configs/src/metrics/annual-minimum-relative-humidity.ts
@@ -36,7 +36,7 @@ export const annualMinimumRelativeHumidity: MetricConfig = {
     "isCalculated": false,
   },
   "seoTitle": "最小相対湿度（年間）",
-  "isActive": false,
+  "isActive": true,
   "isFeatured": false,
   "featuredOrder": 0,
 };

--- a/packages/data-configs/src/metrics/area-ratio-of-total.ts
+++ b/packages/data-configs/src/metrics/area-ratio-of-total.ts
@@ -33,7 +33,7 @@ export const areaRatioOfTotal: MetricConfig = {
     "isCalculated": false,
   },
   "seoTitle": "面積割合（全国面積に占める割合）",
-  "isActive": false,
+  "isActive": true,
   "isFeatured": false,
   "featuredOrder": 0,
 };

--- a/packages/data-configs/src/metrics/artificial-forest-area.ts
+++ b/packages/data-configs/src/metrics/artificial-forest-area.ts
@@ -32,7 +32,7 @@ export const artificialForestArea: MetricConfig = {
   "calculation": {
     "isCalculated": false,
   },
-  "isActive": false,
+  "isActive": true,
   "isFeatured": false,
   "featuredOrder": 0,
 };

--- a/packages/data-configs/src/metrics/average-broadcast-media-consumption-time-employed-man.ts
+++ b/packages/data-configs/src/metrics/average-broadcast-media-consumption-time-employed-man.ts
@@ -33,7 +33,7 @@ export const averageBroadcastMediaConsumptionTimeEmployedMan: MetricConfig = {
     "isCalculated": false,
   },
   "seoTitle": "テレビ・ラジオ・新聞・雑誌の平均時間（有業者・男）",
-  "isActive": false,
+  "isActive": true,
   "isFeatured": false,
   "featuredOrder": 0,
 };

--- a/packages/data-configs/src/metrics/average-broadcast-media-consumption-time-employed-woman.ts
+++ b/packages/data-configs/src/metrics/average-broadcast-media-consumption-time-employed-woman.ts
@@ -33,7 +33,7 @@ export const averageBroadcastMediaConsumptionTimeEmployedWoman: MetricConfig = {
     "isCalculated": false,
   },
   "seoTitle": "テレビ・ラジオ・新聞・雑誌の平均時間（有業者・女）",
-  "isActive": false,
+  "isActive": true,
   "isFeatured": false,
   "featuredOrder": 0,
 };

--- a/packages/data-configs/src/metrics/child-welfare-expenses-prefecture.ts
+++ b/packages/data-configs/src/metrics/child-welfare-expenses-prefecture.ts
@@ -34,7 +34,7 @@ export const childWelfareExpensesPrefecture: MetricConfig = {
     "isCalculated": false,
   },
   "groupKey": "child-welfare-expenses-prefecture",
-  "isActive": false,
+  "isActive": true,
   "isFeatured": false,
   "featuredOrder": 0,
 };

--- a/packages/data-configs/src/metrics/consumer-price-difference-index-clothing-footwear.ts
+++ b/packages/data-configs/src/metrics/consumer-price-difference-index-clothing-footwear.ts
@@ -37,7 +37,7 @@ export const consumerPriceDifferenceIndexClothingFootwear: MetricConfig = {
     "isCalculated": false,
   },
   "seoTitle": "消費者物価地域差指数（被服及び履物）",
-  "isActive": false,
+  "isActive": true,
   "isFeatured": false,
   "featuredOrder": 0,
 };

--- a/packages/data-configs/src/metrics/consumer-price-difference-index-culture-recreation.ts
+++ b/packages/data-configs/src/metrics/consumer-price-difference-index-culture-recreation.ts
@@ -37,7 +37,7 @@ export const consumerPriceDifferenceIndexCultureRecreation: MetricConfig = {
     "isCalculated": false,
   },
   "seoTitle": "消費者物価地域差指数（教養娯楽）",
-  "isActive": false,
+  "isActive": true,
   "isFeatured": false,
   "featuredOrder": 0,
 };

--- a/packages/data-configs/src/metrics/consumer-price-difference-index-education.ts
+++ b/packages/data-configs/src/metrics/consumer-price-difference-index-education.ts
@@ -37,7 +37,7 @@ export const consumerPriceDifferenceIndexEducation: MetricConfig = {
     "isCalculated": false,
   },
   "seoTitle": "消費者物価地域差指数（教育）",
-  "isActive": false,
+  "isActive": true,
   "isFeatured": false,
   "featuredOrder": 0,
 };

--- a/packages/data-configs/src/metrics/consumer-price-difference-index-food.ts
+++ b/packages/data-configs/src/metrics/consumer-price-difference-index-food.ts
@@ -37,7 +37,7 @@ export const consumerPriceDifferenceIndexFood: MetricConfig = {
     "isCalculated": false,
   },
   "seoTitle": "消費者物価地域差指数（食料）",
-  "isActive": false,
+  "isActive": true,
   "isFeatured": false,
   "featuredOrder": 0,
 };

--- a/packages/data-configs/src/metrics/consumer-price-difference-index-furniture-household.ts
+++ b/packages/data-configs/src/metrics/consumer-price-difference-index-furniture-household.ts
@@ -37,7 +37,7 @@ export const consumerPriceDifferenceIndexFurnitureHousehold: MetricConfig = {
     "isCalculated": false,
   },
   "seoTitle": "消費者物価地域差指数（家具・家事用品）",
-  "isActive": false,
+  "isActive": true,
   "isFeatured": false,
   "featuredOrder": 0,
 };

--- a/packages/data-configs/src/metrics/consumer-price-difference-index-healthcare.ts
+++ b/packages/data-configs/src/metrics/consumer-price-difference-index-healthcare.ts
@@ -37,7 +37,7 @@ export const consumerPriceDifferenceIndexHealthcare: MetricConfig = {
     "isCalculated": false,
   },
   "seoTitle": "消費者物価地域差指数（保健医療）",
-  "isActive": false,
+  "isActive": true,
   "isFeatured": false,
   "featuredOrder": 0,
 };

--- a/packages/data-configs/src/metrics/consumer-price-difference-index-housing.ts
+++ b/packages/data-configs/src/metrics/consumer-price-difference-index-housing.ts
@@ -37,7 +37,7 @@ export const consumerPriceDifferenceIndexHousing: MetricConfig = {
     "isCalculated": false,
   },
   "seoTitle": "消費者物価地域差指数（住居）",
-  "isActive": false,
+  "isActive": true,
   "isFeatured": false,
   "featuredOrder": 0,
 };

--- a/packages/data-configs/src/metrics/consumer-price-difference-index-miscellaneous.ts
+++ b/packages/data-configs/src/metrics/consumer-price-difference-index-miscellaneous.ts
@@ -37,7 +37,7 @@ export const consumerPriceDifferenceIndexMiscellaneous: MetricConfig = {
     "isCalculated": false,
   },
   "seoTitle": "消費者物価地域差指数（諸雑費）",
-  "isActive": false,
+  "isActive": true,
   "isFeatured": false,
   "featuredOrder": 0,
 };

--- a/packages/data-configs/src/metrics/consumer-price-difference-index-transport-communication.ts
+++ b/packages/data-configs/src/metrics/consumer-price-difference-index-transport-communication.ts
@@ -37,7 +37,7 @@ export const consumerPriceDifferenceIndexTransportCommunication: MetricConfig = 
     "isCalculated": false,
   },
   "seoTitle": "消費者物価地域差指数（交通・通信）",
-  "isActive": false,
+  "isActive": true,
   "isFeatured": false,
   "featuredOrder": 0,
 };

--- a/packages/data-configs/src/metrics/consumer-price-difference-index-utilities.ts
+++ b/packages/data-configs/src/metrics/consumer-price-difference-index-utilities.ts
@@ -37,7 +37,7 @@ export const consumerPriceDifferenceIndexUtilities: MetricConfig = {
     "isCalculated": false,
   },
   "seoTitle": "消費者物価地域差指数（光熱・水道）",
-  "isActive": false,
+  "isActive": true,
   "isFeatured": false,
   "featuredOrder": 0,
 };

--- a/packages/data-configs/src/metrics/cpi-change-rate-clothing.ts
+++ b/packages/data-configs/src/metrics/cpi-change-rate-clothing.ts
@@ -60,7 +60,7 @@ export const cpiChangeRateClothing: MetricConfig = {
     "isCalculated": false,
   },
   "seoTitle": "消費者物価指数対前年変化率（被服及び履物）",
-  "isActive": false,
+  "isActive": true,
   "isFeatured": false,
   "featuredOrder": 0,
 };

--- a/packages/data-configs/src/metrics/cpi-change-rate-culture-recreation.ts
+++ b/packages/data-configs/src/metrics/cpi-change-rate-culture-recreation.ts
@@ -61,7 +61,7 @@ export const cpiChangeRateCultureRecreation: MetricConfig = {
     "isCalculated": false,
   },
   "seoTitle": "消費者物価指数対前年変化率（教養娯楽）",
-  "isActive": false,
+  "isActive": true,
   "isFeatured": false,
   "featuredOrder": 0,
 };

--- a/packages/data-configs/src/metrics/cpi-change-rate-education.ts
+++ b/packages/data-configs/src/metrics/cpi-change-rate-education.ts
@@ -71,7 +71,7 @@ export const cpiChangeRateEducation: MetricConfig = {
     "isCalculated": false,
   },
   "seoTitle": "消費者物価指数対前年変化率（教育）",
-  "isActive": false,
+  "isActive": true,
   "isFeatured": false,
   "featuredOrder": 0,
 };

--- a/packages/data-configs/src/metrics/cpi-change-rate-excl-food-energy.ts
+++ b/packages/data-configs/src/metrics/cpi-change-rate-excl-food-energy.ts
@@ -37,7 +37,7 @@ export const cpiChangeRateExclFoodEnergy: MetricConfig = {
     "isCalculated": false,
   },
   "seoTitle": "消費者物価指数対前年変化率（食料（酒類を除く）及びエネルギーを除く総合）",
-  "isActive": false,
+  "isActive": true,
   "isFeatured": false,
   "featuredOrder": 0,
 };

--- a/packages/data-configs/src/metrics/cpi-change-rate-excl-fresh-food-energy.ts
+++ b/packages/data-configs/src/metrics/cpi-change-rate-excl-fresh-food-energy.ts
@@ -37,7 +37,7 @@ export const cpiChangeRateExclFreshFoodEnergy: MetricConfig = {
     "isCalculated": false,
   },
   "seoTitle": "消費者物価指数対前年変化率（生鮮食品及びエネルギーを除く総合）",
-  "isActive": false,
+  "isActive": true,
   "isFeatured": false,
   "featuredOrder": 0,
 };

--- a/packages/data-configs/src/metrics/cpi-change-rate-excl-fresh-food.ts
+++ b/packages/data-configs/src/metrics/cpi-change-rate-excl-fresh-food.ts
@@ -36,7 +36,7 @@ export const cpiChangeRateExclFreshFood: MetricConfig = {
     "isCalculated": false,
   },
   "seoTitle": "消費者物価指数対前年変化率（生鮮食品を除く総合）",
-  "isActive": false,
+  "isActive": true,
   "isFeatured": false,
   "featuredOrder": 0,
 };

--- a/packages/data-configs/src/metrics/cpi-change-rate-excl-owner-rent.ts
+++ b/packages/data-configs/src/metrics/cpi-change-rate-excl-owner-rent.ts
@@ -36,7 +36,7 @@ export const cpiChangeRateExclOwnerRent: MetricConfig = {
     "isCalculated": false,
   },
   "seoTitle": "消費者物価指数対前年変化率（持ち家の帰属家賃を除く総合）",
-  "isActive": false,
+  "isActive": true,
   "isFeatured": false,
   "featuredOrder": 0,
 };

--- a/packages/data-configs/src/metrics/cpi-change-rate-food.ts
+++ b/packages/data-configs/src/metrics/cpi-change-rate-food.ts
@@ -81,7 +81,7 @@ export const cpiChangeRateFood: MetricConfig = {
     "isCalculated": false,
   },
   "seoTitle": "消費者物価指数対前年変化率（食料）",
-  "isActive": false,
+  "isActive": true,
   "isFeatured": false,
   "featuredOrder": 0,
 };

--- a/packages/data-configs/src/metrics/cpi-change-rate-furniture.ts
+++ b/packages/data-configs/src/metrics/cpi-change-rate-furniture.ts
@@ -71,7 +71,7 @@ export const cpiChangeRateFurniture: MetricConfig = {
     "isCalculated": false,
   },
   "seoTitle": "消費者物価指数対前年変化率（家具・家事用品）",
-  "isActive": false,
+  "isActive": true,
   "isFeatured": false,
   "featuredOrder": 0,
 };

--- a/packages/data-configs/src/metrics/cpi-change-rate-healthcare.ts
+++ b/packages/data-configs/src/metrics/cpi-change-rate-healthcare.ts
@@ -60,7 +60,7 @@ export const cpiChangeRateHealthcare: MetricConfig = {
     "isCalculated": false,
   },
   "seoTitle": "消費者物価指数対前年変化率（保健医療）",
-  "isActive": false,
+  "isActive": true,
   "isFeatured": false,
   "featuredOrder": 0,
 };

--- a/packages/data-configs/src/metrics/cpi-change-rate-housing.ts
+++ b/packages/data-configs/src/metrics/cpi-change-rate-housing.ts
@@ -60,7 +60,7 @@ export const cpiChangeRateHousing: MetricConfig = {
     "isCalculated": false,
   },
   "seoTitle": "消費者物価指数対前年変化率（住居）",
-  "isActive": false,
+  "isActive": true,
   "isFeatured": false,
   "featuredOrder": 0,
 };

--- a/packages/data-configs/src/metrics/cpi-change-rate-miscellaneous.ts
+++ b/packages/data-configs/src/metrics/cpi-change-rate-miscellaneous.ts
@@ -61,7 +61,7 @@ export const cpiChangeRateMiscellaneous: MetricConfig = {
     "isCalculated": false,
   },
   "seoTitle": "消費者物価指数対前年変化率（諸雑費）",
-  "isActive": false,
+  "isActive": true,
   "isFeatured": false,
   "featuredOrder": 0,
 };

--- a/packages/data-configs/src/metrics/cpi-change-rate-transport-communication.ts
+++ b/packages/data-configs/src/metrics/cpi-change-rate-transport-communication.ts
@@ -71,7 +71,7 @@ export const cpiChangeRateTransportCommunication: MetricConfig = {
     "isCalculated": false,
   },
   "seoTitle": "消費者物価指数対前年変化率（交通・通信）",
-  "isActive": false,
+  "isActive": true,
   "isFeatured": false,
   "featuredOrder": 0,
 };

--- a/packages/data-configs/src/metrics/cpi-change-rate-utilities.ts
+++ b/packages/data-configs/src/metrics/cpi-change-rate-utilities.ts
@@ -77,7 +77,7 @@ export const cpiChangeRateUtilities: MetricConfig = {
     "isCalculated": false,
   },
   "seoTitle": "消費者物価指数対前年変化率（光熱・水道）",
-  "isActive": false,
+  "isActive": true,
   "isFeatured": false,
   "featuredOrder": 0,
 };

--- a/packages/data-configs/src/metrics/cpi-regional-difference-index-food-51cities100.ts
+++ b/packages/data-configs/src/metrics/cpi-regional-difference-index-food-51cities100.ts
@@ -37,7 +37,7 @@ export const cpiRegionalDifferenceIndexFood51cities100: MetricConfig = {
     "isCalculated": false,
   },
   "seoTitle": "消費者物価地域差指数（食料）（51市平均＝100）",
-  "isActive": false,
+  "isActive": true,
   "isFeatured": false,
   "featuredOrder": 0,
 };

--- a/packages/data-configs/src/metrics/cpi-regional-difference-index-food-tokyo100.ts
+++ b/packages/data-configs/src/metrics/cpi-regional-difference-index-food-tokyo100.ts
@@ -63,7 +63,7 @@ export const cpiRegionalDifferenceIndexFoodTokyo100: MetricConfig = {
     "isCalculated": false,
   },
   "seoTitle": "消費者物価地域差指数（食料：東京都区部＝100）",
-  "isActive": false,
+  "isActive": true,
   "isFeatured": false,
   "featuredOrder": 0,
 };

--- a/packages/data-configs/src/metrics/disaster-recovery-expenses-prefecture.ts
+++ b/packages/data-configs/src/metrics/disaster-recovery-expenses-prefecture.ts
@@ -46,7 +46,7 @@ export const disasterRecoveryExpensesPrefecture: MetricConfig = {
     "isCalculated": false,
   },
   "groupKey": "disaster-recovery-expenses-prefecture",
-  "isActive": false,
+  "isActive": true,
   "isFeatured": false,
   "featuredOrder": 0,
 };

--- a/packages/data-configs/src/metrics/elderly-welfare-expenses-prefecture.ts
+++ b/packages/data-configs/src/metrics/elderly-welfare-expenses-prefecture.ts
@@ -64,7 +64,7 @@ export const elderlyWelfareExpensesPrefecture: MetricConfig = {
     "isCalculated": false,
   },
   "groupKey": "elderly-welfare-expenses-prefecture",
-  "isActive": false,
+  "isActive": true,
   "isFeatured": false,
   "featuredOrder": 0,
 };

--- a/packages/data-configs/src/metrics/emergency-hospital-general-clinic-count-per-100k.ts
+++ b/packages/data-configs/src/metrics/emergency-hospital-general-clinic-count-per-100k.ts
@@ -32,7 +32,7 @@ export const emergencyHospitalGeneralClinicCountPer100k: MetricConfig = {
   "calculation": {
     "isCalculated": false,
   },
-  "isActive": false,
+  "isActive": true,
   "isFeatured": false,
   "featuredOrder": 0,
 };

--- a/packages/data-configs/src/metrics/female-part-time-hourly-wage-pre2019.ts
+++ b/packages/data-configs/src/metrics/female-part-time-hourly-wage-pre2019.ts
@@ -32,7 +32,7 @@ export const femalePartTimeHourlyWagePre2019: MetricConfig = {
   "calculation": {
     "isCalculated": false,
   },
-  "isActive": false,
+  "isActive": true,
   "isFeatured": false,
   "featuredOrder": 0,
 };

--- a/packages/data-configs/src/metrics/female-part-time-hourly-wage.ts
+++ b/packages/data-configs/src/metrics/female-part-time-hourly-wage.ts
@@ -32,7 +32,7 @@ export const femalePartTimeHourlyWage: MetricConfig = {
   "calculation": {
     "isCalculated": false,
   },
-  "isActive": false,
+  "isActive": true,
   "isFeatured": false,
   "featuredOrder": 0,
 };

--- a/packages/data-configs/src/metrics/female-parttime-workers-upto2019.ts
+++ b/packages/data-configs/src/metrics/female-parttime-workers-upto2019.ts
@@ -32,7 +32,7 @@ export const femaleParttimeWorkersUpto2019: MetricConfig = {
   "calculation": {
     "isCalculated": false,
   },
-  "isActive": false,
+  "isActive": true,
   "isFeatured": false,
   "featuredOrder": 0,
 };

--- a/packages/data-configs/src/metrics/female-parttime-workers.ts
+++ b/packages/data-configs/src/metrics/female-parttime-workers.ts
@@ -32,7 +32,7 @@ export const femaleParttimeWorkers: MetricConfig = {
   "calculation": {
     "isCalculated": false,
   },
-  "isActive": false,
+  "isActive": true,
   "isFeatured": false,
   "featuredOrder": 0,
 };

--- a/packages/data-configs/src/metrics/fire-dispatch-for-building-fire-count-per-100k.ts
+++ b/packages/data-configs/src/metrics/fire-dispatch-for-building-fire-count-per-100k.ts
@@ -32,7 +32,7 @@ export const fireDispatchForBuildingFireCountPer100k: MetricConfig = {
   "calculation": {
     "isCalculated": false,
   },
-  "isActive": false,
+  "isActive": true,
   "isFeatured": false,
   "featuredOrder": 0,
 };

--- a/packages/data-configs/src/metrics/fire-insurance-amount-received-per-contract.ts
+++ b/packages/data-configs/src/metrics/fire-insurance-amount-received-per-contract.ts
@@ -33,7 +33,7 @@ export const fireInsuranceAmountReceivedPerContract: MetricConfig = {
     "isCalculated": false,
   },
   "seoTitle": "火災保険住宅物件・一般物件受取保険金額（1年）",
-  "isActive": false,
+  "isActive": true,
   "isFeatured": false,
   "featuredOrder": 0,
 };

--- a/packages/data-configs/src/metrics/general-project-investment-agriculture-forestry-fisheries.ts
+++ b/packages/data-configs/src/metrics/general-project-investment-agriculture-forestry-fisheries.ts
@@ -33,7 +33,7 @@ export const generalProjectInvestmentAgricultureForestryFisheries: MetricConfig 
   "calculation": {
     "isCalculated": false,
   },
-  "isActive": false,
+  "isActive": true,
   "isFeatured": false,
   "featuredOrder": 0,
 };

--- a/packages/data-configs/src/metrics/general-project-investment-disaster-recovery.ts
+++ b/packages/data-configs/src/metrics/general-project-investment-disaster-recovery.ts
@@ -33,7 +33,7 @@ export const generalProjectInvestmentDisasterRecovery: MetricConfig = {
   "calculation": {
     "isCalculated": false,
   },
-  "isActive": false,
+  "isActive": true,
   "isFeatured": false,
   "featuredOrder": 0,
 };

--- a/packages/data-configs/src/metrics/general-project-investment-educational-facilities.ts
+++ b/packages/data-configs/src/metrics/general-project-investment-educational-facilities.ts
@@ -55,7 +55,7 @@ export const generalProjectInvestmentEducationalFacilities: MetricConfig = {
   "calculation": {
     "isCalculated": false,
   },
-  "isActive": false,
+  "isActive": true,
   "isFeatured": false,
   "featuredOrder": 0,
 };

--- a/packages/data-configs/src/metrics/general-project-investment-environmental-sanitation.ts
+++ b/packages/data-configs/src/metrics/general-project-investment-environmental-sanitation.ts
@@ -33,7 +33,7 @@ export const generalProjectInvestmentEnvironmentalSanitation: MetricConfig = {
   "calculation": {
     "isCalculated": false,
   },
-  "isActive": false,
+  "isActive": true,
   "isFeatured": false,
   "featuredOrder": 0,
 };

--- a/packages/data-configs/src/metrics/general-project-investment-erosion-flood-control.ts
+++ b/packages/data-configs/src/metrics/general-project-investment-erosion-flood-control.ts
@@ -59,7 +59,7 @@ export const generalProjectInvestmentErosionFloodControl: MetricConfig = {
   "calculation": {
     "isCalculated": false,
   },
-  "isActive": false,
+  "isActive": true,
   "isFeatured": false,
   "featuredOrder": 0,
 };

--- a/packages/data-configs/src/metrics/general-project-investment-housing.ts
+++ b/packages/data-configs/src/metrics/general-project-investment-housing.ts
@@ -56,7 +56,7 @@ export const generalProjectInvestmentHousing: MetricConfig = {
   "calculation": {
     "isCalculated": false,
   },
-  "isActive": false,
+  "isActive": true,
   "isFeatured": false,
   "featuredOrder": 0,
 };

--- a/packages/data-configs/src/metrics/general-project-investment-railway.ts
+++ b/packages/data-configs/src/metrics/general-project-investment-railway.ts
@@ -33,7 +33,7 @@ export const generalProjectInvestmentRailway: MetricConfig = {
   "calculation": {
     "isCalculated": false,
   },
-  "isActive": false,
+  "isActive": true,
   "isFeatured": false,
   "featuredOrder": 0,
 };

--- a/packages/data-configs/src/metrics/general-project-investment-road.ts
+++ b/packages/data-configs/src/metrics/general-project-investment-road.ts
@@ -57,7 +57,7 @@ export const generalProjectInvestmentRoad: MetricConfig = {
   "calculation": {
     "isCalculated": false,
   },
-  "isActive": false,
+  "isActive": true,
   "isFeatured": false,
   "featuredOrder": 0,
 };

--- a/packages/data-configs/src/metrics/general-project-investment-urban-planning.ts
+++ b/packages/data-configs/src/metrics/general-project-investment-urban-planning.ts
@@ -33,7 +33,7 @@ export const generalProjectInvestmentUrbanPlanning: MetricConfig = {
   "calculation": {
     "isCalculated": false,
   },
-  "isActive": false,
+  "isActive": true,
   "isFeatured": false,
   "featuredOrder": 0,
 };

--- a/packages/data-configs/src/metrics/general-project-investment-welfare.ts
+++ b/packages/data-configs/src/metrics/general-project-investment-welfare.ts
@@ -46,7 +46,7 @@ export const generalProjectInvestmentWelfare: MetricConfig = {
   "calculation": {
     "isCalculated": false,
   },
-  "isActive": false,
+  "isActive": true,
   "isFeatured": false,
   "featuredOrder": 0,
 };

--- a/packages/data-configs/src/metrics/goods-inventory-wholesale-retail.ts
+++ b/packages/data-configs/src/metrics/goods-inventory-wholesale-retail.ts
@@ -33,7 +33,7 @@ export const goodsInventoryWholesaleRetail: MetricConfig = {
     "isCalculated": false,
   },
   "seoTitle": "商品手持額（卸売業＋小売業）",
-  "isActive": false,
+  "isActive": true,
   "isFeatured": false,
   "featuredOrder": 0,
 };

--- a/packages/data-configs/src/metrics/hobby-leisure-avg-time-employed-female.ts
+++ b/packages/data-configs/src/metrics/hobby-leisure-avg-time-employed-female.ts
@@ -45,7 +45,7 @@ export const hobbyLeisureAvgTimeEmployedFemale: MetricConfig = {
     "isCalculated": false,
   },
   "seoTitle": "趣味・娯楽の平均時間（有業者・女）",
-  "isActive": false,
+  "isActive": true,
   "isFeatured": false,
   "featuredOrder": 0,
 };

--- a/packages/data-configs/src/metrics/hobby-leisure-avg-time-employed-male.ts
+++ b/packages/data-configs/src/metrics/hobby-leisure-avg-time-employed-male.ts
@@ -45,7 +45,7 @@ export const hobbyLeisureAvgTimeEmployedMale: MetricConfig = {
     "isCalculated": false,
   },
   "seoTitle": "趣味・娯楽の平均時間（有業者・男）",
-  "isActive": false,
+  "isActive": true,
   "isFeatured": false,
   "featuredOrder": 0,
 };

--- a/packages/data-configs/src/metrics/hobby-leisure-avg-time-unemployed-female.ts
+++ b/packages/data-configs/src/metrics/hobby-leisure-avg-time-unemployed-female.ts
@@ -45,7 +45,7 @@ export const hobbyLeisureAvgTimeUnemployedFemale: MetricConfig = {
     "isCalculated": false,
   },
   "seoTitle": "趣味・娯楽の平均時間（無業者・女）",
-  "isActive": false,
+  "isActive": true,
   "isFeatured": false,
   "featuredOrder": 0,
 };

--- a/packages/data-configs/src/metrics/hobby-leisure-avg-time-unemployed-male.ts
+++ b/packages/data-configs/src/metrics/hobby-leisure-avg-time-unemployed-male.ts
@@ -41,7 +41,7 @@ export const hobbyLeisureAvgTimeUnemployedMale: MetricConfig = {
     "isCalculated": false,
   },
   "seoTitle": "趣味・娯楽の平均時間（無業者・男）",
-  "isActive": false,
+  "isActive": true,
   "isFeatured": false,
   "featuredOrder": 0,
 };

--- a/packages/data-configs/src/metrics/household-ratio-main-earner-employee-commute-90min.ts
+++ b/packages/data-configs/src/metrics/household-ratio-main-earner-employee-commute-90min.ts
@@ -34,7 +34,7 @@ export const householdRatioMainEarnerEmployeeCommute90min: MetricConfig = {
     "isCalculated": false,
   },
   "seoTitle": "家計を主に支える者が雇用者である普通世帯比率（通勤時間90分以上）",
-  "isActive": false,
+  "isActive": true,
   "isFeatured": false,
   "featuredOrder": 0,
 };

--- a/packages/data-configs/src/metrics/judo-therapist-count.ts
+++ b/packages/data-configs/src/metrics/judo-therapist-count.ts
@@ -35,7 +35,7 @@ export const judoTherapistCount: MetricConfig = {
   "calculation": {
     "isCalculated": false,
   },
-  "isActive": false,
+  "isActive": true,
   "isFeatured": false,
   "featuredOrder": 0,
 };

--- a/packages/data-configs/src/metrics/main-household-ratio-main-earner-employee-commute-90min.ts
+++ b/packages/data-configs/src/metrics/main-household-ratio-main-earner-employee-commute-90min.ts
@@ -34,7 +34,7 @@ export const mainHouseholdRatioMainEarnerEmployeeCommute90min: MetricConfig = {
     "isCalculated": false,
   },
   "seoTitle": "家計を主に支える者が雇用者である主世帯比率（通勤時間1時間30分以上）",
-  "isActive": false,
+  "isActive": true,
   "isFeatured": false,
   "featuredOrder": 0,
 };

--- a/packages/data-configs/src/metrics/media-avg-time-unemployed-female.ts
+++ b/packages/data-configs/src/metrics/media-avg-time-unemployed-female.ts
@@ -40,7 +40,7 @@ export const mediaAvgTimeUnemployedFemale: MetricConfig = {
     "isCalculated": false,
   },
   "seoTitle": "テレビ・ラジオ・新聞・雑誌の平均時間（無業者・女）",
-  "isActive": false,
+  "isActive": true,
   "isFeatured": false,
   "featuredOrder": 0,
 };

--- a/packages/data-configs/src/metrics/media-avg-time-unemployed-male.ts
+++ b/packages/data-configs/src/metrics/media-avg-time-unemployed-male.ts
@@ -33,7 +33,7 @@ export const mediaAvgTimeUnemployedMale: MetricConfig = {
     "isCalculated": false,
   },
   "seoTitle": "テレビ・ラジオ・新聞・雑誌の平均時間（無業者・男）",
-  "isActive": false,
+  "isActive": true,
   "isFeatured": false,
   "featuredOrder": 0,
 };

--- a/packages/data-configs/src/metrics/middle-school-teachers-ratio-female.ts
+++ b/packages/data-configs/src/metrics/middle-school-teachers-ratio-female.ts
@@ -32,7 +32,7 @@ export const middleSchoolTeachersRatioFemale: MetricConfig = {
   "calculation": {
     "isCalculated": false,
   },
-  "isActive": false,
+  "isActive": true,
   "isFeatured": false,
   "featuredOrder": 0,
 };

--- a/packages/data-configs/src/metrics/migrant-worker-ratio-sales-farm.ts
+++ b/packages/data-configs/src/metrics/migrant-worker-ratio-sales-farm.ts
@@ -33,7 +33,7 @@ export const migrantWorkerRatioSalesFarm: MetricConfig = {
     "isCalculated": false,
   },
   "seoTitle": "出稼者比率（販売農家）",
-  "isActive": false,
+  "isActive": true,
   "isFeatured": false,
   "featuredOrder": 0,
 };

--- a/packages/data-configs/src/metrics/moving-in-rate-japanese.ts
+++ b/packages/data-configs/src/metrics/moving-in-rate-japanese.ts
@@ -42,7 +42,7 @@ export const movingInRateJapanese: MetricConfig = {
   "calculation": {
     "isCalculated": false,
   },
-  "isActive": false,
+  "isActive": true,
   "isFeatured": false,
   "featuredOrder": 0,
 };

--- a/packages/data-configs/src/metrics/moving-out-rate-japanese.ts
+++ b/packages/data-configs/src/metrics/moving-out-rate-japanese.ts
@@ -42,7 +42,7 @@ export const movingOutRateJapanese: MetricConfig = {
   "calculation": {
     "isCalculated": false,
   },
-  "isActive": false,
+  "isActive": true,
   "isFeatured": false,
   "featuredOrder": 0,
 };

--- a/packages/data-configs/src/metrics/number-of-commercial-employees-wholesale-retail.ts
+++ b/packages/data-configs/src/metrics/number-of-commercial-employees-wholesale-retail.ts
@@ -34,7 +34,7 @@ export const numberOfCommercialEmployeesWholesaleRetail: MetricConfig = {
     "isCalculated": false,
   },
   "seoTitle": "商業従業者数（卸売業＋小売業）",
-  "isActive": false,
+  "isActive": true,
   "isFeatured": false,
   "featuredOrder": 0,
 };

--- a/packages/data-configs/src/metrics/number-of-establishments-agriculture-forestry-fisheries.ts
+++ b/packages/data-configs/src/metrics/number-of-establishments-agriculture-forestry-fisheries.ts
@@ -36,7 +36,7 @@ export const numberOfEstablishmentsAgricultureForestryFisheries: MetricConfig = 
   "calculation": {
     "isCalculated": false,
   },
-  "isActive": false,
+  "isActive": true,
   "isFeatured": false,
   "featuredOrder": 0,
 };

--- a/packages/data-configs/src/metrics/number-of-establishments-agriculture-forestry.ts
+++ b/packages/data-configs/src/metrics/number-of-establishments-agriculture-forestry.ts
@@ -36,7 +36,7 @@ export const numberOfEstablishmentsAgricultureForestry: MetricConfig = {
   "calculation": {
     "isCalculated": false,
   },
-  "isActive": false,
+  "isActive": true,
   "isFeatured": false,
   "featuredOrder": 0,
 };

--- a/packages/data-configs/src/metrics/number-of-establishments-construction.ts
+++ b/packages/data-configs/src/metrics/number-of-establishments-construction.ts
@@ -36,7 +36,7 @@ export const numberOfEstablishmentsConstruction: MetricConfig = {
   "calculation": {
     "isCalculated": false,
   },
-  "isActive": false,
+  "isActive": true,
   "isFeatured": false,
   "featuredOrder": 0,
 };

--- a/packages/data-configs/src/metrics/number-of-establishments-education-learning-support.ts
+++ b/packages/data-configs/src/metrics/number-of-establishments-education-learning-support.ts
@@ -36,7 +36,7 @@ export const numberOfEstablishmentsEducationLearningSupport: MetricConfig = {
   "calculation": {
     "isCalculated": false,
   },
-  "isActive": false,
+  "isActive": true,
   "isFeatured": false,
   "featuredOrder": 0,
 };

--- a/packages/data-configs/src/metrics/number-of-establishments-finance-insurance.ts
+++ b/packages/data-configs/src/metrics/number-of-establishments-finance-insurance.ts
@@ -36,7 +36,7 @@ export const numberOfEstablishmentsFinanceInsurance: MetricConfig = {
   "calculation": {
     "isCalculated": false,
   },
-  "isActive": false,
+  "isActive": true,
   "isFeatured": false,
   "featuredOrder": 0,
 };

--- a/packages/data-configs/src/metrics/number-of-establishments-fisheries.ts
+++ b/packages/data-configs/src/metrics/number-of-establishments-fisheries.ts
@@ -36,7 +36,7 @@ export const numberOfEstablishmentsFisheries: MetricConfig = {
   "calculation": {
     "isCalculated": false,
   },
-  "isActive": false,
+  "isActive": true,
   "isFeatured": false,
   "featuredOrder": 0,
 };

--- a/packages/data-configs/src/metrics/number-of-establishments-information-communication.ts
+++ b/packages/data-configs/src/metrics/number-of-establishments-information-communication.ts
@@ -36,7 +36,7 @@ export const numberOfEstablishmentsInformationCommunication: MetricConfig = {
   "calculation": {
     "isCalculated": false,
   },
-  "isActive": false,
+  "isActive": true,
   "isFeatured": false,
   "featuredOrder": 0,
 };

--- a/packages/data-configs/src/metrics/number-of-establishments-manufacturing.ts
+++ b/packages/data-configs/src/metrics/number-of-establishments-manufacturing.ts
@@ -36,7 +36,7 @@ export const numberOfEstablishmentsManufacturing: MetricConfig = {
   "calculation": {
     "isCalculated": false,
   },
-  "isActive": false,
+  "isActive": true,
   "isFeatured": false,
   "featuredOrder": 0,
 };

--- a/packages/data-configs/src/metrics/number-of-establishments-medical-welfare.ts
+++ b/packages/data-configs/src/metrics/number-of-establishments-medical-welfare.ts
@@ -36,7 +36,7 @@ export const numberOfEstablishmentsMedicalWelfare: MetricConfig = {
   "calculation": {
     "isCalculated": false,
   },
-  "isActive": false,
+  "isActive": true,
   "isFeatured": false,
   "featuredOrder": 0,
 };

--- a/packages/data-configs/src/metrics/number-of-establishments-mining-quarrying-gravel-extraction.ts
+++ b/packages/data-configs/src/metrics/number-of-establishments-mining-quarrying-gravel-extraction.ts
@@ -36,7 +36,7 @@ export const numberOfEstablishmentsMiningQuarryingGravelExtraction: MetricConfig
   "calculation": {
     "isCalculated": false,
   },
-  "isActive": false,
+  "isActive": true,
   "isFeatured": false,
   "featuredOrder": 0,
 };

--- a/packages/data-configs/src/metrics/number-of-establishments-real-estate-leasing.ts
+++ b/packages/data-configs/src/metrics/number-of-establishments-real-estate-leasing.ts
@@ -36,7 +36,7 @@ export const numberOfEstablishmentsRealEstateLeasing: MetricConfig = {
   "calculation": {
     "isCalculated": false,
   },
-  "isActive": false,
+  "isActive": true,
   "isFeatured": false,
   "featuredOrder": 0,
 };

--- a/packages/data-configs/src/metrics/number-of-establishments-transport-post.ts
+++ b/packages/data-configs/src/metrics/number-of-establishments-transport-post.ts
@@ -36,7 +36,7 @@ export const numberOfEstablishmentsTransportPost: MetricConfig = {
   "calculation": {
     "isCalculated": false,
   },
-  "isActive": false,
+  "isActive": true,
   "isFeatured": false,
   "featuredOrder": 0,
 };

--- a/packages/data-configs/src/metrics/number-of-establishments-wholesale-retail.ts
+++ b/packages/data-configs/src/metrics/number-of-establishments-wholesale-retail.ts
@@ -36,7 +36,7 @@ export const numberOfEstablishmentsWholesaleRetail: MetricConfig = {
   "calculation": {
     "isCalculated": false,
   },
-  "isActive": false,
+  "isActive": true,
   "isFeatured": false,
   "featuredOrder": 0,
 };

--- a/packages/data-configs/src/metrics/per-capita-child-welfare-expenditure-under17-pref-municipal.ts
+++ b/packages/data-configs/src/metrics/per-capita-child-welfare-expenditure-under17-pref-municipal.ts
@@ -57,7 +57,7 @@ export const perCapitaChildWelfareExpenditureUnder17PrefMunicipal: MetricConfig 
     "isCalculated": false,
   },
   "groupKey": "child-welfare-expenses-prefecture",
-  "isActive": false,
+  "isActive": true,
   "isFeatured": false,
   "featuredOrder": 0,
 };

--- a/packages/data-configs/src/metrics/per-capita-disaster-recovery-expenditure-pref-municipal.ts
+++ b/packages/data-configs/src/metrics/per-capita-disaster-recovery-expenditure-pref-municipal.ts
@@ -34,7 +34,7 @@ export const perCapitaDisasterRecoveryExpenditurePrefMunicipal: MetricConfig = {
     "isCalculated": false,
   },
   "groupKey": "disaster-recovery-expenses-prefecture",
-  "isActive": false,
+  "isActive": true,
   "isFeatured": false,
   "featuredOrder": 0,
 };

--- a/packages/data-configs/src/metrics/per-capita-elderly-welfare-expenditure-65plus-pref-municipal.ts
+++ b/packages/data-configs/src/metrics/per-capita-elderly-welfare-expenditure-65plus-pref-municipal.ts
@@ -68,7 +68,7 @@ export const perCapitaElderlyWelfareExpenditure65plusPrefMunicipal: MetricConfig
     "isCalculated": false,
   },
   "groupKey": "elderly-welfare-expenses-prefecture",
-  "isActive": false,
+  "isActive": true,
   "isFeatured": false,
   "featuredOrder": 0,
 };

--- a/packages/data-configs/src/metrics/per-capita-public-assistance-expenditure-protected-pref-municipal.ts
+++ b/packages/data-configs/src/metrics/per-capita-public-assistance-expenditure-protected-pref-municipal.ts
@@ -48,7 +48,7 @@ export const perCapitaPublicAssistanceExpenditureProtectedPrefMunicipal: MetricC
   },
   "groupKey": "public-assistance-expenses-prefecture",
   "seoTitle": "被保護実人員1人当たり生活保護費",
-  "isActive": false,
+  "isActive": true,
   "isFeatured": false,
   "featuredOrder": 0,
 };

--- a/packages/data-configs/src/metrics/per-capita-social-education-expenditure-pref-municipal.ts
+++ b/packages/data-configs/src/metrics/per-capita-social-education-expenditure-pref-municipal.ts
@@ -68,7 +68,7 @@ export const perCapitaSocialEducationExpenditurePrefMunicipal: MetricConfig = {
     "isCalculated": false,
   },
   "groupKey": "social-education-expenses-prefecture",
-  "isActive": false,
+  "isActive": true,
   "isFeatured": false,
   "featuredOrder": 0,
 };

--- a/packages/data-configs/src/metrics/per-capita-social-welfare-expenditure-pref-municipal.ts
+++ b/packages/data-configs/src/metrics/per-capita-social-welfare-expenditure-pref-municipal.ts
@@ -47,7 +47,7 @@ export const perCapitaSocialWelfareExpenditurePrefMunicipal: MetricConfig = {
     "isCalculated": false,
   },
   "groupKey": "social-welfare-expenses-prefecture",
-  "isActive": false,
+  "isActive": true,
   "isFeatured": false,
   "featuredOrder": 0,
 };

--- a/packages/data-configs/src/metrics/per-child-student-special-support-school-expenditure-pref-municipal.ts
+++ b/packages/data-configs/src/metrics/per-child-student-special-support-school-expenditure-pref-municipal.ts
@@ -35,7 +35,7 @@ export const perChildStudentSpecialSupportSchoolExpenditurePrefMunicipal: Metric
   },
   "groupKey": "special-support-school-expenses-prefecture",
   "seoTitle": "児童・生徒1人当たり特別支援学校費",
-  "isActive": false,
+  "isActive": true,
   "isFeatured": false,
   "featuredOrder": 0,
 };

--- a/packages/data-configs/src/metrics/population-density-per-km2-inhabitable-area.ts
+++ b/packages/data-configs/src/metrics/population-density-per-km2-inhabitable-area.ts
@@ -42,7 +42,7 @@ export const populationDensityPerKm2InhabitableArea: MetricConfig = {
   "calculation": {
     "isCalculated": false,
   },
-  "isActive": false,
+  "isActive": true,
   "isFeatured": false,
   "featuredOrder": 0,
 };

--- a/packages/data-configs/src/metrics/primary-activity-avg-time-female.ts
+++ b/packages/data-configs/src/metrics/primary-activity-avg-time-female.ts
@@ -45,7 +45,7 @@ export const primaryActivityAvgTimeFemale: MetricConfig = {
   "calculation": {
     "isCalculated": false,
   },
-  "isActive": false,
+  "isActive": true,
   "isFeatured": false,
   "featuredOrder": 0,
 };

--- a/packages/data-configs/src/metrics/primary-activity-avg-time-male.ts
+++ b/packages/data-configs/src/metrics/primary-activity-avg-time-male.ts
@@ -38,7 +38,7 @@ export const primaryActivityAvgTimeMale: MetricConfig = {
   "calculation": {
     "isCalculated": false,
   },
-  "isActive": false,
+  "isActive": true,
   "isFeatured": false,
   "featuredOrder": 0,
 };

--- a/packages/data-configs/src/metrics/public-assistance-expenses-prefecture.ts
+++ b/packages/data-configs/src/metrics/public-assistance-expenses-prefecture.ts
@@ -68,7 +68,7 @@ export const publicAssistanceExpensesPrefecture: MetricConfig = {
     "isCalculated": false,
   },
   "groupKey": "public-assistance-expenses-prefecture",
-  "isActive": false,
+  "isActive": true,
   "isFeatured": false,
   "featuredOrder": 0,
 };

--- a/packages/data-configs/src/metrics/public-bond-expenses-purpose-prefecture.ts
+++ b/packages/data-configs/src/metrics/public-bond-expenses-purpose-prefecture.ts
@@ -34,7 +34,7 @@ export const publicBondExpensesPurposePrefecture: MetricConfig = {
     "isCalculated": false,
   },
   "seoTitle": "公債費（目的別歳出内訳）",
-  "isActive": false,
+  "isActive": true,
   "isFeatured": false,
   "featuredOrder": 0,
 };

--- a/packages/data-configs/src/metrics/ratio-of-general-households-to-national.ts
+++ b/packages/data-configs/src/metrics/ratio-of-general-households-to-national.ts
@@ -32,7 +32,7 @@ export const ratioOfGeneralHouseholdsToNational: MetricConfig = {
   "calculation": {
     "isCalculated": false,
   },
-  "isActive": false,
+  "isActive": true,
   "isFeatured": false,
   "featuredOrder": 0,
 };

--- a/packages/data-configs/src/metrics/ratio-of-total-population.ts
+++ b/packages/data-configs/src/metrics/ratio-of-total-population.ts
@@ -33,7 +33,7 @@ export const ratioOfTotalPopulation: MetricConfig = {
     "isCalculated": false,
   },
   "seoTitle": "全国総人口に占める人口割合（A1101/A1101(全国)）",
-  "isActive": false,
+  "isActive": true,
   "isFeatured": false,
   "featuredOrder": 0,
 };

--- a/packages/data-configs/src/metrics/regular-cash-salary-female-pre2019.ts
+++ b/packages/data-configs/src/metrics/regular-cash-salary-female-pre2019.ts
@@ -32,7 +32,7 @@ export const regularCashSalaryFemalePre2019: MetricConfig = {
   "calculation": {
     "isCalculated": false,
   },
-  "isActive": false,
+  "isActive": true,
   "isFeatured": false,
   "featuredOrder": 0,
 };

--- a/packages/data-configs/src/metrics/regular-cash-salary-female.ts
+++ b/packages/data-configs/src/metrics/regular-cash-salary-female.ts
@@ -32,7 +32,7 @@ export const regularCashSalaryFemale: MetricConfig = {
   "calculation": {
     "isCalculated": false,
   },
-  "isActive": false,
+  "isActive": true,
   "isFeatured": false,
   "featuredOrder": 0,
 };

--- a/packages/data-configs/src/metrics/regular-cash-salary-male-pre2019.ts
+++ b/packages/data-configs/src/metrics/regular-cash-salary-male-pre2019.ts
@@ -32,7 +32,7 @@ export const regularCashSalaryMalePre2019: MetricConfig = {
   "calculation": {
     "isCalculated": false,
   },
-  "isActive": false,
+  "isActive": true,
   "isFeatured": false,
   "featuredOrder": 0,
 };

--- a/packages/data-configs/src/metrics/regular-cash-salary-male.ts
+++ b/packages/data-configs/src/metrics/regular-cash-salary-male.ts
@@ -32,7 +32,7 @@ export const regularCashSalaryMale: MetricConfig = {
   "calculation": {
     "isCalculated": false,
   },
-  "isActive": false,
+  "isActive": true,
   "isFeatured": false,
   "featuredOrder": 0,
 };

--- a/packages/data-configs/src/metrics/secondary-activity-avg-time-employed-female.ts
+++ b/packages/data-configs/src/metrics/secondary-activity-avg-time-employed-female.ts
@@ -46,7 +46,7 @@ export const secondaryActivityAvgTimeEmployedFemale: MetricConfig = {
     "isCalculated": false,
   },
   "seoTitle": "2次活動の平均時間（有業者・女）",
-  "isActive": false,
+  "isActive": true,
   "isFeatured": false,
   "featuredOrder": 0,
 };

--- a/packages/data-configs/src/metrics/secondary-activity-avg-time-employed-male.ts
+++ b/packages/data-configs/src/metrics/secondary-activity-avg-time-employed-male.ts
@@ -46,7 +46,7 @@ export const secondaryActivityAvgTimeEmployedMale: MetricConfig = {
     "isCalculated": false,
   },
   "seoTitle": "2次活動の平均時間（有業者・男）",
-  "isActive": false,
+  "isActive": true,
   "isFeatured": false,
   "featuredOrder": 0,
 };

--- a/packages/data-configs/src/metrics/secondary-activity-avg-time-unemployed-female.ts
+++ b/packages/data-configs/src/metrics/secondary-activity-avg-time-unemployed-female.ts
@@ -46,7 +46,7 @@ export const secondaryActivityAvgTimeUnemployedFemale: MetricConfig = {
     "isCalculated": false,
   },
   "seoTitle": "2次活動の平均時間（無業者・女）",
-  "isActive": false,
+  "isActive": true,
   "isFeatured": false,
   "featuredOrder": 0,
 };

--- a/packages/data-configs/src/metrics/secondary-activity-avg-time-unemployed-male.ts
+++ b/packages/data-configs/src/metrics/secondary-activity-avg-time-unemployed-male.ts
@@ -42,7 +42,7 @@ export const secondaryActivityAvgTimeUnemployedMale: MetricConfig = {
     "isCalculated": false,
   },
   "seoTitle": "2次活動の平均時間（無業者・男）",
-  "isActive": false,
+  "isActive": true,
   "isFeatured": false,
   "featuredOrder": 0,
 };

--- a/packages/data-configs/src/metrics/sewerage-penetration-rate-2012on.ts
+++ b/packages/data-configs/src/metrics/sewerage-penetration-rate-2012on.ts
@@ -34,7 +34,7 @@ export const seweragePenetrationRate2012on: MetricConfig = {
     "isCalculated": false,
   },
   "seoTitle": "下水道普及率（2012－）",
-  "isActive": false,
+  "isActive": true,
   "isFeatured": false,
   "featuredOrder": 0,
 };

--- a/packages/data-configs/src/metrics/sewerage-penetration-rate-pre2011.ts
+++ b/packages/data-configs/src/metrics/sewerage-penetration-rate-pre2011.ts
@@ -34,7 +34,7 @@ export const seweragePenetrationRatePre2011: MetricConfig = {
     "isCalculated": false,
   },
   "seoTitle": "下水道普及率（－2011）",
-  "isActive": false,
+  "isActive": true,
   "isFeatured": false,
   "featuredOrder": 0,
 };

--- a/packages/data-configs/src/metrics/sex-old-population-ratio.ts
+++ b/packages/data-configs/src/metrics/sex-old-population-ratio.ts
@@ -36,7 +36,7 @@ export const sexOldPopulationRatio: MetricConfig = {
     "isCalculated": false,
   },
   "seoTitle": "人口性比（65歳以上人口) (A130301/A130302)",
-  "isActive": false,
+  "isActive": true,
   "isFeatured": false,
   "featuredOrder": 0,
 };

--- a/packages/data-configs/src/metrics/sex-production-age-population-ratio.ts
+++ b/packages/data-configs/src/metrics/sex-production-age-population-ratio.ts
@@ -36,7 +36,7 @@ export const sexProductionAgePopulationRatio: MetricConfig = {
     "isCalculated": false,
   },
   "seoTitle": "人口性比（15～64歳人口）(A130201/A130202)",
-  "isActive": false,
+  "isActive": true,
   "isFeatured": false,
   "featuredOrder": 0,
 };

--- a/packages/data-configs/src/metrics/sex-young-population-ratio.ts
+++ b/packages/data-configs/src/metrics/sex-young-population-ratio.ts
@@ -36,7 +36,7 @@ export const sexYoungPopulationRatio: MetricConfig = {
     "isCalculated": false,
   },
   "seoTitle": "人口性比（15歳未満人口）(A130101/A130102)",
-  "isActive": false,
+  "isActive": true,
   "isFeatured": false,
   "featuredOrder": 0,
 };

--- a/packages/data-configs/src/metrics/social-education-expenses-prefecture.ts
+++ b/packages/data-configs/src/metrics/social-education-expenses-prefecture.ts
@@ -74,7 +74,7 @@ export const socialEducationExpensesPrefecture: MetricConfig = {
     "isCalculated": false,
   },
   "groupKey": "social-education-expenses-prefecture",
-  "isActive": false,
+  "isActive": true,
   "isFeatured": false,
   "featuredOrder": 0,
 };

--- a/packages/data-configs/src/metrics/social-welfare-expenses-prefecture.ts
+++ b/packages/data-configs/src/metrics/social-welfare-expenses-prefecture.ts
@@ -47,7 +47,7 @@ export const socialWelfareExpensesPrefecture: MetricConfig = {
     "isCalculated": false,
   },
   "groupKey": "social-welfare-expenses-prefecture",
-  "isActive": false,
+  "isActive": true,
   "isFeatured": false,
   "featuredOrder": 0,
 };

--- a/packages/data-configs/src/metrics/special-support-school-expenses-prefecture.ts
+++ b/packages/data-configs/src/metrics/special-support-school-expenses-prefecture.ts
@@ -68,7 +68,7 @@ export const specialSupportSchoolExpensesPrefecture: MetricConfig = {
     "isCalculated": false,
   },
   "groupKey": "special-support-school-expenses-prefecture",
-  "isActive": false,
+  "isActive": true,
   "isFeatured": false,
   "featuredOrder": 0,
 };

--- a/packages/data-configs/src/metrics/tertiary-activity-avg-time-employed-female.ts
+++ b/packages/data-configs/src/metrics/tertiary-activity-avg-time-employed-female.ts
@@ -44,7 +44,7 @@ export const tertiaryActivityAvgTimeEmployedFemale: MetricConfig = {
     "isCalculated": false,
   },
   "seoTitle": "3次活動の平均時間（有業者・女）",
-  "isActive": false,
+  "isActive": true,
   "isFeatured": false,
   "featuredOrder": 0,
 };

--- a/packages/data-configs/src/metrics/tertiary-activity-avg-time-employed-male.ts
+++ b/packages/data-configs/src/metrics/tertiary-activity-avg-time-employed-male.ts
@@ -39,7 +39,7 @@ export const tertiaryActivityAvgTimeEmployedMale: MetricConfig = {
     "isCalculated": false,
   },
   "seoTitle": "3次活動の平均時間（有業者・男）",
-  "isActive": false,
+  "isActive": true,
   "isFeatured": false,
   "featuredOrder": 0,
 };

--- a/packages/data-configs/src/metrics/tertiary-activity-avg-time-unemployed-female.ts
+++ b/packages/data-configs/src/metrics/tertiary-activity-avg-time-unemployed-female.ts
@@ -46,7 +46,7 @@ export const tertiaryActivityAvgTimeUnemployedFemale: MetricConfig = {
     "isCalculated": false,
   },
   "seoTitle": "3次活動の平均時間（無業者・女）",
-  "isActive": false,
+  "isActive": true,
   "isFeatured": false,
   "featuredOrder": 0,
 };

--- a/packages/data-configs/src/metrics/tertiary-activity-avg-time-unemployed-male.ts
+++ b/packages/data-configs/src/metrics/tertiary-activity-avg-time-unemployed-male.ts
@@ -46,7 +46,7 @@ export const tertiaryActivityAvgTimeUnemployedMale: MetricConfig = {
     "isCalculated": false,
   },
   "seoTitle": "3次活動の平均時間（無業者・男）",
-  "isActive": false,
+  "isActive": true,
   "isFeatured": false,
   "featuredOrder": 0,
 };

--- a/packages/data-configs/src/metrics/total-area-including-northern-territories-and-takeshima.ts
+++ b/packages/data-configs/src/metrics/total-area-including-northern-territories-and-takeshima.ts
@@ -35,7 +35,7 @@ export const totalAreaIncludingNorthernTerritoriesAndTakeshima: MetricConfig = {
     "isCalculated": false,
   },
   "seoTitle": "総面積（北方地域及び竹島を含む）",
-  "isActive": false,
+  "isActive": true,
   "isFeatured": false,
   "featuredOrder": 0,
 };

--- a/packages/data-configs/src/metrics/water-supply-population-ratio-2012on.ts
+++ b/packages/data-configs/src/metrics/water-supply-population-ratio-2012on.ts
@@ -34,7 +34,7 @@ export const waterSupplyPopulationRatio2012on: MetricConfig = {
     "isCalculated": false,
   },
   "seoTitle": "上水道給水人口比率（2012－）",
-  "isActive": false,
+  "isActive": true,
   "isFeatured": false,
   "featuredOrder": 0,
 };

--- a/packages/data-configs/src/metrics/water-supply-population-ratio-pre2011.ts
+++ b/packages/data-configs/src/metrics/water-supply-population-ratio-pre2011.ts
@@ -34,7 +34,7 @@ export const waterSupplyPopulationRatioPre2011: MetricConfig = {
     "isCalculated": false,
   },
   "seoTitle": "上水道給水人口比率（－2011）",
-  "isActive": false,
+  "isActive": true,
   "isFeatured": false,
   "featuredOrder": 0,
 };

--- a/packages/data-configs/src/metrics/work-avg-time-employed-female.ts
+++ b/packages/data-configs/src/metrics/work-avg-time-employed-female.ts
@@ -44,7 +44,7 @@ export const workAvgTimeEmployedFemale: MetricConfig = {
     "isCalculated": false,
   },
   "seoTitle": "仕事の平均時間（有業者・女）",
-  "isActive": false,
+  "isActive": true,
   "isFeatured": false,
   "featuredOrder": 0,
 };

--- a/packages/data-configs/src/metrics/work-avg-time-employed-male.ts
+++ b/packages/data-configs/src/metrics/work-avg-time-employed-male.ts
@@ -36,7 +36,7 @@ export const workAvgTimeEmployedMale: MetricConfig = {
     "isCalculated": false,
   },
   "seoTitle": "仕事の平均時間（有業者・男）",
-  "isActive": false,
+  "isActive": true,
   "isFeatured": false,
   "featuredOrder": 0,
 };


### PR DESCRIPTION
## 概要

D1→R2 移行時に未キュレーションのまま `isActive: false` だった metric config 207件を分類・検証し、**完全データ(47県揃い)の独立指標122件**を `isActive: true` に変更する。これは **config(SSOT) の変更**であり、実際の 410→200 公開には下流パイプライン (別途) が必要。

## 選定 (証拠ベース)

| 区分 | 件数 | 扱い |
|---|---|---|
| 完全データ・独立指標 | **122** | 本PRで活性化 |
| 重複/廃止/単年版 (-alt/-old/s60/h27) | 76 | 非活性維持 (重複コンテンツ回避) |
| データ404 | 8 | スキップ (要 e-Stat 取込) |
| 部分カバレッジ | 1 | 別判断 |

全122件で values.json 最新年カバレッジ ≥45県を検証済。

## ⚠️ 重要: 本PRだけでは公開されない

調査の結果、**config → R2 `app/ranking/<key>/item.json` の isActive を refresh する生成コードが現状存在しない**ことが判明 (`ranking-items-per-url-snapshot.ts` L38-40 が "config→item.json field refresh は follow-up" と明記、master exporter は既存 item.json の再グループ化のみ)。

410→200 の活性化には以下の follow-up が必要:
1. **config→item.json refresh ツール** (新規実装が必要 / dbless SSOT 準拠)
2. `generate-known-ranking-keys` 再生成 (item.json の isActive を読む 410ゲート)
3. sitemap-ranking-keys 再生成
4. アプリ再デプロイ
5. Indexing API 投入

本PRは①の入力となる **SSOT の正しい状態**を確定する基盤。検証 (validate:years 2209 configs / tsc) は通過済。

🤖 Generated with [Claude Code](https://claude.com/claude-code)