### PR TITLE
fix(home): トップを ISR 化し「注目のランキング」消失を修正

### DIFF
--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -23,6 +23,24 @@ import {
 import { AdSenseAd, RANKING_PAGE_FOOTER } from "@/lib/google-adsense";
 
 /**
+ * ISR (5 分) で再検証する。
+ *
+ * このページは `<FeaturedRankings>`（注目のランキング）と `listLatestArticles`（最新記事）を
+ * R2 snapshot から読む。ビルド環境では R2 が読めない（S3 creds 不一致 + R2_PUBLIC_FETCH_URL 未設定で
+ * `fetchFromR2` が throw、build log: `home/featured.json が R2 に存在しません` / `hasS3Credentials:false`）
+ * ため、純 SSG だと「注目のランキング」セクションが null のまま焼き込まれ、トップに /ranking 詳細への
+ * 導線が消える（クリックできるのは /themes だけになる）回帰が起きていた。
+ *
+ * `revalidate` を付けて ISR 化すると、Cloudflare Workers ランタイムでの再生成時に R2 バインディングで
+ * featured.json / values / 記事を実データ取得でき、tile map・1 位データ付きで正しく描画される
+ * （/ranking/[key]（revalidate=86400）が同じ理由で正常に出ているのと同様）。デプロイ直後の最大 5 分は
+ * ビルド時の空セクションが配信されるが、その後は自己回復する。build 側に手を入れて全 ranking ページを
+ * 事前生成させる（R2_PUBLIC_FETCH_URL を build env に追加）と generateStaticParams が ~1,800 件返して
+ * ビルドが激重になるため、ランタイム ISR で局所的に解決する。
+ */
+export const revalidate = 300;
+
+/**
  * 主要ページプレビュー画像/動画の R2 公開 URL ベース。
  * 仕様: docs/01_技術設計/08_homepage-previews.md
  * 撮影: apps/web/scripts/capture-home-previews.ts


### PR DESCRIPTION
## 症状 (本番実機で確認)
- https://stats47.jp/ トップから「注目のランキング」セクションが消失。
- トップ上の「ランキング」ラベルの導線が `/themes` だけになり、`/ranking/<key>` 詳細への直接導線が消えた。

## 根本原因
- トップ `/` は **純 SSG (revalidate なし・`x-nextjs-stale-time` 実質無限)** で、ビルド時に焼き込まれる。
- `<FeaturedRankings>` は R2 `app/home/featured.json` + ranking values を読むが、**ビルド環境では R2 が読めない**。
  - `detectEnvironment()` が要求する `R2_ACCESS_KEY_ID/R2_SECRET_ACCESS_KEY/R2_S3_ENDPOINT` と deploy-workers.yml が渡す `CLOUDFLARE_R2_*` の**名前が不一致**で `hasS3Credentials:false`、かつ `R2_PUBLIC_FETCH_URL` 未設定 → `fetchFromR2` が throw。
  - 最新 deploy のビルドログに `home/featured.json が R2 に存在しません` / `hasS3Credentials:false` を確認。
- そのため `FeaturedRankings` が `items.length===0 → return null` となり、空セクションが静的 HTML に永続。`/ranking/[key]` は `revalidate=86400` の ISR でランタイム再生成され正常 (= 同じ機構で直る)。

## 修正
- トップに `export const revalidate = 300` を付与し ISR 化。Workers ランタイムでの再生成時に R2 バインディングで実データ取得 → tile map・1位データ付きで自己回復。

## 不採用案
- build env に `R2_PUBLIC_FETCH_URL` を足す案は、`generateStaticParams` が ~1,800 件返してビルドが激重化するため不採用（ランタイム ISR で局所解決）。

## 検証
- `npx tsc --noEmit -p apps/web/tsconfig.json` → 0 errors。
- デプロイ後: 反映直後〜最大5分はビルド時の空セクション、その後トップに `/ranking/<key>` カードが復活することを実機確認予定。

## 後続
- main マージ後 `origin/main` を develop に同期 (分岐再発防止ルール)。
- 別途、ビルド時 R2 read 不能 (env 名不一致) は search-index / blog/all.json にも影響する latent issue として機能バックログに記録予定。

🤖 Generated with [Claude Code](https://claude.com/claude-code)