### PR TITLE
deploy: テーマ hero 右側を代表指標4つの全国値に差し替え

### DIFF
--- a/.claude/rules/branch-workflow.md
+++ b/.claude/rules/branch-workflow.md
@@ -25,6 +25,22 @@ PR は **develop → main の 1 段階のみ**。feature/* → develop は直 me
 - **main**: 本番デプロイブランチ。**develop → main の PR 経由でのみ更新**。`gh pr create --base main --head develop` で CI (`.github/workflows/pr-quality-check.yml`) を発火 → green を確認してマージ → Cloudflare Pages 自動デプロイ
 - main への直接コミット / push / force push は禁止
 
+## hotfix / main 直行を入れたら main → develop を即同期する（★分岐再発防止・2026-06-08）
+
+緊急 hotfix を `hotfix/* → main` の PR で入れる等、**develop を経由せず main に commit が乗った場合**、main が develop より先行して **main/develop が分岐**する。同じ内容を develop でも別 SHA で持っていると、次の `develop → main` PR が **重複コミット込みで巨大化・コンフリクト化**する（2026-06-08 実際に発生: PR が 2955 ファイル diff になり手作業 reconcile が必要だった）。
+
+**規約**: main に develop 非経由の commit が入ったら、**その場で `origin/main` を develop に取り込んで同期する**。
+
+```bash
+git fetch origin main develop
+git rev-list --count origin/develop..origin/main   # >0 なら main が先行＝要同期
+git switch develop && git pull origin develop
+git merge origin/main --no-edit                    # コンフリクトは内容同一なら ours/theirs で解決
+git push origin develop
+```
+
+原則は「main に入るものは必ず develop を先に通す」。hotfix もできる限り `feature → develop → PR develop→main` に乗せ、緊急で main 直行した場合のみ上記で即同期する。`/deploy` は Step 1 で `origin/develop..origin/main` を必ずチェックする。
+
 ## なぜ PR を develop → main にだけ置くか
 
 - `pr-quality-check.yml` の trigger は `pull_request: branches: [main]` のため、CI は **main PR でしか発火しない**

--- a/.claude/skills/dev/deploy/SKILL.md
+++ b/.claude/skills/dev/deploy/SKILL.md
@@ -89,6 +89,29 @@ git status -s | grep -v "^??" | head             # 自分以外の tracked 変�
   この場合デプロイ後に `develop` が `main` より遅れるので、別途 `main → develop` を取り込んで同期する（並行セッションが落ち着いてから）。
 - develop が origin とクリーン（乖離なし・自分のみ）なら通常どおり Step 3 へ進む。
 
+#### main 先行（hotfix 直行）チェック（★必須・2026-06-08 追加）
+
+上の乖離チェックは「develop が origin/develop からズレているか」だけを見る。**hotfix が develop を経由せず main へ直行している場合、`main` が `develop` より先行して main/develop が分岐し、develop→main PR が重複コミット込みで巨大化・コンフリクト化する**（2026-06-08 発生: PR が 2955 ファイル diff に）。develop→main PR を作る前に必ず確認する:
+
+```bash
+git fetch origin main develop
+git rev-list --count origin/develop..origin/main   # main が develop より先行している commit 数
+```
+
+- **0 なら** main は develop に内包済み → そのまま Step 3 へ。
+- **>0 なら** main 先行＝分岐している。**先に `origin/main` を develop に取り込んで同期してから** develop→main PR を作る（これをしないと PR が巨大化する）:
+
+  ```bash
+  git switch develop && git pull origin develop
+  git merge origin/main --no-edit
+  # コンフリクトは内容同一（hotfix と develop の重複）なら ours/theirs で解決:
+  #   コード   → main(theirs) の lint 修正済み版を採用
+  #   docs等   → develop(ours) の最新状態を採用
+  git push origin develop
+  ```
+
+  詳細規約: `.claude/rules/branch-workflow.md` の「hotfix / main 直行を入れたら main → develop を即同期する」。
+
 ### Step 1.5: feature ブランチ化（develop/main にいる場合）
 
 `$CURRENT_BRANCH` が `develop` or `main` の場合、未 push コミットがあるなら **feature ブランチへ移動**する。ブランチ名はユーザーに確認するか `feature/<日時>-<短い要約>` 形式で提案。

--- a/apps/web/src/features/theme-dashboard/components/ThemePageLayout.tsx
+++ b/apps/web/src/features/theme-dashboard/components/ThemePageLayout.tsx
@@ -8,6 +8,7 @@ import {
   BreadcrumbPage,
   BreadcrumbSeparator,
 } from "@stats47/components/atoms/ui/breadcrumb";
+import { formatNumberForDisplay } from "@stats47/utils";
 
 import { SidebarPromoBanner } from "@/features/ads";
 import { resolveAffiliateBanners } from "@/features/ads/server";
@@ -57,6 +58,33 @@ export async function ThemePageLayout({ theme, data, areaContext }: Props) {
   const nativeBanners = theme.relatedArticleTagKeys && theme.relatedArticleTagKeys.length > 0
     ? await resolveAffiliateBanners(theme.relatedArticleTagKeys, 4).catch(() => [])
     : [];
+
+  // Hero 右側: 代表指標（rankingKeys 順=primary 始まり）の先頭4件の全国値を表示する。
+  // 全国値が無い指標（計算型 / city / port）は都道府県値の単純平均にフォールバック。
+  const tabLabelByKey = new Map(
+    theme.tabIndicators.map((t) => [t.rankingKey, t.tabLabel] as const),
+  );
+  const heroKpis = theme.rankingKeys
+    .filter((key) => data.indicatorDataMap[key])
+    .slice(0, 4)
+    .map((key) => {
+      const d = data.indicatorDataMap[key];
+      const values = d.rankingValues
+        .map((v) => v.value)
+        .filter((v): v is number => typeof v === "number" && Number.isFinite(v));
+      const mean =
+        values.length > 0
+          ? values.reduce((a, b) => a + b, 0) / values.length
+          : null;
+      const figure = d.nationalValue ?? mean;
+      return {
+        key,
+        label: tabLabelByKey.get(key) ?? d.rankingItem.title,
+        value: figure !== null ? formatNumberForDisplay(figure) : "—",
+        unit: d.rankingItem.unit ?? undefined,
+      };
+    });
+
   return (
     <div className="container mx-auto px-4 py-4 text-foreground">
       <script
@@ -126,33 +154,24 @@ export async function ThemePageLayout({ theme, data, areaContext }: Props) {
               {theme.description}
             </p>
           </div>
-          <div>
-            <KpiGrid columns={2}>
-              <KpiTile
-                label="指標数"
-                value={String(theme.rankingKeys.length)}
-                unit="件"
-                variant="dark"
-              />
-              <KpiTile
-                label="エリア"
-                value="47"
-                unit="都道府県"
-                variant="dark"
-              />
-              <KpiTile
-                label="可視化"
-                value="地図 + グラフ"
-                variant="dark"
-              />
-              <KpiTile
-                label="データ"
-                value="CSV"
-                unit="DL 可"
-                variant="dark"
-              />
-            </KpiGrid>
-          </div>
+          {heroKpis.length > 0 && (
+            <div>
+              <p className="mb-2 text-[10.5px] font-semibold uppercase tracking-widest text-white/55">
+                全国値
+              </p>
+              <KpiGrid columns={2}>
+                {heroKpis.map((kpi) => (
+                  <KpiTile
+                    key={kpi.key}
+                    label={kpi.label}
+                    value={kpi.value}
+                    unit={kpi.unit}
+                    variant="dark"
+                  />
+                ))}
+              </KpiGrid>
+            </div>
+          )}
         </div>
       </HeroShell>
 

--- a/apps/web/src/features/theme-dashboard/lib/load-theme-data.ts
+++ b/apps/web/src/features/theme-dashboard/lib/load-theme-data.ts
@@ -8,6 +8,7 @@ import { fetchPrefectureTopology, fetchAllCitiesTopology } from "@stats47/gis/ge
 import {
   fetchRankingValuesFromSource,
   filterOutNationalArea,
+  filterToNational,
   rankByValue,
   readRankingItemFromR2,
   readRankingValuesFromR2,
@@ -36,15 +37,16 @@ export interface ThemePageData {
 async function fetchIndicatorValues(
   rankingItem: RankingItem,
   yearCode: string,
-): Promise<RankingValue[]> {
+): Promise<{ values: RankingValue[]; nationalValue?: number }> {
   const { sourceConfig, calculation } = rankingItem;
 
-  // 計算型アイテムは既存ロジックに委譲
+  // 計算型アイテムは既存ロジックに委譲（全国行は持たないため nationalValue は無し）
   if (calculation?.isCalculated) {
-    return fetchRankingValuesFromSource(rankingItem, yearCode);
+    const values = await fetchRankingValuesFromSource(rankingItem, yearCode);
+    return { values };
   }
 
-  if (!sourceConfig?.statsDataId) return [];
+  if (!sourceConfig?.statsDataId) return { values: [] };
 
   // cdTimeFrom/cdTimeTo を指定せず全年度を一括取得し、R2 キャッシュを共有する
   const params: GetStatsDataParams = {
@@ -53,11 +55,19 @@ async function fetchIndicatorValues(
 
   const storage = await getEstatCacheStorage();
   const rawData = await fetchFormattedStats(params, storage);
+
+  // 全国値 (areaCode "00000") を対象年度で抽出（filterOutNationalArea の逆）
+  const nationalRow = filterToNational(rawData).find(
+    (d) => d.yearCode === yearCode,
+  );
+  const nationalValue =
+    typeof nationalRow?.value === "number" ? nationalRow.value : undefined;
+
   const filteredData = filterOutNationalArea(rawData)
     .filter((d) => d.yearCode === yearCode);
-  if (filteredData.length === 0) return [];
+  if (filteredData.length === 0) return { values: [], nationalValue };
 
-  return rankByValue(filteredData) as RankingValue[];
+  return { values: rankByValue(filteredData) as RankingValue[], nationalValue };
 }
 
 /**
@@ -116,27 +126,31 @@ export async function loadThemeData(
   const valuesPromises = validItems.map(({ key, item }) => {
     const yearCode = item.latestYear?.yearCode;
     if (!yearCode)
-      return Promise.resolve({ key, values: [] as RankingValue[] });
+      return Promise.resolve({
+        key,
+        values: [] as RankingValue[],
+        nationalValue: undefined as number | undefined,
+      });
 
-    // city: R2 から直接読む (e-Stat 経由しない)
+    // city: R2 から直接読む (e-Stat 経由しない。全国行は無いため平均にフォールバック)
     if (areaType === "city") {
       return readRankingValuesFromR2(key, "city", yearCode)
         .then((result) => {
           const values = isOk(result) ? result.data : [];
-          return { key, values };
+          return { key, values, nationalValue: undefined as number | undefined };
         })
         .catch((error) => {
           logger.error({ error, key, yearCode }, "テーマダッシュボード: city values 取得失敗");
-          return { key, values: [] as RankingValue[] };
+          return { key, values: [] as RankingValue[], nationalValue: undefined as number | undefined };
         });
     }
 
-    // prefecture: 既存ロジック (e-Stat fetch + ランク計算)
+    // prefecture: 既存ロジック (e-Stat fetch + ランク計算 + 全国値)
     return fetchIndicatorValues(item, yearCode)
-      .then((values) => ({ key, values }))
+      .then(({ values, nationalValue }) => ({ key, values, nationalValue }))
       .catch((error) => {
         logger.error({ error, key }, "テーマダッシュボード: e-Stat データ取得失敗");
-        return { key, values: [] as RankingValue[] };
+        return { key, values: [] as RankingValue[], nationalValue: undefined as number | undefined };
       });
   });
 
@@ -155,6 +169,7 @@ export async function loadThemeData(
         rankingItem: item,
         rankingValues: values,
         availableYears: item.availableYears ?? [],
+        nationalValue: valResult?.nationalValue,
       };
     }
   }

--- a/apps/web/src/features/theme-dashboard/types.ts
+++ b/apps/web/src/features/theme-dashboard/types.ts
@@ -84,6 +84,12 @@ export interface ThemeIndicatorData {
   rankingValues: RankingValue[];
   /** 利用可能年度リスト（年度セレクタ用） */
   availableYears?: { yearCode: string; yearName: string }[];
+  /**
+   * 全国値（e-Stat の areaCode "00000" 行の値、最新年度）。
+   * 計算型 / city / port 指標など全国行が無い場合は undefined。
+   * 表示側は undefined なら都道府県値の単純平均にフォールバックする。
+   */
+  nationalValue?: number;
 }
 
 /** Server → Client に渡す props */

--- a/docs/03_週次運用/メトリクス/2026-W23.md
+++ b/docs/03_週次運用/メトリクス/2026-W23.md
@@ -1,0 +1,78 @@
+---
+type: weekly-metrics
+week: 2026-W23
+date: 2026-06-08
+status: auto-generated
+---
+
+# Weekly Metrics — 2026-W23
+
+生成時刻: 2026-06-08T00:48:39.807Z
+
+## 🚀 PSI（日次計測、週間集計）
+
+- 計測日数: **6日** / 対象 38 組
+- 週間累積違反: **error 385 / warning 220**
+
+**LCP ワースト 5（週平均）:**
+
+| URL | Strategy | LCP (avg ms) |
+|---|---|---|
+| /ranking/future-population-change-rate-2050 | mobile | 9141 |
+| /ranking/total-population | mobile | 6951 |
+| /ranking/agricultural-output | mobile | 6841 |
+| /areas | mobile | 6763 |
+| /about | mobile | 6516 |
+
+## 🔎 GSC（検索パフォーマンス）
+
+- Clicks: **1349** ▲ (+3.1%)
+- Impressions: **47201** ▼ (-0.5%)
+- CTR: **2.86%** ·
+- Avg Position: **8.53** ▼
+
+## 📊 GA4（サイトアクセス）
+
+- Active Users: **1521** ▼ (-69.9%)
+- Sessions: **1821** ▼ (-68.4%)
+- Pageviews: **4419** ▼ (-68.3%)
+- Avg Session Duration: **189.1s** ▲
+- Bounce Rate: **42.67%** ▲
+
+## 💰 AdSense（広告収益）
+
+- Earnings: **119** ▲ (+19.0%)
+- Page Views: **2391** ▲ (+0.3%)
+- RPM: **50.00** ▲
+- Clicks: **33** ▲
+- CTR: **1.57%** ·
+- Viewability: **61.2%** ·
+
+## 🚨 今週の自動起票 Issue（閾値違反）
+
+- #451 [PSI Alert] しきい値割れ検知 2026-06-07 _(auto-generated, psi-alert)_
+- #449 [PSI Alert] しきい値割れ検知 2026-06-06 _(auto-generated, psi-alert)_
+- #443 [PSI Alert] しきい値割れ検知 2026-06-05 _(auto-generated, psi-alert)_
+- #442 [CTR Improvement Candidates] 2026-06 _(auto-generated, ctr-improvement-candidate)_
+- #436 [PSI Alert] しきい値割れ検知 2026-06-04 _(auto-generated, psi-alert)_
+- #429 [PSI Alert] しきい値割れ検知 2026-06-03 _(auto-generated, psi-alert)_
+- #419 [PSI Alert] しきい値割れ検知 2026-06-02 _(auto-generated, psi-alert)_
+- #402 [PSI Alert] しきい値割れ検知 2026-06-01 _(auto-generated, psi-alert)_
+
+## ⏳ 効果判定待ち施策（effect/pending）
+
+14 日経過は 👀 マーク → 効果判定を進めるべき候補
+
+| Tier | Metric | ID | Title | Status | Due | Owner |
+|---|---|---|---|---|---|---|
+| 2 | ga4 | GA4-BOT-02 | Cloudflare WAF rule で bot スキャナをブロック | pending | 2026-06-14 | uruhayato373 |
+| 2 | affiliate | AFF-02 | 広告ゼロ 8 軸の在庫補充 | pending | 2026-06-21 | uruhayato373 |
+| 2 | ai-content | AICONTENT-001 | wheat-flour-consumption-quantity ai_cont… | pending | 2026-07-15 | claude |
+
+---
+
+生データ:
+- [PSI history.csv](../blob/develop/.claude/state/metrics/psi/history.csv) / [LATEST.md](../blob/develop/.claude/state/metrics/psi/LATEST.md)
+- [GSC history.csv](../blob/develop/.claude/state/metrics/gsc/history.csv) / [LATEST.md](../blob/develop/.claude/state/metrics/gsc/LATEST.md)
+- [GA4 history.csv](../blob/develop/.claude/state/metrics/ga4/history.csv) / [LATEST.md](../blob/develop/.claude/state/metrics/ga4/LATEST.md)
+- [AdSense history.csv](../blob/develop/.claude/state/metrics/adsense/history.csv) / [LATEST.md](../blob/develop/.claude/state/metrics/adsense/LATEST.md)


### PR DESCRIPTION
develop → main 本番デプロイ。

## 変更点
- **feat(themes)**: `/themes/<slug>` hero 右側の固定4タイル（エリア47 / 可視化 / CSV / 指標数）を、**そのテーマの代表指標4つ（rankingKeys 先頭=primary 始まり）の全国値**に差し替え。固定値は全22テーマ共通で情報量ゼロだったため。
  - `types.ts`: `ThemeIndicatorData.nationalValue` 追加
  - `load-theme-data.ts`: `filterToNational` で e-Stat 全国行(`00000`)の値を捕捉。計算型/city/port は全国行が無いため表示側で都道府県平均にフォールバック
  - `ThemePageLayout.tsx`: hero 4タイルを代表指標の全国値（単位付き・「全国値」ラベル）に置換

## 検証
- [x] `npx tsc --noEmit -p apps/web/tsconfig.json` = exit 0
- [x] `eslint`（変更3ファイル）= exit 0
- [x] `next build` = exit 0、`/themes/[themeSlug]` は `●` SSG 維持（Dynamic 化なし）
- [x] 全22テーマが build 時に prerender 成功（新コードが全テーマで実データ相手に正常実行）

## 注記
- コードのみの変更（R2 データ変更なし）。本番反映対象は Next.js アプリコード（テーマページ hero）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01YVSLwMwDKc6XHNPEnABYeH)_