### PR TITLE
fix(ads): 運営者カード lint修正 (set-state-in-effect)

### DIFF
--- a/apps/web/src/features/ads/components/OperatorPromoCard.tsx
+++ b/apps/web/src/features/ads/components/OperatorPromoCard.tsx
@@ -68,6 +68,10 @@ export function OperatorPromoCard({ placement = "global" }: OperatorPromoCardPro
   const [axis, setAxis] = useState<Axis | null>(null);
 
   useEffect(() => {
+    // 初回マウント後にクライアント側でランダムに軸を確定する。
+    // render 中に Math.random() を使うと SSR と client でハッシュ不一致になるため、
+    // 意図的に effect 内で確定させる (mount 1 回のみ)。
+    // eslint-disable-next-line react-hooks/set-state-in-effect
     setAxis(Math.random() < 0.5 ? "tenshoku" : "ai");
   }, []);
 


### PR DESCRIPTION
PR #438 の Code Quality Check で `react-hooks/set-state-in-effect` Error。マウント後のランダム軸確定は意図的なため eslint-disable-next-line で抑制。

https://claude.ai/code/session_01RwnhnLFiwZXwWVvFoeMxFd

---
_Generated by [Claude Code](https://claude.ai/code/session_01RwnhnLFiwZXwWVvFoeMxFd)_