### PR TITLE
feat(perf): OpenNext R2 incremental cache 再有効化 (token 権限修正済)

### DIFF
--- a/.github/workflows/deploy-workers.yml
+++ b/.github/workflows/deploy-workers.yml
@@ -212,16 +212,6 @@ jobs:
 
       - name: Deploy to Production
         uses: cloudflare/wrangler-action@v3
-        env:
-          # `wrangler deploy` は OpenNext プロジェクトを検出すると自動で
-          # `opennextjs-cloudflare deploy`（= populateCache + deploy）へ転送する。
-          # populateCache は account-level の R2 バケット存在チェック API を叩くが、
-          # 現行 CLOUDFLARE_API_TOKEN にその権限が無く 403 (code 10000) で deploy 全体が落ちる。
-          # OPEN_NEXT_DEPLOY=true で転送を抑止し、素の `wrangler deploy` を実行する。
-          # r2IncrementalCache は runtime で binding (NEXT_INC_CACHE_R2_BUCKET) 経由に
-          # オンデマンド自動シードされるため、deploy 時 populateCache をスキップしても機能する。
-          # 事前シード (populateCache) を復活させたい場合は API token に R2 バケット管理権限を付与する。
-          OPEN_NEXT_DEPLOY: "true"
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}

--- a/apps/web/open-next.config.ts
+++ b/apps/web/open-next.config.ts
@@ -1,10 +1,22 @@
-// default open-next.config.ts file created by @opennextjs/cloudflare
+// open-next.config.ts — @opennextjs/cloudflare adapter config
 import { defineCloudflareConfig } from "@opennextjs/cloudflare/config";
+// R2 incremental cache: ISR/SSG エントリを R2 バケット (binding NEXT_INC_CACHE_R2_BUCKET) に
+// 永続化する。これを設定しないと OpenNext は incremental cache を無効化し、
+// revalidate を付けたページも毎リクエスト full render になる (キャッシュが効かない)。
+import r2IncrementalCache from "@opennextjs/cloudflare/overrides/incremental-cache/r2-incremental-cache";
+// 同一データセンター内のリクエストに対し Cache API でローカルヒットを返すラッパー。
+// long-lived モードは ISR/SSG エントリを最大 30 分エッジ再利用する。
+import { withRegionalCache } from "@opennextjs/cloudflare/overrides/incremental-cache/regional-cache";
 
 export default defineCloudflareConfig({
-	// 注意: AWS SDK の除外は next.config.ts の serverExternalPackages と webpack.externals で行う
-	// Open-Next は next.config.ts の設定を読み取るため、ここでの設定は不要
-	// 
-	// Workers runtime用のビルドを生成するには、ビルド時に --workers-runtime フラグを指定すること
-	// package.json の workers:build スクリプトで既に設定済み
+  // 注意: AWS SDK の除外は next.config.ts の serverExternalPackages と webpack.externals で行う
+  // Open-Next は next.config.ts の設定を読み取るため、ここでの設定は不要
+  //
+  // Workers runtime用のビルドを生成するには、ビルド時に --workers-runtime フラグを指定すること
+  // package.json の workers:build スクリプトで既に設定済み
+
+  // R2 を SSOT とする incremental cache。binding 名は override が要求する
+  // NEXT_INC_CACHE_R2_BUCKET 固定 (wrangler.toml で stats47 バケットに割当)。
+  // regional cache (long-lived) でエッジローカルヒットを上乗せする。
+  incrementalCache: withRegionalCache(r2IncrementalCache, { mode: "long-lived" }),
 });

--- a/apps/web/wrangler.toml
+++ b/apps/web/wrangler.toml
@@ -24,6 +24,13 @@ binding = "STATS47_BUCKET"
 bucket_name = "stats47"
 preview_bucket_name = "stats47"
 
+# OpenNext incremental cache 用 R2 binding（ローカル開発用）。
+# r2-incremental-cache override が固定名 NEXT_INC_CACHE_R2_BUCKET を要求する。
+[[r2_buckets]]
+binding = "NEXT_INC_CACHE_R2_BUCKET"
+bucket_name = "stats47"
+preview_bucket_name = "stats47"
+
 
 # Observability設定（デフォルト）
 [observability]
@@ -75,6 +82,13 @@ NEXT_PUBLIC_AMAZON_ASSOCIATE_TAG = "stats47-22"
 
 [[env.production.r2_buckets]]
 binding = "STATS47_BUCKET"
+bucket_name = "stats47"
+
+# OpenNext incremental cache 用 R2 binding（Production）。
+# deploy 前に `opennextjs-cloudflare populateCache remote --env production` で
+# ビルド済 ISR/SSG エントリをこのバケット (prefix incremental-cache/) に投入する。
+[[env.production.r2_buckets]]
+binding = "NEXT_INC_CACHE_R2_BUCKET"
 bucket_name = "stats47"
 
 


### PR DESCRIPTION
R2 incremental cache を再有効化する。デプロイ用 Cloudflare API token に R2 バケット管理権限が付与されたため、populateCache が正規に動作する前提が整った (PR #467 で一時 revert していた構成を復活)。

## 変更
- `5afb383c` (cache 一時 revert) を revert → `open-next.config.ts` の `r2IncrementalCache + withRegionalCache`、`wrangler.toml` の `NEXT_INC_CACHE_R2_BUCKET` binding (default + production) を復活
- `dae56b25` (OPEN_NEXT_DEPLOY=true) を revert → デプロイ時に `opennextjs-cloudflare deploy` の populateCache を正規実行し cache を事前シード

## 検証ポイント (デプロイ時)
- populateCache が 403 を出さず成功すること (= token 権限修正の検証)
- 成功後 PSI で TTFB/LCP 改善 (PERF-OPENNEXT-CACHE-01 の根本原因仮説) を計測

🤖 Generated with [Claude Code](https://claude.com/claude-code)