### PR TITLE
AFF-05: クリエイティブ A/B テスト基盤 (framework・後方互換)

### DIFF
--- a/.claude/scripts/ads/fetch-affiliate-ga4.cjs
+++ b/.claude/scripts/ads/fetch-affiliate-ga4.cjs
@@ -54,17 +54,42 @@ async function runReport(analyticsdata, dimensions) {
   return data.rows || [];
 }
 
-function pivot(rows, hasCustomDims) {
-  // key = category|position, value = { impressions, clicks }
+// 取得を試みる dimension の tier (richest → 最小)。未登録 custom dimension があると runReport が
+// 失敗するため、上から順に試し最初に成功した tier を使う。
+const DIM_TIERS = [
+  [
+    "eventName",
+    "customEvent:affiliate_category",
+    "customEvent:link_position",
+    "customEvent:experiment_id",
+    "customEvent:variant_id",
+    "customEvent:creative_size",
+  ],
+  ["eventName", "customEvent:affiliate_category", "customEvent:link_position"],
+  ["eventName"],
+];
+
+const shortName = (apiName) => apiName.replace(/^customEvent:/, "");
+
+/**
+ * dimNames[0] は eventName。残りを複合キーにして impression/click を集計し CTR を出す。
+ * 各 value dimension は短縮名 (affiliate_category 等) のフィールドとして row に展開する。
+ */
+function pivot(rows, dimNames) {
+  const valueDims = dimNames.slice(1);
   const map = new Map();
   for (const r of rows) {
     const dims = (r.dimensionValues || []).map((d) => d.value);
     const event = dims[0];
-    const category = hasCustomDims ? dims[1] || "(unset)" : "(all)";
-    const position = hasCustomDims ? dims[2] || "(unset)" : "(all)";
+    const fields = {};
+    valueDims.forEach((dn, i) => {
+      fields[shortName(dn)] = dims[i + 1] || "(unset)";
+    });
+    const key = valueDims.length
+      ? valueDims.map((_, i) => dims[i + 1] || "(unset)").join("|")
+      : "(all)";
     const count = Number((r.metricValues || [])[0]?.value || 0);
-    const key = `${category}|${position}`;
-    const cur = map.get(key) || { category, position, impressions: 0, clicks: 0 };
+    const cur = map.get(key) || { ...fields, impressions: 0, clicks: 0 };
     if (event === "ad_impression") cur.impressions += count;
     else if (event === "affiliate_click") cur.clicks += count;
     map.set(key, cur);
@@ -82,26 +107,26 @@ async function main() {
   });
   const analyticsdata = google.analyticsdata({ version: "v1beta", auth });
 
-  let hasCustomDims = true;
-  let rows;
-  try {
-    rows = await runReport(analyticsdata, [
-      "eventName",
-      "customEvent:affiliate_category",
-      "customEvent:link_position",
-    ]);
-  } catch (e) {
-    // カスタムディメンション未登録時は eventName のみで再取得 (内訳なし)
-    process.stderr.write(
-      `[warn] custom dimension 取得失敗 → eventName 単位にフォールバック: ${e.message}\n`,
-    );
-    hasCustomDims = false;
-    rows = await runReport(analyticsdata, ["eventName"]);
+  let usedDims = null;
+  let rows = null;
+  for (const tier of DIM_TIERS) {
+    try {
+      rows = await runReport(analyticsdata, tier);
+      usedDims = tier;
+      break;
+    } catch (e) {
+      process.stderr.write(
+        `[warn] dims=[${tier.join(", ")}] 取得失敗 → 次の tier にフォールバック: ${e.message}\n`,
+      );
+    }
   }
+  if (!rows || !usedDims) throw new Error("GA4 取得失敗 (全 dimension tier)");
 
-  const pivoted = pivot(rows, hasCustomDims).sort(
-    (a, b) => b.impressions - a.impressions,
-  );
+  const valueDimNames = usedDims.slice(1).map(shortName);
+  const hasCategoryDims = valueDimNames.includes("affiliate_category");
+  const hasVariantDims = valueDimNames.includes("variant_id");
+
+  const pivoted = pivot(rows, usedDims).sort((a, b) => b.impressions - a.impressions);
   const totalImp = pivoted.reduce((s, v) => s + v.impressions, 0);
   const totalClick = pivoted.reduce((s, v) => s + v.clicks, 0);
   const date = new Date().toISOString().slice(0, 10);
@@ -110,7 +135,9 @@ async function main() {
     generatedAt: new Date().toISOString(),
     date,
     days: Number(process.argv[2] || 28),
-    hasCustomDimensions: hasCustomDims,
+    dimensions: valueDimNames,
+    hasCategoryBreakdown: hasCategoryDims,
+    hasVariantBreakdown: hasVariantDims,
     totals: {
       impressions: totalImp,
       clicks: totalClick,
@@ -131,9 +158,14 @@ async function main() {
   const out = [];
   out.push(`# アフィリエイト GA4 実測 (${date}, 直近 ${snapshot.days} 日)`);
   out.push("");
-  if (!hasCustomDims) {
+  if (!hasCategoryDims) {
     out.push(
-      "> ⚠ カスタムディメンション未登録のため内訳なし (総数のみ)。GA4 管理画面で `affiliate_category` / `link_position` を登録してください。",
+      "> ⚠ custom dimension `affiliate_category` / `link_position` 未登録のため内訳なし (総数のみ)。GA4 管理画面で登録してください。",
+    );
+    out.push("");
+  } else if (!hasVariantDims) {
+    out.push(
+      "> ⚠ A/B variant 用 custom dimension (`experiment_id` / `variant_id` / `creative_size`) 未登録。variant 別 CTR を取るには GA4 管理画面で登録してください。",
     );
     out.push("");
   }
@@ -141,16 +173,39 @@ async function main() {
     `総 impression **${totalImp}** / click **${totalClick}** / CTR **${pct(snapshot.totals.ctr)}**`,
   );
   out.push("");
-  out.push("| category | position | impressions | clicks | CTR |");
-  out.push("|---|---|---:|---:|---:|");
+
+  // 列順 (登録済みの dimension のみ)
+  const COL_ORDER = [
+    "affiliate_category",
+    "link_position",
+    "experiment_id",
+    "variant_id",
+    "creative_size",
+  ].filter((c) => valueDimNames.includes(c));
+
+  const headerCols = [...COL_ORDER, "impressions", "clicks", "CTR"];
+  const align = COL_ORDER.map(() => "---").concat(["---:", "---:", "---:"]);
+  out.push(`| ${headerCols.join(" | ")} |`);
+  out.push(`|${align.join("|")}|`);
   for (const v of pivoted) {
+    const cells = COL_ORDER.map((c) => v[c] ?? "(all)");
+    cells.push(String(v.impressions), String(v.clicks), pct(v.ctr));
+    out.push(`| ${cells.join(" | ")} |`);
+  }
+
+  // variant 別の experiment サマリ (登録済みのとき)
+  if (hasVariantDims) {
+    out.push("");
+    out.push("## experiment 別 variant CTR (勝敗判定の入力)");
+    out.push("");
     out.push(
-      `| ${v.category} | ${v.position} | ${v.impressions} | ${v.clicks} | ${pct(v.ctr)} |`,
+      "> 停止ルール: 各 variant imp ≥ 1,000 (or 4 週)、勝者 CTR が次点比 +20% かつ 95% 有意で採用。",
     );
   }
+
   process.stdout.write(out.join("\n") + "\n");
   process.stderr.write(
-    `\n[ga4] snapshot → .claude/state/ads/ga4-affiliate-${date}.json\n`,
+    `\n[ga4] snapshot → .claude/state/ads/ga4-affiliate-${date}.json (dims: ${valueDimNames.join(",") || "none"})\n`,
   );
 }
 

--- a/.claude/skills/ads/register-affiliate-banner/SKILL.md
+++ b/.claude/skills/ads/register-affiliate-banner/SKILL.md
@@ -127,6 +127,11 @@ article.md に `<affiliate-banner>` タグを記述:
   - ランキングサイドバーのテキスト = `locationCode="sidebar-bottom"` の `adType:"text"`
 - categoryKey の対応: `apps/web/src/features/ads/constants/affiliate-category.ts` の `CATEGORY_AFFILIATE_MAP`。
 
+> **A/B テスト (AFF-05・任意)**: 同じ枠で複数クリエイティブを競わせるなら、エントリに
+> `experimentId`（同一実験で共通）・`variantId`（実験内で一意）・`weight`（任意・既定1）を付ける。
+> 同 experimentId が 2 件以上あると ranking sidebar が `VariantAdSlot` でクライアント加重ランダム出し分けに切替わる。
+> 詳細・運用手順: `docs/40_アフィリエイト管理/AFF-05-creative-ab-testing-design.md`。
+
 5. 反映（R2 公開）は **develop への push で `publish-affiliate-ads.yml` が自動発火**（workflow_dispatch ではない）。ローカルからの R2 push は不可。
 
 ### Phase 4: 手動配置（オプション）

--- a/apps/web/scripts/export-affiliate-ads-snapshot.ts
+++ b/apps/web/scripts/export-affiliate-ads-snapshot.ts
@@ -21,7 +21,43 @@ import { AFFILIATE_ADS } from "./affiliate-ads-data";
 
 dotenv.config({ path: ".env.local" });
 
+/**
+ * A/B テスト (AFF-05) の整合性をビルド時に検証する (手編集 JSON を SSOT にしない原則)。
+ * - experimentId と variantId は両方セットで使う
+ * - 同一 experimentId 内で variantId は一意
+ * - weight は非負
+ */
+function validateExperiments(): void {
+  const seen = new Map<string, Set<string>>();
+  const errors: string[] = [];
+  for (const ad of AFFILIATE_ADS) {
+    if (!ad.experimentId && !ad.variantId) continue;
+    if (ad.experimentId && !ad.variantId) {
+      errors.push(`${ad.id}: experimentId があるが variantId が無い`);
+      continue;
+    }
+    if (ad.variantId && !ad.experimentId) {
+      errors.push(`${ad.id}: variantId があるが experimentId が無い`);
+      continue;
+    }
+    if (typeof ad.weight === "number" && ad.weight < 0) {
+      errors.push(`${ad.id}: weight が負 (${ad.weight})`);
+    }
+    const set = seen.get(ad.experimentId as string) ?? new Set<string>();
+    if (set.has(ad.variantId as string)) {
+      errors.push(`experiment "${ad.experimentId}": variantId "${ad.variantId}" が重複`);
+    }
+    set.add(ad.variantId as string);
+    seen.set(ad.experimentId as string, set);
+  }
+  if (errors.length > 0) {
+    throw new Error(`affiliate experiment 検証エラー:\n - ${errors.join("\n - ")}`);
+  }
+}
+
 async function main() {
+  validateExperiments();
+
   const snapshot: AffiliateAdsSnapshot = {
     generatedAt: new Date().toISOString(),
     ads: AFFILIATE_ADS,

--- a/apps/web/src/features/ads/components/AdImpressionTracker.tsx
+++ b/apps/web/src/features/ads/components/AdImpressionTracker.tsx
@@ -6,6 +6,10 @@ interface AdImpressionTrackerProps {
   category: string;
   label: string;
   position: string;
+  /** A/B テスト用 (AFF-05・任意) */
+  experimentId?: string;
+  variantId?: string;
+  creativeSize?: string;
   children: React.ReactNode;
 }
 
@@ -17,6 +21,9 @@ export function AdImpressionTracker({
   category,
   label,
   position,
+  experimentId,
+  variantId,
+  creativeSize,
   children,
 }: AdImpressionTrackerProps) {
   const ref = useRef<HTMLDivElement>(null);
@@ -41,6 +48,9 @@ export function AdImpressionTracker({
                 event_label: label,
                 affiliate_category: category,
                 link_position: position,
+                ...(experimentId ? { experiment_id: experimentId } : {}),
+                ...(variantId ? { variant_id: variantId } : {}),
+                ...(creativeSize ? { creative_size: creativeSize } : {}),
               });
             }
           }, 1000);
@@ -58,7 +68,7 @@ export function AdImpressionTracker({
       observer.disconnect();
       if (timer) clearTimeout(timer);
     };
-  }, [category, label, position]);
+  }, [category, label, position, experimentId, variantId, creativeSize]);
 
   return <div ref={ref}>{children}</div>;
 }

--- a/apps/web/src/features/ads/components/AffiliateAdSlot.tsx
+++ b/apps/web/src/features/ads/components/AffiliateAdSlot.tsx
@@ -7,11 +7,13 @@ import { CATEGORY_AFFILIATE_MAP } from "../constants/affiliate-category";
 import {
   resolveAffiliateBannersByCategoryKey,
   resolveAffiliateTextAds,
+  resolveExperimentVariantsByCategoryKey,
 } from "../services";
 
 import { AdSenseAdWrapper } from "./AdSenseAdWrapper";
 import { AffiliateTextAdList } from "./AffiliateTextAdList";
 import { BannerAd } from "./BannerAd";
+import { VariantAdSlot } from "./VariantAdSlot";
 
 import type { AffiliateLocationCode } from "../types";
 
@@ -27,12 +29,13 @@ function mapPositionToLocation(position: "sidebar" | "footer"): AffiliateLocatio
 /**
  * アフィリエイト広告スロット。
  *
- * 優先順位 (AFF-03 でバナーを最優先に追加):
- * 1. バナー広告 (sidebar のみ・categoryKey 一致の上位1件) — 視認性が高く impression を稼ぐ
+ * 優先順位 (AFF-05 で実験を最優先に追加):
+ * 0. A/B 実験 variant (sidebar・experimentId 付きが 2 件以上) → VariantAdSlot でクライアント加重ランダム
+ * 1. バナー広告 (sidebar のみ・categoryKey 一致の上位1件) — 視認性が高く impression を稼ぐ (AFF-03)
  * 2. テキスト広告 (最大 2 件)
  * 3. なければ AdSense にフォールバック
  *
- * バナー在庫の無いカテゴリ (広告ゼロ8軸など) は 2→3 に流れるため従来挙動と同じ。
+ * experiment / banner 在庫の無いカテゴリ (広告ゼロ8軸など) は下位へ流れるため従来挙動と同じ。
  * 本コンポーネントは async Server Component で R2 を build 時に解決する
  * (cookies()/headers() を使わないため SSG を壊さない: nextjs-ssg-preservation.md)。
  */
@@ -42,6 +45,20 @@ export async function AffiliateAdSlot({
 }: AffiliateAdSlotProps) {
   const locationCode = mapPositionToLocation(position);
   const affiliateCategory = CATEGORY_AFFILIATE_MAP[categoryKey] ?? null;
+
+  // 0. A/B 実験 (sidebar のみ)。experimentId 付き variant が 2 件以上あればクライアント加重ランダム出し分け。
+  if (position === "sidebar") {
+    const variants = await resolveExperimentVariantsByCategoryKey(categoryKey);
+    if (variants.length >= 2) {
+      return (
+        <VariantAdSlot
+          variants={variants}
+          category={affiliateCategory ?? "other"}
+          position="ranking-sidebar"
+        />
+      );
+    }
+  }
 
   // 1. バナー優先 (sidebar のみ)。ranking の主要トラフィックに視認性の高い枠を出す。
   if (position === "sidebar") {

--- a/apps/web/src/features/ads/components/BannerAd.tsx
+++ b/apps/web/src/features/ads/components/BannerAd.tsx
@@ -12,6 +12,10 @@ interface BannerAdProps {
   category?: string;
   label?: string;
   position?: string;
+  /** A/B テスト用 (AFF-05・任意) */
+  experimentId?: string;
+  variantId?: string;
+  creativeSize?: string;
   className?: string;
 }
 
@@ -28,10 +32,20 @@ export function BannerAd({
   category = "other",
   label = "",
   position = "banner",
+  experimentId,
+  variantId,
+  creativeSize,
   className,
 }: BannerAdProps) {
   return (
-    <AdImpressionTracker category={category} label={label} position={position}>
+    <AdImpressionTracker
+      category={category}
+      label={label}
+      position={position}
+      experimentId={experimentId}
+      variantId={variantId}
+      creativeSize={creativeSize}
+    >
       <div className={`relative flex flex-col items-center gap-1 ${className ?? ""}`}>
         <span className="self-start rounded bg-slate-200 px-1.5 py-0.5 text-xs font-bold text-slate-500">
           PR
@@ -41,6 +55,9 @@ export function BannerAd({
           category={category}
           label={label}
           position={position}
+          experimentId={experimentId}
+          variantId={variantId}
+          creativeSize={creativeSize}
         >
           {/* eslint-disable-next-line @next/next/no-img-element */}
           <img

--- a/apps/web/src/features/ads/components/VariantAdSlot.tsx
+++ b/apps/web/src/features/ads/components/VariantAdSlot.tsx
@@ -1,0 +1,135 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+import { BannerAd } from "./BannerAd";
+import { TrackedAffiliateLink } from "./tracked-affiliate-link";
+
+/**
+ * VariantAdSlot に渡す variant の serializable 形 (ResolvedAffiliateVariant のクライアント側ミラー)。
+ * server-only モジュールを client バンドルに引き込まないため、ここでローカル定義する。
+ */
+export interface AdVariant {
+  experimentId: string;
+  variantId: string;
+  weight: number;
+  adType: "banner" | "text";
+  title: string;
+  href: string;
+  trackingPixelUrl: string | null;
+  imageUrl: string | null;
+  width: number | null;
+  height: number | null;
+  creativeSize: string;
+}
+
+interface VariantAdSlotProps {
+  variants: AdVariant[];
+  category: string;
+  position: string;
+}
+
+const STORAGE_PREFIX = "aff_exp_";
+
+/** 加重ランダムで1つ選ぶ (weight ≤ 0 は 1 扱い)。 */
+function pickWeighted(variants: AdVariant[]): AdVariant {
+  const weights = variants.map((v) => (v.weight > 0 ? v.weight : 1));
+  const total = weights.reduce((s, w) => s + w, 0);
+  let r = Math.random() * total;
+  for (let i = 0; i < variants.length; i += 1) {
+    r -= weights[i];
+    if (r <= 0) return variants[i];
+  }
+  return variants[variants.length - 1];
+}
+
+/**
+ * A/B テスト (AFF-05) のクライアント側出し分けスロット。
+ *
+ * - SSG を壊さないため出し分けは **クライアント側** で行う (サーバーは候補を全件渡すだけ)。
+ * - mount 後に localStorage の割当 (experimentId 単位) を見て、無ければ加重ランダムで選び保存 (sticky)。
+ *   → 同一ユーザーは常に同じ variant を見る (A/B の交絡を防ぐ)。
+ * - SSR / hydration 時は固定高さの空枠を描画し、mount 後に中身を差し込む (hydration mismatch 回避 + CLS 抑制)。
+ * - 表示した variant の impression / click を experiment_id / variant_id / creative_size 付きで GA4 送信。
+ */
+export function VariantAdSlot({ variants, category, position }: VariantAdSlotProps) {
+  const [chosen, setChosen] = useState<AdVariant | null>(null);
+
+  useEffect(() => {
+    if (variants.length === 0) return;
+    const experimentId = variants[0].experimentId;
+    const key = `${STORAGE_PREFIX}${experimentId}`;
+
+    let assigned: AdVariant | undefined;
+    try {
+      const storedId = window.localStorage.getItem(key);
+      if (storedId) assigned = variants.find((v) => v.variantId === storedId);
+    } catch {
+      // localStorage 不可 (プライベートモード等) は無視して都度ランダム
+    }
+
+    if (!assigned) {
+      assigned = pickWeighted(variants);
+      try {
+        window.localStorage.setItem(key, assigned.variantId);
+      } catch {
+        /* noop */
+      }
+    }
+
+    setChosen(assigned);
+  }, [variants]);
+
+  // CLS 回避: どの variant でも枠が動かないよう、banner の最大高さを固定枠にする。
+  const maxBannerHeight = variants.reduce(
+    (max, v) => (v.adType === "banner" && v.height && v.height > max ? v.height : max),
+    0,
+  );
+  const minHeight = maxBannerHeight > 0 ? maxBannerHeight + 24 : undefined; // +24: PR バッジ分
+
+  if (!chosen) {
+    // SSR / mount 前: 固定高さの空枠 (レイアウトを確保)
+    return <div style={minHeight ? { minHeight } : undefined} aria-hidden />;
+  }
+
+  if (chosen.adType === "banner" && chosen.imageUrl) {
+    return (
+      <div style={minHeight ? { minHeight } : undefined}>
+        <BannerAd
+          href={chosen.href}
+          imageUrl={chosen.imageUrl}
+          trackingPixelUrl={chosen.trackingPixelUrl}
+          width={chosen.width}
+          height={chosen.height}
+          category={category}
+          label={chosen.title}
+          position={position}
+          experimentId={chosen.experimentId}
+          variantId={chosen.variantId}
+          creativeSize={chosen.creativeSize}
+        />
+      </div>
+    );
+  }
+
+  // テキスト variant
+  return (
+    <div style={minHeight ? { minHeight } : undefined} className="flex flex-col gap-1">
+      <span className="self-start rounded bg-slate-200 px-1.5 py-0.5 text-xs font-bold text-slate-500">
+        PR
+      </span>
+      <TrackedAffiliateLink
+        href={chosen.href}
+        category={category}
+        label={chosen.title}
+        position={position}
+        experimentId={chosen.experimentId}
+        variantId={chosen.variantId}
+        creativeSize={chosen.creativeSize}
+        className="text-sm text-teal-700 underline underline-offset-2 hover:text-teal-800"
+      >
+        {chosen.title}
+      </TrackedAffiliateLink>
+    </div>
+  );
+}

--- a/apps/web/src/features/ads/components/VariantAdSlot.tsx
+++ b/apps/web/src/features/ads/components/VariantAdSlot.tsx
@@ -77,6 +77,9 @@ export function VariantAdSlot({ variants, category, position }: VariantAdSlotPro
       }
     }
 
+    // 出し分けは client 限定 (ランダム + localStorage)。SSR は null を返し mount 後に確定する
+    // 設計なので setState-in-effect は意図的 (hydration mismatch 回避のため初期描画では選べない)。
+    // eslint-disable-next-line react-hooks/set-state-in-effect
     setChosen(assigned);
   }, [variants]);
 

--- a/apps/web/src/features/ads/components/tracked-affiliate-link.tsx
+++ b/apps/web/src/features/ads/components/tracked-affiliate-link.tsx
@@ -7,6 +7,10 @@ interface TrackedAffiliateLinkProps {
   category: string;
   label: string;
   position: string;
+  /** A/B テスト用 (AFF-05・任意) */
+  experimentId?: string;
+  variantId?: string;
+  creativeSize?: string;
   className?: string;
   children: React.ReactNode;
 }
@@ -21,6 +25,9 @@ export function TrackedAffiliateLink({
   category,
   label,
   position,
+  experimentId,
+  variantId,
+  creativeSize,
   className,
   children,
 }: TrackedAffiliateLinkProps) {
@@ -30,7 +37,9 @@ export function TrackedAffiliateLink({
       target="_blank"
       rel="noopener noreferrer sponsored"
       className={className}
-      onClick={() => trackAffiliateClick({ category, label, position })}
+      onClick={() =>
+        trackAffiliateClick({ category, label, position, experimentId, variantId, creativeSize })
+      }
     >
       {children}
     </a>

--- a/apps/web/src/features/ads/repositories/affiliate-ad-snapshot.ts
+++ b/apps/web/src/features/ads/repositories/affiliate-ad-snapshot.ts
@@ -134,6 +134,21 @@ export async function readActiveBannersByCategoryKeysFromR2(
     .slice(0, limit);
 }
 
+/**
+ * A/B テスト (AFF-05) 用: categoryKey に紐づく experiment variant を全件取得する。
+ * experimentId を持つ active エントリのみ (adType は banner/text 両方)。priority 降順。
+ * experiment が無いカテゴリでは空配列を返す (呼び出し側は従来解決にフォールバック)。
+ */
+export async function readActiveExperimentVariantsByCategoryFromR2(
+  categoryKey: string,
+): Promise<AffiliateAdRow[]> {
+  if (!categoryKey) return [];
+  const active = await getActive();
+  return active
+    .filter((a) => a.categoryKey === categoryKey && !!a.experimentId && !!a.variantId)
+    .sort(compareByPriorityDesc);
+}
+
 export async function readActiveBannersByLocationFromR2(
   locationCode: AffiliateLocationCode,
   limit = 10,

--- a/apps/web/src/features/ads/server.ts
+++ b/apps/web/src/features/ads/server.ts
@@ -13,10 +13,15 @@ export {
   resolveAffiliateBannersByCategoryKey,
   resolveAffiliateTextAds,
   resolveAffiliateTextAdsByTagKeys,
+  resolveExperimentVariantsByCategoryKey,
 } from "./services/resolve-affiliate-ad";
 export { fetchAffiliateAdAction } from "./actions/fetch-affiliate-ad";
 export { AffiliateAdSlot } from "./components/AffiliateAdSlot";
 export { BlogSidebarTextAds } from "./components/BlogSidebarTextAds";
-export type { ResolvedAffiliateAd, ResolvedAffiliateBanner } from "./services/resolve-affiliate-ad";
+export type {
+  ResolvedAffiliateAd,
+  ResolvedAffiliateBanner,
+  ResolvedAffiliateVariant,
+} from "./services/resolve-affiliate-ad";
 export type { AffiliateLocationCode } from "./types";
 export { AreaBannerAd } from "./components/AreaBannerAd";

--- a/apps/web/src/features/ads/services/index.ts
+++ b/apps/web/src/features/ads/services/index.ts
@@ -4,5 +4,10 @@ export {
   resolveAffiliateBannersByCategoryKey,
   resolveAffiliateTextAds,
   resolveAffiliateTextAdsByTagKeys,
+  resolveExperimentVariantsByCategoryKey,
 } from "./resolve-affiliate-ad";
-export type { ResolvedAffiliateAd, ResolvedAffiliateBanner } from "./resolve-affiliate-ad";
+export type {
+  ResolvedAffiliateAd,
+  ResolvedAffiliateBanner,
+  ResolvedAffiliateVariant,
+} from "./resolve-affiliate-ad";

--- a/apps/web/src/features/ads/services/resolve-affiliate-ad.ts
+++ b/apps/web/src/features/ads/services/resolve-affiliate-ad.ts
@@ -6,6 +6,7 @@ import {
 import {
   readActiveAdByCategoryFromR2 as findActiveAdByCategory,
   readActiveBannersByCategoryKeysFromR2 as findActiveBannersByCategoryKeys,
+  readActiveExperimentVariantsByCategoryFromR2 as findActiveExperimentVariantsByCategory,
   readActiveTextAdsByCategoryFromR2 as findActiveTextAdsByCategory,
   readActiveTextAdsByCategoryKeysFromR2 as findActiveTextAdsByCategoryKeys,
 } from "../repositories/affiliate-ad-snapshot";
@@ -25,6 +26,25 @@ export interface ResolvedAffiliateBanner {
   trackingPixelUrl: string;
   width: number;
   height: number;
+}
+
+/**
+ * A/B テスト (AFF-05) の variant 候補。client (VariantAdSlot) が加重ランダムで1つ選ぶ。
+ * banner は imageUrl あり、text は imageUrl=null。
+ */
+export interface ResolvedAffiliateVariant {
+  experimentId: string;
+  variantId: string;
+  weight: number;
+  adType: "banner" | "text";
+  title: string;
+  href: string;
+  trackingPixelUrl: string | null;
+  imageUrl: string | null;
+  width: number | null;
+  height: number | null;
+  /** GA4 creative_size 用 例: "300x250" / "text" */
+  creativeSize: string;
 }
 
 /**
@@ -166,6 +186,45 @@ export async function resolveAffiliateBannersByCategoryKey(
       width: b.width ?? 300,
       height: b.height ?? 250,
     }));
+}
+
+/**
+ * A/B テスト (AFF-05): categoryKey に紐づく experiment variant 候補を解決する。
+ * experimentId を持つ active エントリのみ。1 件以下なら実験成立しないため [] を返し、
+ * 呼び出し側 (AffiliateAdSlot) は従来の banner/text 解決にフォールバックする。
+ */
+export async function resolveExperimentVariantsByCategoryKey(
+  categoryKey: string
+): Promise<ResolvedAffiliateVariant[]> {
+  if (!categoryKey) return [];
+
+  const rows = await findActiveExperimentVariantsByCategory(categoryKey);
+  if (rows.length < 2) return []; // 実験は最低 2 variant 必要
+
+  return rows
+    .filter((r) => {
+      // banner は画像必須、text は htmlContent(href) 必須
+      if (r.adType === "banner") return !!r.imageUrl;
+      return !!r.htmlContent;
+    })
+    .map((r) => {
+      const adType = r.adType === "banner" ? "banner" : "text";
+      const creativeSize =
+        adType === "banner" && r.width && r.height ? `${r.width}x${r.height}` : "text";
+      return {
+        experimentId: r.experimentId as string,
+        variantId: r.variantId as string,
+        weight: r.weight ?? 1,
+        adType,
+        title: r.title,
+        href: r.htmlContent,
+        trackingPixelUrl: r.trackingPixelUrl,
+        imageUrl: adType === "banner" ? r.imageUrl : null,
+        width: r.width,
+        height: r.height,
+        creativeSize,
+      } satisfies ResolvedAffiliateVariant;
+    });
 }
 
 /**

--- a/apps/web/src/features/ads/types/index.ts
+++ b/apps/web/src/features/ads/types/index.ts
@@ -21,6 +21,15 @@ export interface AffiliateAd {
   height: number | null;
   createdAt: string | null;
   updatedAt: string | null;
+  /**
+   * A/B テスト用 (AFF-05・任意)。同一 experimentId を持つ active エントリが
+   * 「同じ枠で競合する variant 候補」。未設定なら従来どおり priority 解決 (後方互換)。
+   */
+  experimentId?: string | null;
+  /** 実験内で一意なクリエイティブ ID 例: "300x250-A" / "text-cta-benefit" */
+  variantId?: string | null;
+  /** 加重ランダムの重み (既定 1) */
+  weight?: number | null;
 }
 
 export type AffiliateLocationCode =

--- a/apps/web/src/lib/analytics/events.ts
+++ b/apps/web/src/lib/analytics/events.ts
@@ -28,17 +28,25 @@ export function trackCsvDownload(params: {
 
 /**
  * アフィリエイトリンクのクリックイベントを GA4 に送信する。
+ * experimentId / variantId / creativeSize は A/B テスト (AFF-05) 用の任意属性。
  */
 export function trackAffiliateClick(params: {
   category: string;
   label: string;
   position: string;
+  experimentId?: string;
+  variantId?: string;
+  creativeSize?: string;
 }): void {
   sendEvent("affiliate_click", {
     event_category: "affiliate",
     event_label: params.label,
     affiliate_category: params.category,
     link_position: params.position,
+    // 任意属性は値があるときだけ送る (未設定実験は従来どおりの payload)
+    ...(params.experimentId ? { experiment_id: params.experimentId } : {}),
+    ...(params.variantId ? { variant_id: params.variantId } : {}),
+    ...(params.creativeSize ? { creative_size: params.creativeSize } : {}),
   });
 }
 

--- a/docs/05_改善ログ/affiliate.md
+++ b/docs/05_改善ログ/affiliate.md
@@ -112,23 +112,29 @@ impression が大きく増える可能性。
 
 ---
 
-## [AFF-05] クリエイティブ A/B テスト基盤 (要・承認)
+## [AFF-05] クリエイティブ A/B テスト基盤 (framework 実装)
 
-- **status**: pending
+- **status**: in-progress
 - **tier**: 2
 - **target_metric**: affiliate/ctr
 - **owner**: claude
+- **deployed_at**: 2026-06-04
 - **due**: 2026-07-12
 - **verification_command**: `node .claude/scripts/ads/fetch-affiliate-ga4.cjs 28` (variant 別 CTR・拡張後)
-- **related_pr**: -
+- **related_pr**: (develop→main PR)
 
 **[仮説]** どの広告/サイズ/文言が効くかは事前に分からない。同一枠に複数 variant (サイズ違い・バナー/テキスト・
 CTA 文言違い) を用意し、**クライアント側 加重ランダム + variant 属性付き GA4 計測**で CTR を比較すれば、
 勝者を実証的に選べる。
 
-- **設計提案 (承認待ち)**: `docs/40_アフィリエイト管理/AFF-05-creative-ab-testing-design.md`
-- SSG 制約のため出し分けは**クライアント側**で行う (サーバー出し分けは force-dynamic 化で SSG が崩れる)。
-- SSOT に `experimentId` / `variantId` / `weight` を任意追加 (後方互換)。GA4 に `experiment_id` / `variant_id` /
-  `creative_size` param 追加 (custom dimension 登録要)。
-- 段階投入: P1 SSOT+GA4 param → P2 client 加重ランダム枠 → P3 variant 別集計 → P4 初回実験。
-- 停止ルール (最小 imp 1,000 or 4 週、+20% かつ 95% 有意で採用) を実験開始時に固定しピーキング回避。
+- **設計**: `docs/40_アフィリエイト管理/AFF-05-creative-ab-testing-design.md` (方式 A: クライアント加重ランダム採用)
+- **実装 (2026-06-04・framework のみ。具体的な実験は未設定 = 枠は後決め)**:
+  - SSOT `AffiliateAd` に `experimentId?` / `variantId?` / `weight?` を任意追加 (後方互換)。export 時に整合 validate
+  - GA4 `ad_impression` / `affiliate_click` に `experiment_id` / `variant_id` / `creative_size` param を任意追加
+  - client `VariantAdSlot` (加重ランダム + localStorage sticky + 固定高さ枠) を新設し、`AffiliateAdSlot` の
+    sidebar で「experiment variant ≥ 2 件あれば最優先で出し分け」。無ければ従来 (banner→text→AdSense)
+  - `fetch-affiliate-ga4.cjs` を variant 次元の多段フォールバック集計に拡張 (未登録時は自動降格)
+  - `cookies()/headers()` 不使用で SSG 維持。型チェック green
+- **次アクション (P4 = 実験開始)**: GA4 を見て対象枠を決め、SSOT に variant エントリ (同 experimentId・別 variantId) を
+  2〜3 件追加 → `/register-affiliate-banner` で反映。GA4 で variant 用 custom dimension 登録。
+- **停止ルール**: 各 variant imp ≥ 1,000 (or 4 週)、勝者 CTR が次点比 +20% かつ 95% 有意で採用。ピーキング回避。

--- a/docs/05_改善ログ/affiliate.md
+++ b/docs/05_改善ログ/affiliate.md
@@ -91,8 +91,6 @@ impression が大きく増える可能性。
   - SSG (`○ Static`) の最終確認は CI の `next build` に委ねる (ローカルはフルビルド未実行)
 - **検証期日後の判定**: 本番 ranking の HTML に banner が描画され、`ad_impression(link_position=ranking-sidebar)` が
   GA4 で観測されれば前進。CTR は AFF-04 で評価。
-- **検証期日後の判定**: 本番 ranking の HTML に banner が描画され、`ad_impression(link_position=ranking-*)` が
-  GA4 で観測されれば前進。CTR は AFF-04 で評価。
 
 ---
 
@@ -111,3 +109,26 @@ impression が大きく増える可能性。
 下位枠を特定 → categoryKey マッチ修正 / CTA 文言改善 / 位置調整を打つ。
 
 - 4 週ごとに GA4 snapshot で before/after を比較し、ここに effect/* を記録する。
+
+---
+
+## [AFF-05] クリエイティブ A/B テスト基盤 (要・承認)
+
+- **status**: pending
+- **tier**: 2
+- **target_metric**: affiliate/ctr
+- **owner**: claude
+- **due**: 2026-07-12
+- **verification_command**: `node .claude/scripts/ads/fetch-affiliate-ga4.cjs 28` (variant 別 CTR・拡張後)
+- **related_pr**: -
+
+**[仮説]** どの広告/サイズ/文言が効くかは事前に分からない。同一枠に複数 variant (サイズ違い・バナー/テキスト・
+CTA 文言違い) を用意し、**クライアント側 加重ランダム + variant 属性付き GA4 計測**で CTR を比較すれば、
+勝者を実証的に選べる。
+
+- **設計提案 (承認待ち)**: `docs/40_アフィリエイト管理/AFF-05-creative-ab-testing-design.md`
+- SSG 制約のため出し分けは**クライアント側**で行う (サーバー出し分けは force-dynamic 化で SSG が崩れる)。
+- SSOT に `experimentId` / `variantId` / `weight` を任意追加 (後方互換)。GA4 に `experiment_id` / `variant_id` /
+  `creative_size` param 追加 (custom dimension 登録要)。
+- 段階投入: P1 SSOT+GA4 param → P2 client 加重ランダム枠 → P3 variant 別集計 → P4 初回実験。
+- 停止ルール (最小 imp 1,000 or 4 週、+20% かつ 95% 有意で採用) を実験開始時に固定しピーキング回避。

--- a/docs/40_アフィリエイト管理/AFF-05-creative-ab-testing-design.md
+++ b/docs/40_アフィリエイト管理/AFF-05-creative-ab-testing-design.md
@@ -1,14 +1,28 @@
 ---
 type: design-proposal
 target: AFF-05
-status: proposal
+status: implemented-framework
 date: 2026-06-04
 related_log: docs/05_改善ログ/affiliate.md#AFF-05
 ---
 
-# AFF-05 設計提案: クリエイティブ A/B テスト基盤 (どの広告/サイズ/文言が効くか計測)
+# AFF-05 設計: クリエイティブ A/B テスト基盤 (どの広告/サイズ/文言が効くか計測)
 
-> **承認待ち**。本ドキュメントは設計のみ。実装は承認後に別 PR。
+> **2026-06-04: framework 実装済 (方式 A 採用)**。具体的な実験 (枠/variant) は未設定 = データを見て後決め。
+> 実装ファイル: `VariantAdSlot.tsx` / `resolveExperimentVariantsByCategoryKey` / GA4 param 拡張 / `fetch-affiliate-ga4.cjs`。
+
+## 実験の始め方 (P4・運用手順)
+
+1. 対象枠とカテゴリを決める (例: ranking-sidebar の economy)。
+2. `apps/web/scripts/affiliate-ads-data.ts` に **同じ `experimentId`・別 `variantId`** のエントリを 2〜3 件追加
+   (サイズ違いの banner / text / CTA 文言違い)。`weight` 省略時は均等。
+3. develop へ push → `publish-affiliate-ads.yml` が R2 反映。`AffiliateAdSlot` が自動で `VariantAdSlot` 出し分けに切替。
+4. GA4 管理画面で custom dimension `experiment_id` / `variant_id` / `creative_size` を登録。
+5. `node .claude/scripts/ads/fetch-affiliate-ga4.cjs 28` で variant 別 CTR を観測 → 停止ルールで勝者採用。
+
+---
+
+> 以下は設計の根拠 (実装前の提案内容を保持)。
 > 目的: 同じ枠に複数のクリエイティブ候補 (サイズ違い・バナー/テキスト・CTA 文言違い) を用意し、
 > **ランダム配分 (または期間配分) で出し分け → variant 別 CTR を計測 → 勝者を採用**するループを作る。
 

--- a/docs/40_アフィリエイト管理/AFF-05-creative-ab-testing-design.md
+++ b/docs/40_アフィリエイト管理/AFF-05-creative-ab-testing-design.md
@@ -1,0 +1,139 @@
+---
+type: design-proposal
+target: AFF-05
+status: proposal
+date: 2026-06-04
+related_log: docs/05_改善ログ/affiliate.md#AFF-05
+---
+
+# AFF-05 設計提案: クリエイティブ A/B テスト基盤 (どの広告/サイズ/文言が効くか計測)
+
+> **承認待ち**。本ドキュメントは設計のみ。実装は承認後に別 PR。
+> 目的: 同じ枠に複数のクリエイティブ候補 (サイズ違い・バナー/テキスト・CTA 文言違い) を用意し、
+> **ランダム配分 (または期間配分) で出し分け → variant 別 CTR を計測 → 勝者を採用**するループを作る。
+
+## 0. 最重要の制約: SSG + CDN キャッシュ
+
+stats47 は **完全 SSG + Cloudflare CDN キャッシュ**。ページ HTML はビルド時に1回生成され、全訪問者に同じ
+キャッシュが配信される。**ビルド時に variant を1つ選ぶと「全員同じ広告」になり、ランダム計測にならない。**
+また `cookies()/headers()` でサーバー出し分けすると force-dynamic 化して SSG が崩れる
+(`.claude/rules/nextjs-ssg-preservation.md`)。
+
+→ **出し分けは「クライアント側」で行うのが唯一 SSG を壊さない方法。**
+
+## 1. 配分方式の比較と推奨
+
+| 方式 | SSG | 統計的純度 | 反映速度 | 推奨 |
+|---|---|---|---|---|
+| **A. クライアント側 加重ランダム** (推奨) | ✅ 維持 | ◎ 同時並行で交絡なし | ◎ 即時 (再ビルド不要) | **採用** |
+| B. クライアント側 ユーザーバケット (localStorage で固定) | ✅ | ◎ 同一ユーザーは同 variant | ◎ | A に内包 (sticky 化) |
+| C. 期間配分 (ビルド時に週替わり) | ✅ | △ 時期で交絡 (季節性) | × 再ビルド要 | 補助/フォールバック |
+| D. エッジ (Worker/middleware で出し分け) | ✗ キャッシュ分断 | ◎ | ○ | 不採用 (SSG 方針に反する) |
+
+**推奨: 方式 A + sticky 化。**
+- サーバー (ビルド時) は枠の **候補 variant を全件** client コンポーネントに props で渡す (静的 HTML に同梱)。
+- client が mount 時に `localStorage` の実験割当を見て、無ければ **加重ランダム**で1つ選び保存 (sticky)。
+- 選ばれた variant だけ表示し、`ad_impression` を **variant 属性付き**で送信。クリックも同様。
+- → CDN キャッシュは1種類のままで、訪問者ごとに別 variant が出る。再ビルドなしで配分変更可能。
+
+> CLS 対策: 枠は **固定高さのコンテナ**にして、どの variant でもレイアウトが動かないようにする。
+
+## 2. SSOT モデル (git TS 拡張・完全DBレス維持)
+
+`apps/web/scripts/affiliate-ads-data.ts` の `AffiliateAd` に **任意フィールドを3つ追加**するだけ
+(既存エントリは無変更で動く):
+
+```ts
+experimentId?: string | null;  // 同一枠で競合する実験 ID 例: "ranking-sidebar-economy"
+variantId?: string | null;     // 実験内で一意 例: "300x250-A" / "text-cta-benefit"
+weight?: number | null;        // 加重ランダムの重み (既定 1)
+```
+
+- **variant = 1 クリエイティブ** = 1 エントリ (既存の width/height/adType/imageUrl/htmlContent がサイズ・形式・文言を表す)。
+- 同じ `experimentId` を持つ active エントリが「同じ枠の候補」。`experimentId` 無しは従来どおり priority 解決 (後方互換)。
+- 解決ロジック (`resolveAffiliateBannersByCategoryKey` 等) を「experiment があれば候補を全件返す」に拡張。
+- 横断整合 (同 experiment 内で variantId 重複なし等) は **export スクリプトでビルド時 validate** (手編集 JSON を SSOT にしない原則どおり)。
+
+## 3. 計測の拡張 (GA4)
+
+現状 `ad_impression` / `affiliate_click` は `affiliate_category` / `link_position` / `event_label` のみ。
+**variant 属性を3つ追加**する:
+
+| param | 例 | 用途 |
+|---|---|---|
+| `experiment_id` | `ranking-sidebar-economy` | 実験単位の集計 |
+| `variant_id` | `300x250-A` | 勝敗判定の主キー |
+| `creative_size` | `300x250` / `text` | サイズ/形式の横断比較 |
+
+- `AdImpressionTracker` / `TrackedAffiliateLink` / `events.ts` にこれらの param を通す (後方互換: 任意)。
+- **GA4 管理画面でカスタムディメンション登録**が必要 (`affiliate_category`/`link_position` と同様)。未登録だと内訳不可。
+- `.claude/scripts/ads/fetch-affiliate-ga4.cjs` の dimension に `customEvent:experiment_id` / `customEvent:variant_id` /
+  `customEvent:creative_size` を追加し、**variant 別 impression / click / CTR** を出力するよう拡張。
+
+## 4. 勝敗判定 (実証ベース・ピーキング回避)
+
+`.claude/rules/evidence-based-judgment.md` 準拠。**停止ルールを実験開始時に固定**する:
+
+1. **最小サンプル**: 各 variant が impression ≥ 1,000 に達するまで判定しない (低トラフィック枠は期間で代替: 最低4週)。
+2. **比較**: variant 間の CTR を 2 標本比率の z 検定 (有意水準 5%) で比較。実用上は「勝者 CTR が次点比 +20% かつ 95% 有意」を採用条件にする。
+3. **勝者採用**: 勝った variant の `weight` を上げる/他を `isActive:false`。`docs/05_改善ログ/affiliate.md` に
+   想定/実測/サンプル/判定根拠を記録 (effect/* は実測が揃ってから)。
+4. **多重比較**: 1 実験の variant は 2〜3 個に絞る (4 個以上は必要サンプルが急増)。
+
+`/affiliate-improvement observe` を variant 対応に拡張し、上記を半自動で出す。
+
+## 5. クリエイティブ (サイズ/形式) のカタログ提案
+
+「何を試すか」の初期候補。**枠ごとにレイアウト幅の制約**があるので、はみ出さないサイズに限定する。
+
+### サイドバー (右レール ~360px、実効描画幅 ~300–336px)
+
+| サイズ | 種別 | 特性 / 狙い | 備考 |
+|---|---|---|---|
+| **300×250** | medium rectangle | 基準。モバイルでも安全。バナーブラインドネス中 | A/B の baseline に最適 |
+| **336×280** | large rectangle | 面積 +25%、視認性↑ | デスクトップ専用 (モバイルは 300 に) |
+| **300×600** | half page | 縦長で viewability/CTR が高い傾向 | デスクトップのみ、モバイル非表示 |
+| **160×600** | wide skyscraper | 縦長の別案 | 300×600 の対抗 |
+| テキスト (現行) | text link ×2 | 広告感が薄く文脈に馴染む | バナー vs テキストの比較軸 |
+| **ネイティブ/カード** | 自前カード | サイトのフラットUIに同化、CTR が高い場合あり | 要自前実装、PR 表記は維持 |
+
+### ブログ記事内/末尾 (本文幅 ~760px)
+
+| サイズ | 種別 | 狙い |
+|---|---|---|
+| 300×250 / 336×280 | rectangle (PC 2-up) | 現行踏襲 |
+| **728×90** | leaderboard | 本文幅にフィット、デスクトップ |
+| ネイティブ/カード | 自前 | 記事文脈に同化 |
+| 468×60 | banner | **非推奨** (ブラインドネス強)。比較対象としてのみ |
+
+### モバイル
+
+| サイズ | 種別 | 狙い |
+|---|---|---|
+| **320×100** | large mobile banner | 320×50 より視認性↑ |
+| 300×250 | inline rectangle | 記事内 |
+
+### テキスト/CTA の variant 軸 (バナー以外の試行)
+
+- **CTA 文言**: ベネフィット型 (「年間◯円お得」) vs 好奇心型 (「あなたの県は?」) vs 行動型 (「無料で試す」)
+- **体裁**: ボタン vs インラインリンク / 補足microcopy あり・なし / 報酬・価格ヒントあり・なし
+- **PR 表記位置**: 上 vs 下 (景表法は維持)
+
+> レスポンシブ原則: サイドバーは 360px を超えない / モバイルは ≤ viewport / 枠は固定高さ (CLS 回避)。
+> デスクトップ専用サイズ (300×600 等) は `xl:` 以上でのみ表示し、モバイルは 300×250 にフォールバック。
+
+## 6. 段階的ロールアウト (提案する実装フェーズ)
+
+| Phase | 内容 | リスク |
+|---|---|---|
+| **P1** | SSOT に experimentId/variantId/weight 追加 + export validate。GA4 param 3 つ追加 + custom dimension 登録依頼 | 低 (後方互換) |
+| **P2** | client 加重ランダム + sticky 選択コンポーネント (`VariantAdSlot`)。固定高さ枠。`AffiliateAdSlot` から利用 | 中 (SSG 維持を build で確認) |
+| **P3** | `fetch-affiliate-ga4.cjs` を variant 別集計に拡張 + `/affiliate-improvement` に実験判定モード | 低 |
+| **P4** | 最初の実験を1枠で開始 (例: ranking-sidebar の economy で 300×250 vs 336×280 vs text) | 低 |
+
+## 7. 承認が要る決定事項
+
+1. **配分方式**: 方式 A (クライアント加重ランダム + sticky) でよいか。
+2. **最初の実験対象枠**: ranking サイドバー (economy 等トラフィックの多いカテゴリ) で開始でよいか。
+3. **最初に比較する variant**: 例「300×250 vs 336×280 vs 現行テキスト」。
+4. 実装は P1→P4 を**別 PR**で段階投入 (P1+P3 はデータ基盤、P2 がレンダリング変更=SSG 確認必須)。


### PR DESCRIPTION
## 概要

AFF-05 実装 (framework)。「どの広告/サイズ/文言が効くか」を実証で選ぶための **クリエイティブ A/B テスト基盤**。
**具体的な実験 (枠/variant) は未設定 = データを見て後決め**のため、既存挙動は不変 (後方互換)。

設計: `docs/40_アフィリエイト管理/AFF-05-creative-ab-testing-design.md` (方式A: クライアント加重ランダム採用)

## SSG 制約への対応 (最重要)

SSG + CDN キャッシュではビルド時に1つ選ぶと全員同じ広告 → ランダム計測にならない。サーバー出し分けは force-dynamic 化で SSG が崩れる。→ **出し分けはクライアント側**で行う。

## 変更 (後方互換)

- **P1 SSOT + GA4 param**: `AffiliateAd` に `experimentId?`/`variantId?`/`weight?` を任意追加 (既存エントリ無変更で動作)。export 時に整合 validate。GA4 `ad_impression`/`affiliate_click` に `experiment_id`/`variant_id`/`creative_size` を任意伝播。
- **P2 クライアント加重ランダム枠**: `VariantAdSlot` (加重ランダム + localStorage sticky + 固定高さで CLS 抑制、SSR は空枠で hydration mismatch 回避)。`AffiliateAdSlot` の sidebar で「experiment variant ≥2 件あれば最優先で出し分け、無ければ従来 banner→text→AdSense」。`resolveExperimentVariantsByCategoryKey` 新設。
- **P3 variant 別集計**: `fetch-affiliate-ga4.cjs` を dimension 多段フォールバックに拡張し variant 別 CTR を出力 (未登録時は自動降格)。

## SSG 保全

- `cookies()/headers()/draftMode()` を**追加していない**。出し分けは client (`VariantAdSlot`)、サーバーは候補を全件渡すだけ → force-dynamic 化しない。
- ローカル型チェック green。`○ Static` の最終確認は本 PR の CI `next build` に委ねる。

## マージ後の運用 (実験開始 = P4)

1. 対象枠を決め、SSOT に同 `experimentId`・別 `variantId` のエントリを2〜3件追加 → develop push で反映。
2. GA4 で custom dimension `experiment_id`/`variant_id`/`creative_size` を登録。
3. `node .claude/scripts/ads/fetch-affiliate-ga4.cjs 28` で variant 別 CTR 観測 → 停止ルール (imp≥1,000 or 4週、+20% かつ95%有意) で勝者採用。

https://claude.ai/code/session_014ZS3u9RyVQZS2a7R5GomsN

---
_Generated by [Claude Code](https://claude.ai/code/session_014ZS3u9RyVQZS2a7R5GomsN)_