### PR TITLE
Revert T2-2 search-index unbundle (Workers self-fetch で degrade)

### DIFF
--- a/apps/web/src/app/search/page.tsx
+++ b/apps/web/src/app/search/page.tsx
@@ -24,8 +24,7 @@ function buildResultsSummary(
   return `「${query}」の検索結果 ${resultsCount} 件`;
 }
 
-// 検索インデックスは public 静的アセット (/search-index.json) を runtime fetch する
-// (Worker バンドルに焼き込まない / isolate 単位でキャッシュ。search-server.ts 参照)。
+// 検索インデックスはビルド時に static JSON として bundle 済み（D1 read なし）。
 // searchParams が異なれば Next.js が per-request render に切替えるので force-dynamic は不要。
 
 const searchTitle = "検索 | stats47";
@@ -61,18 +60,17 @@ export default async function SearchPage({ searchParams }: PageProps) {
     ? tags.split(",").filter(Boolean)
     : undefined;
 
-  const [initialResults, filterMeta] = await Promise.all([
-    q
-      ? searchDocumentsServer(q, {
-          type: parsedType,
-          category: parsedType !== "blog" ? category : undefined,
-          tags: parsedType === "blog" ? parsedTags : undefined,
-          year: parsedType === "blog" ? year : undefined,
-          month: parsedType === "blog" ? month : undefined,
-        }).then((r) => r.results)
-      : Promise.resolve([]),
-    getSearchIndexMeta(),
-  ]);
+  const initialResults = q
+    ? searchDocumentsServer(q, {
+        type: parsedType,
+        category: parsedType !== "blog" ? category : undefined,
+        tags: parsedType === "blog" ? parsedTags : undefined,
+        year: parsedType === "blog" ? year : undefined,
+        month: parsedType === "blog" ? month : undefined,
+      }).results
+    : [];
+
+  const filterMeta = getSearchIndexMeta();
 
   return (
     <PageShell>

--- a/apps/web/src/features/search/lib/search-server.ts
+++ b/apps/web/src/features/search/lib/search-server.ts
@@ -3,11 +3,8 @@ import "server-only";
 /**
  * サーバーサイド検索ユーティリティ
  *
- * 検索インデックス (search-index.json / search-index-meta.json) は public 静的
- * アセットとして配信され、クライアント (search-client) も同じ URL を fetch する。
- * 旧来はサーバーで `require()` して 1.35MB を Worker サーバーバンドルに焼き込んでいたが、
- * Worker サイズ / cold-start 削減のため **runtime fetch + isolate キャッシュ** に変更した。
- * 同一オリジンの CDN 配信アセットを取得するだけなので追加コストは isolate ごと 1 回。
+ * ビルド時に生成された search-index.json を静的インポートし、
+ * Server Component から MiniSearch 検索を実行する。
  */
 import MiniSearch from "minisearch";
 
@@ -21,56 +18,43 @@ import type {
   SearchResponse,
 } from "../types/search.types";
 
-const BASE_URL = process.env.NEXT_PUBLIC_BASE_URL || "https://stats47.jp";
-const SEARCH_INDEX_URL = `${BASE_URL}/search-index.json`;
-const SEARCH_INDEX_META_URL = `${BASE_URL}/search-index-meta.json`;
+// Static imports — bundled at build time
+ 
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const searchIndexMetaJson = require("../../../../public/search-index-meta.json");
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const searchIndexJson = require("../../../../public/search-index.json");
 
-const EMPTY_META: SearchIndexMeta = { categories: [], blogTags: [], blogYears: [] };
+// Module-level cache is intentional here.
+// MiniSearch instances contain tokenizer closures and are NOT JSON-serializable,
+// so Next.js `unstable_cache` (requires serializable return values) cannot be used.
+// This caches the deserialized search index — a static, deploy-time artifact
+// from `public/search-index.json` (not R2 data) — so it is deserialized only once
+// per Worker isolate. Safe because the index is immutable within a deployment.
+let cachedInstance: MiniSearch<SearchDocument> | null = null;
 
-// MiniSearch instance は tokenizer closure を含み JSON 直列化不可のため Next.js の
-// unstable_cache は使えない。fetch + deserialize を isolate 単位で 1 回に抑えるため
-// Promise をモジュールスコープにキャッシュする (index は deploy ごとに不変、isolate は
-// deploy ごとに作り直されるため stale にならない)。fetch 失敗時はサーバー検索を degrade
-// し (results 空 / meta 空)、クライアント側検索が補完する — クラッシュさせない。
-let instancePromise: Promise<MiniSearch<SearchDocument> | null> | null = null;
-let metaPromise: Promise<SearchIndexMeta> | null = null;
-
-async function loadServerSearchInstance(): Promise<MiniSearch<SearchDocument> | null> {
-  try {
-    const res = await fetch(SEARCH_INDEX_URL, { cache: "no-store" });
-    if (!res.ok) return null;
-    const json = await res.json();
-    return MiniSearch.loadJS(json, {
-      ...MINISEARCH_OPTIONS,
-      storeFields: STORE_FIELDS,
-      tokenize,
-    });
-  } catch {
-    return null;
-  }
-}
-
-function getServerSearchInstance(): Promise<MiniSearch<SearchDocument> | null> {
-  if (!instancePromise) instancePromise = loadServerSearchInstance();
-  return instancePromise;
+function getServerSearchInstance(): MiniSearch<SearchDocument> {
+  if (cachedInstance) return cachedInstance;
+  cachedInstance = MiniSearch.loadJS(searchIndexJson, {
+    ...MINISEARCH_OPTIONS,
+    storeFields: STORE_FIELDS,
+    tokenize,
+  });
+  return cachedInstance;
 }
 
 /**
  * サーバーサイドでドキュメントを検索する
  */
-export async function searchDocumentsServer(
+export function searchDocumentsServer(
   query: string,
   options?: SearchOptions
-): Promise<SearchResponse> {
+): SearchResponse {
   if (!query.trim()) {
     return { results: [], total: 0, query, options };
   }
 
-  const ms = await getServerSearchInstance();
-  if (!ms) {
-    // index fetch 失敗時はサーバー検索を degrade (クライアント側検索が補完)
-    return { results: [], total: 0, query, options };
-  }
+  const ms = getServerSearchInstance();
   const rawResults = ms.search(query, { prefix: true, fuzzy: 0.2 });
 
   return buildSearchResponse(rawResults, query, options);
@@ -79,17 +63,6 @@ export async function searchDocumentsServer(
 /**
  * フィルタ用メタデータを取得する
  */
-export async function getSearchIndexMeta(): Promise<SearchIndexMeta> {
-  if (!metaPromise) {
-    metaPromise = (async () => {
-      try {
-        const res = await fetch(SEARCH_INDEX_META_URL, { cache: "no-store" });
-        if (!res.ok) return EMPTY_META;
-        return (await res.json()) as SearchIndexMeta;
-      } catch {
-        return EMPTY_META;
-      }
-    })();
-  }
-  return metaPromise;
+export function getSearchIndexMeta(): SearchIndexMeta {
+  return searchIndexMetaJson as SearchIndexMeta;
 }


### PR DESCRIPTION
T2-2 の search-index runtime fetch 化 (#472) は Workers の self-fetch 落とし穴でサーバー検索が degrade (人口検索が0件)。既知良好状態 (require) に revert して復旧。proper な unbundle は ASSETS binding か R2 移行が必要 (別途)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)