### PR TITLE
fix(theme): ダッシュボード指標値を R2 統一 (本番 error fallback 根治)

### DIFF
--- a/.claude/skills/theme/optimize-themes/SKILL.md
+++ b/.claude/skills/theme/optimize-themes/SKILL.md
@@ -13,8 +13,8 @@ primary_agent: theme-component-builder
 
 - **1データ1コンポーネント**: 同じ指標は1つの chart_key を areas / theme で共有
 - **既存コンポーネント再利用優先**: areas にあるチャートは page_components に同じ chart_key を別行 INSERT するだけ
-- **e-Stat API 起点**: DB にデータがなくても e-Stat API から取得可能なら追加候補
-- **KPI は e-Stat API ベース**: kpiDataByArea でプリフェッチ、ranking_data ベースの KPI は使わない
+- **e-Stat API 起点（指標の発見・選定）**: DB にデータがなくても e-Stat API から取得可能なら追加候補（これは「どの指標を追加するか」のオーサリング判断であり、runtime のデータ取得ではない）
+- **ダッシュボード本体の指標値は R2 から読む（2026-06-20 統一）**: `loadThemeData` が `app/ranking/<key>/values.json`（全年）を読み、`ThemeMetricsDashboard` の KPI カード・上位県バー・トレンドを描画する。**e-Stat ライブ取得はしない**（Workers ランタイムで失敗するため。正典: `docs/02_実装計画/10_テーマダッシュボード強化.md`）。`kpiDataByArea`（e-Stat estatParams プリフェッチ）は page_components の `kpi-card` コンポーネント専用で、ダッシュボード本体の KPI とは別経路。
 
 ## 引数
 

--- a/apps/web/src/features/theme-dashboard/lib/load-theme-data.ts
+++ b/apps/web/src/features/theme-dashboard/lib/load-theme-data.ts
@@ -1,22 +1,12 @@
 import "server-only";
 
-import {
-  fetchFormattedStats,
-  type GetStatsDataParams,
-} from "@stats47/estat-api/server";
 import { fetchPrefectureTopology, fetchAllCitiesTopology } from "@stats47/gis/geoshape";
 import {
-  fetchRankingValuesFromSource,
-  filterOutNationalArea,
-  filterToNational,
-  rankByValue,
+  readAllYearsRankingValuesFromR2,
   readRankingItemFromR2,
   readRankingValuesFromR2,
 } from "@stats47/ranking/server";
 import { isOk, type AreaType, type TopoJSONTopology } from "@stats47/types";
-
-
-import { getEstatCacheStorage } from "@/components/stat-charts/server";
 
 import { logger } from "@/lib/logger";
 
@@ -29,64 +19,45 @@ export interface ThemePageData {
 }
 
 /**
- * e-Stat API（R2キャッシュ優先）から指標データを取得する。
- * cdArea/cdTime 指定なしで全都道府県・全年度を一括取得し、キャッシュ効率を最大化する。
+ * 都道府県指標の全年 R2 values から「全国」トレンド (年次の県平均) を構築する。
  *
- * 計算型アイテムは fetchRankingValuesFromSource に委譲する。
+ * R2 ranking values (app/ranking/<key>/values.json) には全国行 (00000) が無いため、
+ * 各年の都道府県平均を「全国」系列 (MiniLineChart 用) として用いる。
+ * ThemeMetricsDashboard も都道府県未選択時は県平均を KPI 値に使うため整合する。
  */
-async function fetchIndicatorValues(
-  rankingItem: RankingItem,
-  yearCode: string,
-): Promise<{ values: RankingValue[]; nationalValue?: number; nationalSeries?: { year: number; value: number }[] }> {
-  const { sourceConfig, calculation } = rankingItem;
-
-  // 計算型アイテムは既存ロジックに委譲（全国行は持たないため nationalValue / nationalSeries は無し）
-  if (calculation?.isCalculated) {
-    const values = await fetchRankingValuesFromSource(rankingItem, yearCode);
-    return { values };
+function buildNationalSeries(
+  allYears: RankingValue[],
+): { year: number; value: number }[] {
+  const byYear = new Map<number, number[]>();
+  for (const v of allYears) {
+    if (typeof v.value !== "number" || !Number.isFinite(v.value)) continue;
+    const y = Number(String(v.yearCode).slice(0, 4));
+    if (!Number.isFinite(y)) continue;
+    const arr = byYear.get(y);
+    if (arr) arr.push(v.value);
+    else byYear.set(y, [v.value]);
   }
-
-  if (!sourceConfig?.statsDataId) return { values: [] };
-
-  // cdTimeFrom/cdTimeTo を指定せず全年度を一括取得し、R2 キャッシュを共有する
-  const params: GetStatsDataParams = {
-    ...(sourceConfig as GetStatsDataParams),
-  };
-
-  const storage = await getEstatCacheStorage();
-  const rawData = await fetchFormattedStats(params, storage);
-
-  // 全国値 (areaCode "00000") を対象年度で抽出（filterOutNationalArea の逆）
-  const nationalRow = filterToNational(rawData).find(
-    (d) => d.yearCode === yearCode,
-  );
-  const nationalValue =
-    typeof nationalRow?.value === "number" ? nationalRow.value : undefined;
-
-  // 全国行の全年度トレンドを構築（MiniLineChart 用）
-  const nationalSeries = filterToNational(rawData)
-    .filter((d) => typeof d.value === "number" && Number.isFinite(d.value as number))
-    .map((d) => ({ year: Number(String(d.yearCode).slice(0, 4)), value: d.value as number }))
-    .filter((p) => Number.isFinite(p.year))
+  return [...byYear.entries()]
+    .map(([year, vals]) => ({
+      year,
+      value: vals.reduce((a, b) => a + b, 0) / vals.length,
+    }))
     .sort((a, b) => a.year - b.year);
-
-  const filteredData = filterOutNationalArea(rawData)
-    .filter((d) => d.yearCode === yearCode);
-  if (filteredData.length === 0) return { values: [], nationalValue, nationalSeries };
-
-  return { values: rankByValue(filteredData) as RankingValue[], nationalValue, nationalSeries };
 }
 
 /**
  * テーマダッシュボード用のデータを一括取得
  *
- * 全指標の RankingItem 定義 + e-Stat API データ + TopoJSON を並列取得し、
- * indicatorDataMap として返す。
- * tabIndicators がある場合はそのキーもマージして取得する。
+ * 全指標の RankingItem 定義 + R2 ranking values + TopoJSON を並列取得し、
+ * indicatorDataMap として返す。tabIndicators がある場合はそのキーもマージして取得する。
  *
- * areaType="city" 指定時:
- *   - R2 の per-key values.json を読み込み (e-Stat 直接取得はしない)
- *   - city 用 municipality topology を使用
+ * ★データ source は R2 の `app/ranking/<key>/values.json` のみ (e-Stat ライブ取得はしない)。
+ *   e-Stat ライブ取得は Cloudflare Workers ランタイムで失敗し本番で error fallback を招いたため、
+ *   /ranking/* と同一の R2 source に統一した (完全DBレス: docs/01_技術設計/12_完全DBレス設計.md)。
+ *   build 時は readRankingValuesFromR2 が ok([]) を返すため、ページは force-dynamic で runtime 描画する。
+ *
+ * - prefecture: readAllYearsRankingValuesFromR2 で全年を 1 read → current 年 values + 全国(県平均)トレンド
+ * - city: readRankingValuesFromR2 で current 年のみ (全市区町村×全年は巨大なため)
  */
 export async function loadThemeData(
   theme: ThemeConfig,
@@ -153,11 +124,25 @@ export async function loadThemeData(
         });
     }
 
-    // prefecture: 既存ロジック (e-Stat fetch + ランク計算 + 全国値)
-    return fetchIndicatorValues(item, yearCode)
-      .then(({ values, nationalValue, nationalSeries }) => ({ key, values, nationalValue, nationalSeries }))
+    // prefecture: R2 から全年度を 1 read (e-Stat ライブ取得しない。/ranking/* と同一 source)。
+    // current 年の values + 全国(県平均)トレンドを構築。全国行は無いため nationalValue は undefined
+    // (ThemeMetricsDashboard が未選択時に県平均へフォールバックする)。
+    return readAllYearsRankingValuesFromR2(key, "prefecture")
+      .then((result) => {
+        const all = isOk(result) ? result.data : [];
+        const ny = yearCode.slice(0, 4);
+        const values = all.filter((v) => String(v.yearCode).slice(0, 4) === ny);
+        const nationalSeries = buildNationalSeries(all);
+        return {
+          key,
+          values,
+          nationalValue: undefined as number | undefined,
+          nationalSeries:
+            nationalSeries.length > 0 ? nationalSeries : undefined,
+        };
+      })
       .catch((error) => {
-        logger.error({ error, key }, "テーマダッシュボード: e-Stat データ取得失敗");
+        logger.error({ error, key }, "テーマダッシュボード: ranking values 取得失敗 (R2)");
         return { key, values: [] as RankingValue[], nationalValue: undefined as number | undefined, nationalSeries: undefined as { year: number; value: number }[] | undefined };
       });
   });

--- a/docs/02_実装計画/10_テーマダッシュボード強化.md
+++ b/docs/02_実装計画/10_テーマダッシュボード強化.md
@@ -21,9 +21,15 @@ tags: [実装計画, theme-dashboard]
 | テーマ一覧・メタ | `apps/web/src/features/theme-dashboard/config/all-themes.ts`（`ALL_THEMES`） | ビルド時直読 | `generateStaticParams` / `loadThemeData` |
 | テーマ別 指標セット | `packages/types/src/indicator-sets/*.ts` | ビルド時直読 | `to-theme-config.ts` → `ThemeConfig` |
 | チャート構成 | `apps/web/scripts/data/page-components/theme/<key>.json`（page_components git TS SSOT, Phase E 実装済） | R2 `app/page-components/theme/<key>.json` | `ThemeDbChartRenderer` |
-| 指標値 | e-Stat（page_components の `estatParams`）/ ranking R2 snapshot | runtime fetch | KPI カード・各チャート |
+| **指標値（ダッシュボード本体: KPI カード・上位県バー・トレンド）** | — | **R2 `app/ranking/<key>/values.json`（全年 partitions）** | `loadThemeData` → `ThemeMetricsDashboard` |
+| 指標値（page_components チャート: line/mixed/composition 等） | — | e-Stat（`estatParams`）runtime fetch | `ThemeDbChartRenderer`（server actions） |
 
-- **ルーティング**: 1 個の動的 `app/themes/[themeSlug]/page.tsx`（旧 17 静的ページを集約）。`local-finance` は Power BI 風 `LocalFinanceDashboard` を持つため専用ページ構成。
+> ★**ダッシュボード本体の指標値は R2 `app/ranking/<key>/values.json` のみから読む（e-Stat ライブ取得しない）**。`loadThemeData` が `readAllYearsRankingValuesFromR2` で全年を 1 read し、current 年 values + 全国(県平均)トレンドを構築する。全国行(00000)は R2 に無いため未選択時は県平均を KPI に使う。
+> - **理由**: 旧実装は指標値を e-Stat からライブ取得していたが、**Cloudflare Workers ランタイムで e-Stat fetch が失敗**し本番テーマページが全て「データの取得に失敗しました」を表示していた（2026-06-20 修正）。`/ranking/*` と同一の R2 source に統一して解消。完全DBレス原則（`docs/01_技術設計/12_完全DBレス設計.md`「本番アプリは R2 snapshot のみ読む」）にも準拠。
+> - **force-dynamic 必須**: テーマページ（`[themeSlug]` / `local-finance` / `cities`）は `export const dynamic = "force-dynamic"`。SSG/ISR にすると build 時に R2 を読めず（`readRankingValuesFromR2` が build phase で `ok([])`）error fallback が prerender に焼かれ、ISR 無効のため回復しない（home と同型。memory `feedback_home_pure_ssg_r2_empty`）。
+> - **未統一（latent）**: page_components チャート（`ThemeDbChartRenderer` の `fetch-db-chart-data` / `fetch-metric-timeseries` / `fetch-population-pyramid` server actions）は今も e-Stat runtime fetch。cards-only ビューでは描画しないため現状の本番表示には影響しないが、これらを表示する場合は同じ Workers ランタイム失敗リスクがある（R2 化が今後の課題）。
+
+- **ルーティング**: 1 個の動的 `app/themes/[themeSlug]/page.tsx`（旧 17 静的ページを集約）。`local-finance` / `local-finance/cities` は都道府県/市区町村トグルのため専用ページだが、**中身は汎用 `ThemePageLayout` に統合済み**（旧 bespoke `LocalFinanceDashboard` は廃止＝orphan。財政フロー Sankey は `EMBEDDED_SECTIONS` に定義を残し hideMap で一旦非表示）。
 - **KPI カード**: `tabIndicators`（role≠context の指標）から自動生成。県選択時は値・全国順位・全国平均比、未選択時は全国平均。→ **page_components 不要**。
 - **チャート**: `ThemeDbChartRenderer` 対応の **7 タイプのみ** — `line-chart` / `mixed-chart` / `composition-chart` / `donut-chart` / `pyramid-chart` / `cpi-profile` / `cpi-heatmap`（+ `markdown-section`）。`estatParams` は `packages/data-configs/src/metrics/<key>.ts` の `source`（statsDataId / cdCat01）を転記（手入力の推測値は禁止）。
 - **個別チャート**: `MetricFocusCharts`（コロプレスで選択中の指標について、時系列 line + 上下位 5 県 bar を描画。タブ切替・県クリックで自動再描画）。pie/breakdown は未実装。

--- a/packages/ranking/src/repositories/ranking-value/index.ts
+++ b/packages/ranking/src/repositories/ranking-value/index.ts
@@ -4,6 +4,7 @@ export { getAvailableYears } from "./get-available-years";
 export { listRankingValues } from "./list-ranking-values";
 export {
   readAllYearsNormalizedRankingValuesFromR2,
+  readAllYearsRankingValuesFromR2,
   readNormalizedRankingValuesFromR2,
   readRankingValuesByPrefectureFromR2,
   readRankingValuesFromR2,

--- a/packages/ranking/src/repositories/ranking-value/read-ranking-values-from-r2.ts
+++ b/packages/ranking/src/repositories/ranking-value/read-ranking-values-from-r2.ts
@@ -86,6 +86,41 @@ export async function readRankingValuesFromR2(
 }
 
 /**
+ * 生 R2 snapshot から **全年度** の ranking_values を取得 (1 fetch)。
+ *
+ * - テーマダッシュボードが「current 年の values + 全年トレンド」を 1 read で得るために使う
+ *   (都道府県指標を e-Stat ライブ取得しないための堅牢経路。`/ranking/*` と同一の R2 source)。
+ * - build 時 (NEXT_PHASE=phase-production-build) は ok([]) を返す → 呼び出し側は force-dynamic で
+ *   build prerender を避け、runtime (Worker) で R2 を読む。
+ * - 都道府県 (47×全年) 用。市区町村 (1741×全年) は巨大なため単年 readRankingValuesFromR2 を使う。
+ */
+export async function readAllYearsRankingValuesFromR2(
+  rankingKey: string,
+  areaType: AreaType,
+): Promise<Result<RankingValue[], Error>> {
+  if (process.env.NEXT_PHASE === "phase-production-build") {
+    return ok([]);
+  }
+
+  try {
+    const snapshot = await loadRankingValuesForKey(rankingKey, areaType);
+    if (!snapshot) return ok([]);
+
+    const all: RankingValue[] = [];
+    for (const partition of snapshot.partitions) {
+      all.push(...partition.values);
+    }
+    return ok(all);
+  } catch (error) {
+    logger.error(
+      { rankingKey, areaType, error: error instanceof Error ? error.message : String(error) },
+      "readAllYearsRankingValuesFromR2: failed",
+    );
+    return err(error instanceof Error ? error : new Error(String(error)));
+  }
+}
+
+/**
  * 正規化済み R2 snapshot から ranking_values を取得。
  *
  * normType: "per_population" → app/ranking/{key}/values-per-population.json


### PR DESCRIPTION
## 問題
本番テーマページが全て「データの取得に失敗しました」を表示（前回 force-dynamic 化しても残存）。

## 根本原因
`loadThemeData` が都道府県指標を **e-Stat からライブ取得**しており、それが **Cloudflare Workers ランタイムで失敗** → `indicatorDataMap` 空 → null → error fallback。`/ranking/*`（R2 直読み）とは別経路だった。

## 修正
- `loadThemeData` を **R2 `app/ranking/<key>/values.json`（全年 partitions）直読み**に統一。e-Stat fetch 経路を全削除。
- ranking package に `readAllYearsRankingValuesFromR2` 追加（全年 1 read → current 年 values + 全国(県平均)トレンド）。
- 全テーマ指標（計算型含む）が R2 に存在することを確認。

## ドキュメント統一（修正漏れ防止）
- `docs/02_実装計画/10`: 指標値 source = R2 ranking snapshot に更新、force-dynamic 必須、page_components チャート(e-Stat)の latent risk 明記、local-finance 汎用統合反映
- `skills/theme/optimize-themes`: ダッシュボード本体 KPI は R2 と訂正

## 検証
- ローカル dev で全テーマがダッシュボード描画（error fallback 0・KPI/セレクタ/左ナビ/上位県バー表示）
- デプロイ後に本番 /themes/* で実描画を確認する

🤖 Generated with [Claude Code](https://claude.com/claude-code)