### PR TITLE
feat(cwv): [auto] LCP 改修案 for /themes/population-dynamics

### DIFF
--- a/apps/web/src/features/theme-dashboard/components/ThemeDashboardTabbed.tsx
+++ b/apps/web/src/features/theme-dashboard/components/ThemeDashboardTabbed.tsx
@@ -2,9 +2,11 @@
 
 import { useCallback, useEffect, useMemo, useState, useTransition } from "react";
 
+import dynamic from "next/dynamic";
 import Link from "next/link";
 
 import { lookupArea } from "@stats47/area";
+import { Skeleton } from "@stats47/components/atoms/ui/skeleton";
 import {
   Tabs,
   TabsContent,
@@ -23,9 +25,21 @@ import { MetricFocusCharts } from "./MetricFocusCharts";
 import { PopulationScatterSection } from "./PopulationScatterSection";
 import { ScrollableTabsList } from "./ScrollableTabsList";
 import { ThemeCombinationAnalysis } from "./ThemeCombinationAnalysis";
-import { ThemeLeafletMap } from "./ThemeLeafletMap";
 import { ThemeMetricsDashboard } from "./ThemeMetricsDashboard";
 import { ThemeYoyCharts } from "./ThemeYoyCharts";
+
+// LCP 改善: ThemeLeafletMap を dynamic import で遅延ロード。
+// leaflet 関連コード (タイル/Choropleth/ドリルダウンアクション) を初期バンドルから外し、
+// desktop の LCP 要素を leaflet タイル → 静的テキストに移行する。
+const ThemeLeafletMap = dynamic(
+  () => import("./ThemeLeafletMap").then((mod) => ({ default: mod.ThemeLeafletMap })),
+  {
+    ssr: false,
+    loading: () => (
+      <Skeleton className="h-[400px] lg:h-[500px] w-full rounded-md" />
+    ),
+  }
+);
 
 import type { ThemeDashboardClientProps } from "../types";
 import type { RankingValue } from "@stats47/ranking";


### PR DESCRIPTION
## Auto-generated CWV improvement PR

**警告**: この PR は Claude (Anthropic Cloud Routine) が自動生成しました。merge 前に人手レビュー必須。

- **URL**: https://stats47.jp/themes/population-dynamics
- **対象ファイル**: `apps/web/src/features/theme-dashboard/components/ThemeDashboardTabbed.tsx`
- **過去施策ヒント**: dynamic import + tile preload (T1-PSI-LCP-02 系)
- **目標**: LCP < 3.5s (mobile)

### 実測 (2026-06-07 PSI / [PSI Alert] Issue #451)

| Strategy | LCP | Perf | LCP element |
|---|---|---|---|
| mobile | **5251ms** 🚨 | 58 🚨 | テーマ説明テキスト (`p.mt-2`) |
| desktop | **6272ms** 🚨 | 36 🚨 | **`div.leaflet-pane`** (leaflet タイル) |

### 改修内容

`ThemeLeafletMap` を `next/dynamic({ ssr: false })` で遅延ロードする。

- 既存: `ThemeLeafletMap` 内部の `LeafletChoroplethMap` / `TileSwitcher` は dynamic だったが、**ラッパー自体は静的 import** されており、`useTheme` / タイルオプション / ドリルダウン action 等のコードが初期 client bundle に含まれていた
- 変更後: ラッパーごと dynamic import → leaflet 関連コードが初期バンドルから完全に切り離される
- desktop 側は `sticky top-20` 内で eager render されていた leaflet タイルが LCP 要素になっていたが、Skeleton (`h-[400px] lg:h-[500px]`) に置き換わり、LCP は静的テキストへ移行する想定
- Skeleton で領域予約 → CLS=0 維持

### レビュー観点

- [ ] dynamic import の skeleton が適切 (`h-[400px] lg:h-[500px] w-full rounded-md`)
- [ ] 既存 props 互換性が維持されている (`ThemeLeafletMapProps` は named export を維持)
- [ ] PSI で LCP 改善を実測 (mobile < 3.5s)
- [ ] 他テーマページ (`local-economy` 等同症状) でも同等改善が起きるか追跡
- [ ] 地図タブを開いたときの体感遅延が許容範囲内か (Skeleton → leaflet 描画までの間)

### 検証コマンド (merge 後)

```bash
curl "https://www.googleapis.com/pagespeedonline/v5/runPagespeed?url=https://stats47.jp/themes/population-dynamics&strategy=mobile&category=performance"
```

### 関連

- 親 plan: `docs/02_実装計画/seo-todo-unify-phase-1-3.md` Sprint 5
- 改善バックログ: `docs/02_実装計画/improvement-backlog.md` (T1-PSI-LCP 系)
- 詳細ログ: `.claude/skills/analytics/performance-improvement/reference/improvement-log.md`

🤖 Generated by Anthropic Cloud Routine `stats47-weekly-cwv-pr`

---
_Generated by [Claude Code](https://claude.ai/code/session_01Fw1WWYpSb9R8ifuWcXMibL)_