### PR TITLE
fix(home): トップを force-dynamic 化（revalidate では復旧せず）

### DIFF
--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -23,22 +23,27 @@ import {
 import { AdSenseAd, RANKING_PAGE_FOOTER } from "@/lib/google-adsense";
 
 /**
- * ISR (5 分) で再検証する。
+ * 動的レンダリング（ランタイム SSR）を強制する。
  *
  * このページは `<FeaturedRankings>`（注目のランキング）と `listLatestArticles`（最新記事）を
- * R2 snapshot から読む。ビルド環境では R2 が読めない（S3 creds 不一致 + R2_PUBLIC_FETCH_URL 未設定で
- * `fetchFromR2` が throw、build log: `home/featured.json が R2 に存在しません` / `hasS3Credentials:false`）
- * ため、純 SSG だと「注目のランキング」セクションが null のまま焼き込まれ、トップに /ranking 詳細への
- * 導線が消える（クリックできるのは /themes だけになる）回帰が起きていた。
+ * R2 snapshot から読む。**ビルド環境では R2 が読めない**（detectEnvironment が要求する
+ * `R2_ACCESS_KEY_ID/SECRET/ENDPOINT` と deploy が渡す `CLOUDFLARE_R2_*` の名前不一致 +
+ * `R2_PUBLIC_FETCH_URL` 未設定で `fetchFromR2` が throw、build log: `home/featured.json が R2 に
+ * 存在しません` / `hasS3Credentials:false`）。
  *
- * `revalidate` を付けて ISR 化すると、Cloudflare Workers ランタイムでの再生成時に R2 バインディングで
- * featured.json / values / 記事を実データ取得でき、tile map・1 位データ付きで正しく描画される
- * （/ranking/[key]（revalidate=86400）が同じ理由で正常に出ているのと同様）。デプロイ直後の最大 5 分は
- * ビルド時の空セクションが配信されるが、その後は自己回復する。build 側に手を入れて全 ranking ページを
- * 事前生成させる（R2_PUBLIC_FETCH_URL を build env に追加）と generateStaticParams が ~1,800 件返して
- * ビルドが激重になるため、ランタイム ISR で局所的に解決する。
+ * トップは純 SSG（`○ /`）で **ビルド時に空の FeaturedRankings を焼き込み**、本 OpenNext 構成では
+ * prerendered ページは再デプロイまで配信され続ける（`revalidate` を付けても時間ベース ISR 再生成が
+ * 効かず `x-nextjs-stale-time` が無限のまま＝検証で空のまま byte 一致を確認）ため、トップから
+ * /ranking 詳細への導線が恒久的に消える回帰が起きていた。
+ *
+ * `force-dynamic` でビルド時 prerender を止め、**毎リクエスト Cloudflare Workers ランタイムで描画**
+ * させると、R2 バインディング（ランタイムで稼働。/ranking/[key] が同経路で実データ描画されるのと同じ）で
+ * featured.json / values / 記事を取得でき、tile map・1 位データ付きで正しく出る。
+ *
+ * 不採用: build env に `R2_PUBLIC_FETCH_URL` を足してビルド時に読む案は、/ranking/[key] の
+ * generateStaticParams が ~1,800 件返してビルドが激重化するため見送り。
  */
-export const revalidate = 300;
+export const dynamic = "force-dynamic";
 
 /**
  * 主要ページプレビュー画像/動画の R2 公開 URL ベース。


### PR DESCRIPTION
## 背景
#477 の `revalidate=300` ではトップの「注目のランキング」消失が**復旧しなかった**。

実機調査の結果:
- トップ `/` はビルドで `○ (Static)` 判定。ビルド時は R2 が読めず `<FeaturedRankings>` が空で焼き込まれる。
- 本 OpenNext 構成では **prerendered ページは再デプロイまで配信され続け、時間ベース ISR 再生成が効かない**（`x-nextjs-stale-time` が無限・配信 HTML が空のまま byte 一致を確認）。
- `/ranking/[key]` が無事なのは `generateStaticParams` が `[]` を返し prerender されず、**ランタイムで on-demand 描画**されるから（その経路では R2 バインディングが効き実データが出る）。

## 修正
- トップに `export const dynamic = "force-dynamic"` を付与し、ビルド prerender を止めて**毎リクエスト Workers ランタイムで描画**。R2 バインディングで featured.json / values / 記事を取得 → tile map・1 位データ付きで正しく出る。

## 不採用
- build env に `R2_PUBLIC_FETCH_URL` を足す案は `generateStaticParams` が ~1,800 件返してビルド激重化のため見送り。

## 検証
- `tsc` 0 errors。デプロイ後にトップへ `/ranking/<key>` カード復活を実機確認する。

🤖 Generated with [Claude Code](https://claude.com/claude-code)