### PR TITLE
docs(affiliate): improvement-log メトリクスリストに affiliate を追加

### DIFF
--- a/.claude/agents/improvement-triage.md
+++ b/.claude/agents/improvement-triage.md
@@ -5,11 +5,11 @@ description: docs/05_改善ログ/*.md の整理・status 更新・INDEX 維持�
 
 # Improvement Triage Agent
 
-`docs/05_改善ログ/` 配下の TODO 真実源を維持する agent。 GSC / GA4 / PSI / AdSense / Cloudflare-cost / SNS-metrics 各 analyst から計測結果を受け取り、施策の status (pending / effect/full / effect/partial / effect/none / effect/adverse) を更新する。 改善ログへの write は本 agent が排他的に行う。
+`docs/05_改善ログ/` 配下の TODO 真実源を維持する agent。 GSC / GA4 / PSI / AdSense / Affiliate / Cloudflare-cost / SNS-metrics 各 analyst から計測結果を受け取り、施策の status (pending / effect/full / effect/partial / effect/none / effect/adverse) を更新する。 改善ログへの write は本 agent が排他的に行う。
 
 ## 担当範囲
 
-- `docs/05_改善ログ/{gsc,ga4,psi,adsense,cloudflare-cost,content,indexing}.md` の section append / status 更新
+- `docs/05_改善ログ/{gsc,ga4,psi,adsense,affiliate,cloudflare-cost,content,indexing}.md` の section append / status 更新
 - `docs/05_改善ログ/INDEX.md` の維持 (pending 一覧の生成)
 - analyst 計測結果を実証ベース判定して effect/* ラベル付け替え
 - 検証期日経過時の next action 提案
@@ -35,7 +35,7 @@ description: docs/05_改善ログ/*.md の整理・status 更新・INDEX 維持�
 
 ## 触る state / files
 
-- `docs/05_改善ログ/{gsc,ga4,psi,adsense,cloudflare-cost,content,indexing}.md` — append / status 更新 (排他)
+- `docs/05_改善ログ/{gsc,ga4,psi,adsense,affiliate,cloudflare-cost,content,indexing}.md` — append / status 更新 (排他)
 - `docs/05_改善ログ/INDEX.md` — 全件 status dashboard 再生成 (排他)
 - `.claude/skills/analytics/<metric>-improvement/reference/improvement-log.md` — agent 用詳細層 (read 主体)
 - `.claude/state/metrics/{gsc,ga4,psi,adsense,cloudflare,blog,note,sns}/` — read only (analyst write を読む)

--- a/.claude/rules/data-storage.md
+++ b/.claude/rules/data-storage.md
@@ -63,7 +63,7 @@ git TS 化し永続 D1 を全廃した。アプリが読む各データの真実
 | 週次計画・週次レビュー | `docs/03_週次運用/週次{計画,レビュー}/YYYY-Www.md` |
 | 週次メトリクスサマリ（自動生成） | `docs/03_週次運用/メトリクス/YYYY-Www.md` |
 | 批判的レビュー・事前検死・SEO 監査・SNS 週報・パフォーマンス・コスト月報 | `docs/04_レビュー/<subcategory>/{YYYY-MM-DD,YYYY-Www,YYYY-MM}.md` |
-| 改善施策の人間向け要約 | `docs/05_改善ログ/{gsc,ga4,adsense,psi,cloudflare-cost}.md` (append-only) |
+| 改善施策の人間向け要約 | `docs/05_改善ログ/{gsc,ga4,adsense,psi,affiliate,cloudflare-cost}.md` (append-only) |
 | YouTube 実験 (1 実験 1 ファイル) | `docs/15_実験ログ/youtube/EXP-NNN.md` |
 | コンテンツ backlog | `docs/{20_ブログ記事企画,22_YouTube企画,30_note記事企画}/backlog/` |
 | 未着手の機能・自動化・UI 改善 backlog | `docs/50_Issues/{feature,automation,ui-improvements}-backlog.md` |
@@ -83,6 +83,7 @@ git TS 化し永続 D1 を全廃した。アプリが読む各データの真実
 | Cloudflare 月次 snapshot JSON + budget 閾値 | `.claude/skills/analytics/cloudflare-cost-improvement/reference/`（人間向け要約は `docs/04_レビュー/cloudflare-cost/YYYY-MM.md` と `docs/05_改善ログ/cloudflare-cost.md`） |
 | Cloudflare 日次 usage（D1/Workers/R2） | `.claude/state/metrics/cloudflare/{snapshots/YYYY-MM-DD.json,history.csv,LATEST.md}`（GitHub Actions 日次 JST 02:30、閾値違反時 `[Cloudflare Alert]` Issues 起票）/ 閾値: `.claude/skills/analytics/cloudflare-cost-improvement/reference/budgets-daily.json` |
 | SNS 投稿メトリクス時系列 | `.claude/skills/analytics/sns-metrics-improvement/snapshots/YYYY-MM-DD/metrics.csv`（書き込み: `.claude/scripts/lib/sns-metrics-store.cjs`） |
+| アフィリエイト在庫棚卸し + GA4 実測 snapshot | `.claude/state/ads/{inventory-*.json,ga4-affiliate-*.json}`（`affiliate-dashboard-refresh.yml` / `affiliate-ga4-weekly.yml` が生成・commit-back、AFF-05） |
 | NSM 週次 JSON snapshot | `.claude/skills/management/nsm-experiment/reference/weekly-snapshots/YYYY-Www.json` |
 | 実験 state（PDCA） | `.claude/state/experiments.json` |
 | RemoteTrigger 記録 | `.claude/state/triggers.json` |
@@ -110,7 +111,7 @@ git TS 化し永続 D1 を全廃した。アプリが読む各データの真実
 
 ## 2 層構造（improvement 系）
 
-改善施策スキル (gsc / ga4 / adsense / cloudflare-cost / psi / sns-metrics) は **必ず 2 層** で記録:
+改善施策スキル (gsc / ga4 / adsense / affiliate / cloudflare-cost / psi / sns-metrics) は **必ず 2 層** で記録:
 
 | 層 | 場所 | 用途 |
 |---|---|---|

--- a/.claude/rules/docs-vs-issues.md
+++ b/.claude/rules/docs-vs-issues.md
@@ -19,7 +19,7 @@ Obsidian で振り返り・思考整理する習慣を支えるため、ファ�
 | 週次計画・週次レビュー | `docs/03_週次運用/週次{計画,レビュー}/YYYY-Www.md` |
 | 週次メトリクス自動生成 | `docs/03_週次運用/メトリクス/YYYY-Www.md` |
 | 批判的レビュー・事前検死・SEO 監査・SNS 週報・パフォーマンスレポート・コスト月報 | `docs/04_レビュー/<subcategory>/YYYY-MM-DD.md` |
-| 改善施策の人間向け要約 (gsc / ga4 / adsense / psi / cloudflare-cost) | `docs/05_改善ログ/<metric>.md` (append-only) |
+| 改善施策の人間向け要約 (gsc / ga4 / adsense / psi / affiliate / cloudflare-cost) | `docs/05_改善ログ/<metric>.md` (append-only) |
 | YouTube 実験・回復 | `docs/15_実験ログ/youtube/EXP-NNN.md` / `recovery-YYYY-MM-DD.md` |
 | ブログ / note / YouTube コンテンツ backlog | `docs/{20_ブログ記事企画,22_YouTube企画,30_note記事企画}/backlog/` |
 | 機能 / 自動化 / UI 改善 backlog (未着手) | `docs/50_Issues/{feature,automation,ui-improvements}-backlog.md` |
@@ -48,7 +48,7 @@ PR で close される単発タスクか？
 
 ## 改善施策の 2 層構造
 
-improvement 系スキル (gsc / ga4 / adsense / cloudflare-cost / psi / sns-metrics) は 2 層で記録する:
+improvement 系スキル (gsc / ga4 / adsense / affiliate / cloudflare-cost / psi / sns-metrics) は 2 層で記録する:
 
 | 層 | 場所 | 内容 |
 |---|---|---|

--- a/.claude/rules/evidence-based-judgment.md
+++ b/.claude/rules/evidence-based-judgment.md
@@ -152,7 +152,7 @@ curl -s -o /dev/null -w "%{http_code}\n" \
 
 ## スキル設計上の取り込み方
 
-`improvement` 系スキル（gsc-improvement / ga4-improvement / performance-improvement / sns-metrics-improvement / cloudflare-cost-improvement / adsense-improvement）と判定系スキル（seo-audit / weekly-review / critical-review / nsm-experiment）は、effect ラベル付与手順の **直前** に以下のチェックリストを置く:
+`improvement` 系スキル（gsc-improvement / ga4-improvement / performance-improvement / sns-metrics-improvement / cloudflare-cost-improvement / adsense-improvement / affiliate-improvement）と判定系スキル（seo-audit / weekly-review / critical-review / nsm-experiment）は、effect ラベル付与手順の **直前** に以下のチェックリストを置く:
 
 ```markdown
 ## 実証チェックリスト（effect/* ラベルを付ける前に必須）
@@ -194,7 +194,7 @@ NG ワードの検出スクリプト（CI で走らせるか手動レビュー�
 ```bash
 NG="のはず\|と思われる\|Google の仕様\|クロール予算枯渇\|壊滅\|兆候\|浸透待ち\|だろう\|と考えられる"
 grep -rn "$NG" \
-  .claude/skills/analytics/{gsc,ga4,performance,sns-metrics,cloudflare-cost,adsense}-improvement/reference/ \
+  .claude/skills/analytics/{gsc,ga4,performance,sns-metrics,cloudflare-cost,adsense,affiliate}-improvement/reference/ \
   .claude/skills/analytics/seo-audit/SKILL.md \
   .claude/skills/management/{weekly-review,critical-review,nsm-experiment}/SKILL.md \
   | grep -v "evidence-based-judgment\|archive/" \

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,9 +43,9 @@
 | 完了前検証 | `/verification-loop` (ビルド + 型チェック) |
 | バグ修正の教訓 | `/knowledge` |
 | 同じエラー 2 回目 | `/continuous-learning` でパターン化 |
-| **改善施策の TODO 真実源** (status / tier / 期日) | `docs/05_改善ログ/{gsc,ga4,psi,adsense,cloudflare-cost,content,indexing}.md` — INDEX: `docs/05_改善ログ/INDEX.md` |
-| 改善施策デプロイ (人間向け要約) | `docs/05_改善ログ/{gsc,ga4,adsense,psi,cloudflare-cost}.md` |
-| 改善施策デプロイ (agent 用詳細) | `.claude/skills/analytics/{gsc,ga4,adsense,sns-metrics,cloudflare-cost,performance}-improvement/reference/improvement-log.md` |
+| **改善施策の TODO 真実源** (status / tier / 期日) | `docs/05_改善ログ/{gsc,ga4,psi,adsense,affiliate,cloudflare-cost,content,indexing}.md` — INDEX: `docs/05_改善ログ/INDEX.md` |
+| 改善施策デプロイ (人間向け要約) | `docs/05_改善ログ/{gsc,ga4,adsense,psi,affiliate,cloudflare-cost}.md` |
+| 改善施策デプロイ (agent 用詳細) | `.claude/skills/analytics/{gsc,ga4,adsense,affiliate,sns-metrics,cloudflare-cost,performance}-improvement/reference/improvement-log.md` |
 | 週次計画進捗 | `docs/03_週次運用/週次計画/YYYY-Www.md` の TODO チェックボックスを Edit |
 | 週次振り返り | `docs/03_週次運用/週次レビュー/YYYY-Www.md` |
 | 批判的レビュー / 事前検死 | `docs/04_レビュー/{critical-review,pre-mortem}/YYYY-MM-DD-<topic>.md` |

--- a/docs/01_技術設計/10_自動化インベントリ.md
+++ b/docs/01_技術設計/10_自動化インベントリ.md
@@ -45,6 +45,8 @@ stats47 の全自動化タスクの静的な真実源。**新規追加・削除�
 | `ctr-improvement-monthly.yml` | `0 0 5 * *` | 毎月 5 日 09:00 JST | 最新 GSC snapshot から position 5-15 × CTR < 業界平均 のクエリを抽出、`[CTR Improvement Candidates] YYYY-MM` Issue 起票 | GitHub Issue (label: `ctr-improvement-candidate, auto-generated`) | 運用中 | `.claude/scripts/gsc/extract-low-ctr-queries.mjs` |
 | `ksj-catalog-monthly.yml` | `0 18 1 * *` | 毎月 1 日 03:00 JST | 国土数値情報 (jpksj-api) の全データセットカタログを取得、`packages/database/seed/ksj-catalog.json` と diff、追加/削除があれば snapshot を develop に commit + `[KSJ Catalog Update]` Issue 起票 | `packages/database/seed/ksj-catalog.json` → develop commit + GitHub Issue (label: `ksj-catalog, auto-generated`) | 運用中 | `docs/01_技術設計/08_国土数値情報GISデータ.md` |
 | `data-refresh.yml` | (cron 無効化中) | — | クラウド/CI からのデータ追加。現状は ビルドキャッシュ db:pull → e-Stat fetch (page-data-batch) → R2 反映 → db:push の DB round-trip。**⚠️ 完全DBレス (doc 19) 未対応の legacy。e-Stat → R2 直行へ要リファクタ (db:pull/db:push 除去)。cron は無効のまま** | R2 `app/stats/*` (+ legacy `database/stats47.sqlite`) | **手動 (workflow_dispatch のみ)** | `docs/01_技術設計/19_完全DBレス設計.md` / `.claude/rules/data-sqlite-ssot.md` |
+| `affiliate-ga4-weekly.yml` | `0 13 * * 0` | 日曜 22:00 JST | GA4 から affiliate `ad_impression`/`affiliate_click` を (category×position×variant) 別集計し CTR snapshot 生成 (custom dimension 未登録時は総数に降格)。+ `workflow_dispatch` | `.claude/state/ads/ga4-affiliate-*.json` → develop commit | 運用中 | AFF-05 (`docs/05_改善ログ/affiliate.md`) |
+| `affiliate-dashboard-refresh.yml` | `0 12 * * 0` | 日曜 21:00 JST | affiliate 在庫の棚卸し JSON + 管理画面 HTML を再生成し commit-back。+ `affiliate-ads-data.ts`/`.claude/scripts/ads/*` 変更時 push トリガ。本番 R2 未変更 | `.claude/state/ads/inventory-*.json` + `docs/40_アフィリエイト管理/affiliate-dashboard.html` → develop commit | 運用中 | AFF-01 |
 
 ### 投稿系（schedule trigger）
 
@@ -61,6 +63,7 @@ stats47 の全自動化タスクの静的な真実源。**新規追加・削除�
 | `post-deploy-smoke.yml` | deploy 後 | Playwright smoke テスト（商用利用確認） | 運用中 |
 | `pr-quality-check.yml` | PR to main | lint / type-check / test / coverage | 運用中 |
 | `security-scan.yml` | push to main + 毎週日曜 UTC 00:00 | npm audit + CodeQL | 運用中 |
+| `publish-affiliate-ads.yml` | push to develop (`affiliate-ads-data.ts`) + dispatch | git TS SSOT → R2 `app/affiliate-ads/all.json` 反映 + 全ゾーン CDN purge | 運用中 |
 
 ---
 

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -11,7 +11,7 @@
 | `02_実装計画/` | 実装ロードマップ・フェーズ計画 | 内容更新が中心。完了した設計書は `archive/` へ |
 | `03_週次運用/` | 週次計画・週次レビュー・週次メトリクス | `週次計画/YYYY-Www.md` / `週次レビュー/YYYY-Www.md` / `メトリクス/YYYY-Www.md` を週次 append |
 | `04_レビュー/` | 批判的レビュー・事前検死・SEO 監査・SNS 週報・パフォーマンス・コスト月報 | カテゴリ別サブディレクトリで蓄積 |
-| `05_改善ログ/` | gsc / ga4 / adsense / psi / cloudflare-cost 改善施策の人間向け要約 | 1 metric = 1 ファイル append-only。frontmatter `status:` で施策の進捗管理 |
+| `05_改善ログ/` | gsc / ga4 / adsense / psi / affiliate / cloudflare-cost 改善施策の人間向け要約 | 1 metric = 1 ファイル append-only。frontmatter `status:` で施策の進捗管理 |
 | `10_SNS戦略/` | SNS コンテンツ設計 | 内容更新が中心 |
 | `15_実験ログ/` | YouTube 実験ファイル群 (1 実験 1 ファイル) | `youtube/EXP-NNN.md` |
 | `20_ブログ記事企画/` | ブログ記事の企画・テーマ案 | `backlog/` 配下に蓄積。直下は INDEX/運用ファイル (`01_ブログ記事一括企画.md` / `brushup-queue.md`) のみ |
@@ -58,7 +58,7 @@
 
 1. **戦略・要件の変更** → `00_プロジェクト管理/` 該当ファイルを Edit (新規ファイル追加禁止)
 2. **週次計画・レビュー** → `/weekly-plan` / `/weekly-review` スキルが `03_週次運用/` に自動生成
-3. **改善施策の記録** → `/{gsc,ga4,adsense,cloudflare-cost,performance}-improvement action` が `05_改善ログ/` に append
+3. **改善施策の記録** → `/{gsc,ga4,adsense,affiliate,cloudflare-cost,performance}-improvement action` が `05_改善ログ/` に append
 4. **コンテンツ backlog** → 該当 `*企画/backlog/` に Write
 5. **未着手の機能・自動化バックログ** → `50_Issues/{feature,automation}-backlog.md` に section 追加
 6. **機能改修 / バグ** → `gh issue create --label enhancement` で Issues 起票


### PR DESCRIPTION
## 概要

AFF-05 で affiliate の improvement-log (`docs/05_改善ログ/affiliate.md`)・affiliate-improvement スキル・GA4/dashboard workflow が揃ったため、各ドキュメント/ルールの improvement メトリクス列挙に `affiliate` を反映する **ドキュメント整合のみ** の変更。

`apps/web` のコード・R2 配信データは未変更。サイト出力は不変（main 反映による履歴更新のみ）。

## 変更内容

- **CLAUDE.md** — TODO 真実源 / 人間向け要約 / agent 用詳細の 3 行に `affiliate`
- **docs/INDEX.md** — `05_改善ログ/` の説明・記録フロー
- **.claude/agents/improvement-triage.md** — 担当 analyst 列挙・触る files
- **.claude/rules/data-storage.md** — docs/ 表・2 層構造、`.claude/state/ads/` 行を追加
- **.claude/rules/docs-vs-issues.md** — 人間向け要約・2 層構造
- **.claude/rules/evidence-based-judgment.md** — improvement スキル列挙・NG ワード grep パス
- **docs/01_技術設計/10_自動化インベントリ.md** — `affiliate-ga4-weekly.yml` / `affiliate-dashboard-refresh.yml` / `publish-affiliate-ads.yml` を追記

## 検証

- 参照した workflow・`.claude/state/ads/`・`affiliate.md`・`affiliate-improvement` スキルの実在を確認
- improvement メトリクスリストに `affiliate` を欠く箇所が残っていないことを grep で確認

https://claude.ai/code/session_014ZS3u9RyVQZS2a7R5GomsN

---
_Generated by [Claude Code](https://claude.ai/code/session_014ZS3u9RyVQZS2a7R5GomsN)_