### PR TITLE
AFF-03: ランキングサイドバーにアフィリエイトバナー枠を追加 (案A)

### DIFF
--- a/apps/web/src/features/ads/components/AffiliateAdSlot.tsx
+++ b/apps/web/src/features/ads/components/AffiliateAdSlot.tsx
@@ -4,10 +4,14 @@ import {
 } from "@/lib/google-adsense";
 
 import { CATEGORY_AFFILIATE_MAP } from "../constants/affiliate-category";
-import { resolveAffiliateTextAds } from "../services";
+import {
+  resolveAffiliateBannersByCategoryKey,
+  resolveAffiliateTextAds,
+} from "../services";
 
 import { AdSenseAdWrapper } from "./AdSenseAdWrapper";
 import { AffiliateTextAdList } from "./AffiliateTextAdList";
+import { BannerAd } from "./BannerAd";
 
 import type { AffiliateLocationCode } from "../types";
 
@@ -23,26 +27,51 @@ function mapPositionToLocation(position: "sidebar" | "footer"): AffiliateLocatio
 /**
  * アフィリエイト広告スロット。
  *
- * 優先順位:
- * 1. テキスト広告 (最大 2 件) を解決して並べて表示
- * 2. なければ AdSense にフォールバック
+ * 優先順位 (AFF-03 でバナーを最優先に追加):
+ * 1. バナー広告 (sidebar のみ・categoryKey 一致の上位1件) — 視認性が高く impression を稼ぐ
+ * 2. テキスト広告 (最大 2 件)
+ * 3. なければ AdSense にフォールバック
+ *
+ * バナー在庫の無いカテゴリ (広告ゼロ8軸など) は 2→3 に流れるため従来挙動と同じ。
+ * 本コンポーネントは async Server Component で R2 を build 時に解決する
+ * (cookies()/headers() を使わないため SSG を壊さない: nextjs-ssg-preservation.md)。
  */
 export async function AffiliateAdSlot({
   categoryKey,
   position = "sidebar",
 }: AffiliateAdSlotProps) {
   const locationCode = mapPositionToLocation(position);
-  const ads = await resolveAffiliateTextAds(categoryKey, locationCode, 2);
+  const affiliateCategory = CATEGORY_AFFILIATE_MAP[categoryKey] ?? null;
 
-  // アフィリエイトテキスト広告があればそれを表示
+  // 1. バナー優先 (sidebar のみ)。ranking の主要トラフィックに視認性の高い枠を出す。
+  if (position === "sidebar") {
+    const banners = await resolveAffiliateBannersByCategoryKey(categoryKey, 1);
+    const banner = banners[0];
+    if (banner) {
+      return (
+        <BannerAd
+          href={banner.href}
+          imageUrl={banner.imageUrl}
+          trackingPixelUrl={banner.trackingPixelUrl}
+          width={banner.width}
+          height={banner.height}
+          category={affiliateCategory ?? "other"}
+          label={banner.title}
+          position="ranking-sidebar"
+        />
+      );
+    }
+  }
+
+  // 2. テキスト広告
+  const ads = await resolveAffiliateTextAds(categoryKey, locationCode, 2);
   if (ads.length > 0) {
-    const affiliateCategory = CATEGORY_AFFILIATE_MAP[categoryKey] ?? null;
     return (
       <AffiliateTextAdList ads={ads} affiliateCategory={affiliateCategory} position={position} />
     );
   }
 
-  // AdSense フォールバック
+  // 3. AdSense フォールバック
   const adSlot =
     position === "footer" ? RANKING_PAGE_FOOTER : RANKING_PAGE_TABLE_SIDE;
 

--- a/apps/web/src/features/ads/server.ts
+++ b/apps/web/src/features/ads/server.ts
@@ -10,6 +10,7 @@ export {
   resolveAffiliateAd,
   resolveAffiliateBanners,
   resolveAffiliateBannersByCategory,
+  resolveAffiliateBannersByCategoryKey,
   resolveAffiliateTextAds,
   resolveAffiliateTextAdsByTagKeys,
 } from "./services/resolve-affiliate-ad";

--- a/apps/web/src/features/ads/services/index.ts
+++ b/apps/web/src/features/ads/services/index.ts
@@ -1,6 +1,7 @@
 export {
   resolveAffiliateAd,
   resolveAffiliateBanners,
+  resolveAffiliateBannersByCategoryKey,
   resolveAffiliateTextAds,
   resolveAffiliateTextAdsByTagKeys,
 } from "./resolve-affiliate-ad";

--- a/apps/web/src/features/ads/services/resolve-affiliate-ad.ts
+++ b/apps/web/src/features/ads/services/resolve-affiliate-ad.ts
@@ -144,6 +144,31 @@ export async function resolveAffiliateBanners(
 }
 
 /**
+ * 単一 categoryKey に対応するバナー広告を priority 降順で解決する (最大 limit 件)。
+ * ランキング / カテゴリ等、categoryKey を持つページのサイドバーにバナーを出す用途。
+ * (resolveAffiliateBanners は tagKey ベースのため、categoryKey 直指定はこちらを使う)
+ */
+export async function resolveAffiliateBannersByCategoryKey(
+  categoryKey: string,
+  limit = 1
+): Promise<ResolvedAffiliateBanner[]> {
+  if (!categoryKey) return [];
+
+  const banners = await findActiveBannersByCategoryKeys([categoryKey], limit);
+
+  return banners
+    .filter((b) => b.imageUrl && b.trackingPixelUrl)
+    .map((b) => ({
+      title: b.title,
+      href: b.htmlContent,
+      imageUrl: b.imageUrl!,
+      trackingPixelUrl: b.trackingPixelUrl!,
+      width: b.width ?? 300,
+      height: b.height ?? 250,
+    }));
+}
+
+/**
  * すべての AffiliateCategory に対してバナーを一括解決する。
  * category prop で affiliate-banner を宣言的に配置する際のサーバー側解決に使う。
  */

--- a/docs/05_改善ログ/affiliate.md
+++ b/docs/05_改善ログ/affiliate.md
@@ -68,25 +68,29 @@ agent 用詳細 (検証コマンド・仮説・実測) は 2 層構造の下層
 
 ---
 
-## [AFF-03] ランキングページのバナー枠検討 (要・設計レビュー)
+## [AFF-03] ランキングページのバナー枠追加 (案A 実装)
 
-- **status**: pending
+- **status**: in-progress
 - **tier**: 2
 - **target_metric**: affiliate/impression
 - **owner**: claude
+- **deployed_at**: 2026-06-04
 - **due**: 2026-06-28
-- **verification_command**: `curl -s -A "Googlebot" "https://stats47.jp/ranking/<key>" | grep -c affiliate`
-- **related_pr**: -
+- **verification_command**: `curl -s -A "Googlebot" "https://stats47.jp/ranking/<banner在庫のあるkey>" | grep -c "a8.net"`
+- **related_pr**: (develop→main PR)
 
 **[仮説]** ランキング詳細 (`/ranking/[rankingKey]`) はサイトの主要トラフィックだが、現状 affiliate は
 `sidebar-bottom` の **text 18 枠**のみで banner impression がゼロ。視認性の高い banner 枠を 1 つ足せば
 impression が大きく増える可能性。
 
-- **設計提案 (承認待ち)**: `docs/40_アフィリエイト管理/AFF-03-ranking-banner-design.md`
-- **SSG リスクは低い** (確認済): ranking サイドバーの `AffiliateAdSlot` は既に async Server Component で
-  R2 を build 時解決しており、`cookies()/headers()` を増やさなければ force-dynamic 化しない。推奨案 A は
-  `AffiliateAdSlot.tsx` 1 ファイルにバナー優先を足す外科的変更。
-- 実装は本ログとは別 PR で、`next build` の `○ Static` 維持を確認してから。
+- **設計**: `docs/40_アフィリエイト管理/AFF-03-ranking-banner-design.md` (案A 採用)
+- **実装 (2026-06-04)**: `AffiliateAdSlot` の解決優先順位を「バナー → テキスト → AdSense」に変更。
+  - `resolveAffiliateBannersByCategoryKey(categoryKey, 1)` を新設 (services / server から export)
+  - sidebar のみバナー優先。banner 在庫の無い 8 軸は従来どおり text→AdSense にフォールバック
+  - `cookies()/headers()` を追加していないため SSG は維持 (既存 async RSC と同パターン)。型チェック green。
+  - SSG (`○ Static`) の最終確認は CI の `next build` に委ねる (ローカルはフルビルド未実行)
+- **検証期日後の判定**: 本番 ranking の HTML に banner が描画され、`ad_impression(link_position=ranking-sidebar)` が
+  GA4 で観測されれば前進。CTR は AFF-04 で評価。
 - **検証期日後の判定**: 本番 ranking の HTML に banner が描画され、`ad_impression(link_position=ranking-*)` が
   GA4 で観測されれば前進。CTR は AFF-04 で評価。
 


### PR DESCRIPTION
## 概要

AFF-03 実装。ランキング詳細 (`/ranking/[rankingKey]`) サイドバーの `AffiliateAdSlot` の解決優先順位を **「バナー → テキスト → AdSense」** に変更し、主要トラフィックに視認性の高いバナー impression を出す。現状はテキスト枠のみで banner impression がゼロだったのを是正。

設計: `docs/40_アフィリエイト管理/AFF-03-ranking-banner-design.md` (案A 採用)

## 変更

- **新規 service** `resolveAffiliateBannersByCategoryKey(categoryKey, limit=1)` — `resolveAffiliateBanners` は tagKey ベースのため、categoryKey 直指定でバナーを解決する関数を追加 (services/index.ts・server.ts から export)。
- **`AffiliateAdSlot`** — `position="sidebar"` 時に categoryKey 一致バナー上位1件を `BannerAd` で表示。banner 在庫の無いカテゴリ (広告ゼロ8軸) は従来どおり text→AdSense にフォールバック。
- 利用箇所はランキング詳細ページ1箇所のみ (外科的)。

## SSG 保全 (nextjs-ssg-preservation.md)

- `cookies()/headers()/draftMode()` を**一切追加していない**。既存の `AffiliateAdSlot` と同じ async Server Component + R2 build 時解決 + client コンポーネント描画パターンの踏襲のため **force-dynamic 化しない**。
- ローカル型チェック green。**SSG (`○ Static`) の最終確認は本 PR の CI `next build` に委ねる** (ローカルではフルビルド未実行)。

## 効果計測

- デプロイ後、本番 ranking HTML に banner が描画されるか + GA4 `ad_impression(link_position=ranking-sidebar)` を観測。
- 4 週後に CTR を含め `docs/05_改善ログ/affiliate.md` AFF-03 で before/after 判定 (実証チェックリスト準拠)。

https://claude.ai/code/session_014ZS3u9RyVQZS2a7R5GomsN

---
_Generated by [Claude Code](https://claude.ai/code/session_014ZS3u9RyVQZS2a7R5GomsN)_