### PR TITLE
feat(cwv): [auto] LCP 改修案 for /themes/labor-wages

### DIFF
--- a/apps/web/src/features/ads/components/BannerAd.tsx
+++ b/apps/web/src/features/ads/components/BannerAd.tsx
@@ -62,6 +62,8 @@ export function BannerAd({
             width={width ?? undefined}
             height={height ?? undefined}
             alt=""
+            loading="lazy"
+            decoding="async"
             className="max-w-full h-auto"
           />
         </TrackedAffiliateLink>


### PR DESCRIPTION
## Auto-generated CWV improvement PR

**警告**: この PR は Claude (Anthropic Cloud Routine) が自動生成しました。merge 前に人手レビュー必須。

- **URL**: https://stats47.jp/themes/labor-wages
- **対象ファイル**: `apps/web/src/features/ads/components/BannerAd.tsx`
- **過去施策ヒント**: 画像最適化 (LCP 候補から外す lazy/decoding hint)
- **目標**: LCP < 3.5s (mobile)

### 実測 (2026-06-14 PSI / [PSI Alert] Issue #480)

| Strategy | Perf | LCP | CLS | LCP element |
|---|---|---|---|---|
| mobile | **68** 🚨 | **8616ms** 🚨 | 0.155 🚨 | `div > div.relative > a > img.max-w-full` (affiliate banner image) |
| desktop | **87** 🚨 | 1323ms | 0.035 | (TBT 254ms warn) |

### 改修内容

PSI が LCP 要素として `img.max-w-full` (アフィリエイトバナー画像) を計測している。 該当画像はテーマダッシュボード読了後 (`SidebarPromoBanner` / `NativeAffiliateRow` 経由) に配置されており本来は below-fold だが、 `<img>` が **eager-load** されているため critical な above-fold コンテンツ (Hero / dashboard) と帯域・デコード予算を奪い合い、LCP 候補になっている。

`BannerAd` の `<img>` に **`loading="lazy"` + `decoding="async"`** を追加し、 ビューポート近接まで読み込みを遅延させて LCP 候補から外す。 above-fold の本来の LCP 要素 (Hero テキスト等) へ計測対象を移行する想定。

- **scope**: `BannerAd.tsx` のみ (1 component 共有)。すべてのアフィリエイトバナー利用箇所が同時改善
- props 互換性維持 (新規 prop なし)
- 既存の `eslint-disable @next/next/no-img-element` は据置 (next/image 移行は外部画像ドメイン許可リスト整備が別タスク)

### レビュー観点

- [ ] dynamic import の skeleton が適切 (本 PR は image lazy-load なので CLS への影響は `h-auto` のままだが、 banner width/height は config 値が渡るため layout shift は発生しない想定)
- [ ] 既存 props 互換性が維持されている (`BannerAdProps` は変更なし)
- [ ] PSI で LCP 改善を実測 (mobile < 3.5s)
- [ ] 他テーマページ (`local-economy` / `population-dynamics` 等、同 LCP element) でも同等改善が起きるか追跡

### 検証コマンド (merge 後)

```bash
curl "https://www.googleapis.com/pagespeedonline/v5/runPagespeed?url=https://stats47.jp/themes/labor-wages&strategy=mobile&category=performance"
```

### 補足: 候補スクリプトとの差分

`suggest-cwv-candidates.mjs` は `apps/web/src/app/themes/[themeSlug]/page.tsx` 等を候補として返したが、 PSI の LCP element selector (`div > div.relative > a > img.max-w-full`) を grep して BannerAd のみが該当することを確認したため、 実測 LCP 元のコンポーネントを直接修正している (suggest スクリプトは過去 commit ベースで現在の LCP 元を必ずしも捉えない)。

### 関連

- 親 plan: `docs/02_実装計画/seo-todo-unify-phase-1-3.md` Sprint 5
- PSI Alert: #480
- 前週同種 PR (leaflet dynamic import 系): #454 (population-dynamics)

🤖 Generated by Anthropic Cloud Routine `stats47-weekly-cwv-pr`

---
_Generated by [Claude Code](https://claude.ai/code/session_01AFc9ERCruvKwquGBnZjYgY)_