### PR TITLE
fix(prod): CLOUDFLARE_WORKERS=true で本番 R2 snapshot 読みを修正 (テーマ error fallback 根治)

### DIFF
--- a/.claude/rules/blog-data-schema.md
+++ b/.claude/rules/blog-data-schema.md
@@ -101,6 +101,27 @@ metric 選定 (GSC ギャップ/トレンド/カテゴリ/ユーザー指示)
 
 > **2つの一括再生成の使い分け（混在防止）**: ランキングの是正は **`regenerate-ranking-cards.mjs`**（SSOT=R2 app/ranking から**再取得**して manifest 付きで横長+縦長を作る。データが R2 に無い記事でも復元できる）が正典。`regenerate-blog-svgs.yml`（CI）は **既存 `data/*.json` を入力に全チャート種を再描画**する用途で、ソース JSON が R2 に残っていない記事のランキングは再生成できない（→ `regenerate-ranking-cards.mjs` を使う）。
 
+## 1.6 タイルマップ（choropleth）のデータ系譜 + デザイン（2026-06-20 確定） ★
+
+タイルマップもランキングと**同じ SSOT データフロー**に統一する。**SVG からの値の逆復元は禁止**（必ず SSOT から取得し、既存 SVG は metric 照合にのみ使う）。
+
+### デザイン（`packages/svg-builder/src/charts/choropleth.ts` が SSoT）
+
+- サイズ **600×700 固定**。テキストは **全て白 + 濃い縁取り（`paint-order` stroke）+ ソフトシャドウ**（淡色〜濃色どのタイルでも可読。白/黒の切替はしない）。
+- タイトルは**左上の余白に左寄せ・大きく**（自動フィット最大22px）、**年は別行・15px**。
+- **カラーは D3 カラースキーム指定可**: `scheme`（d3-scale-chromatic の `interpolate<Name>`。例 `Blues`/`Viridis`/`RdYlGn`/`RdBu`/`Spectral`/`YlOrRd`…連続・発散とも）。未指定時は既定 Reds。`reverse` で反転。
+- 値表示は `showValue`（県名のみ=既定 / 県名+値）。
+
+### データ取得ルール（SSOT・捏造禁止）
+
+- 地図データの真実源は **R2 `app/ranking/<key>/values.json`**（= metric config → e-Stat → R2 派生。ランキングと同一）。
+- `data/<name>-map.json`（型付き 47 県値）+ `data/<name>-map.source.json`（manifest: `kind:"ranking"`, `rankingKey`, `year`, `verifiedMatchRate`）の3点。author が `scheme` を JSON に指定可。
+- `generate-article-charts.ts` が `*-map.json` を `generateChoroplethSvg` にディスパッチ（`data.scheme`/`reverse`/`showValue`/`legendLabels` を渡す）。
+
+### 既存記事の一括再生成
+
+`.claude/scripts/blog/regenerate-tile-maps.ts`（dry-run=staging `.local/regen-tilemaps` + gallery `/tmp/tilemap-gallery.html`、R2 push しない）。記事の `/ranking/<key>` 候補 × 各年の SSOT 値を**既存地図の表示値と照合**し metric+年を確定（一致率≥0.8）。確証できた地図のみ SSOT から再生成、**確証できない地図は flag**（個別に metric→key 特定が要る。捏造しない）。R2 反映は別途 `diff-push-r2`。
+
 ## 2. Wave 命名規則
 
 Blog の brushup 施策は **wave 単位** で記録・追跡する。wave は「同一目的・同一日付・同一手法」でまとめた施策のセット。

--- a/.claude/rules/blog-svg-chart-standards.md
+++ b/.claude/rules/blog-svg-chart-standards.md
@@ -37,7 +37,7 @@ CLI 内にインライン生成ロジックを書かない（重複・ドリフ�
 |---|---|---|---|---|---|
 | `generateBarChartSvg` | `bar-chart.ts` | `BarItem[]` + `BarChartOptions` | `*-ranking.json` / `*-top5-bottom5.json` | ~239 | ランキングはカード型のみ・**上位5+下位5固定**（10件廃止）。`layout:"columns"`=横長2列カード（左=上位/右=下位、`960×404`、ブログ本文+X 用）/ `layout:"portrait"`=縦長スタックカード（上位5↓下位5、`1080×1350` 4:5、Instagram 用 `-ig.svg`）/ `layout:"single"`=縦1列+「…中略…」(680幅)。`generate-article-charts.ts` が `*-ranking.json` から columns(`<name>.svg`)+portrait(`<name>-ig.svg`)を自動両出力 |
 | `generateScatterSvg` | `scatter.ts` | `ScatterPoint[]` + `ScatterOptions` | `*-scatter.json` | ~166 | 散布図（全都道府県・相関可視化） |
-| `generateChoroplethSvg` | `choropleth.ts` | `ChoroplethItem[]` + `ChoroplethOptions` | `*-map.json` / `*-tile-grid.json` | ~84 | タイルグリッド 47 都道府県マップ |
+| `generateChoroplethSvg` | `choropleth.ts` | `ChoroplethItem[]` + `ChoroplethOptions` | `*-map.json` / `*-tile-grid.json` | ~84 | タイルグリッド47都道府県マップ。**600×700固定・全テキスト白+縁取り・タイトル左上・年15px**。色は **D3カラースキーム** `scheme`(`Blues`/`Viridis`/`RdYlGn`/`RdBu`/`Spectral`/`YlOrRd`…d3-scale-chromatic、未指定時 Reds)、`reverse`/`showValue` 可。データは SSOT(R2 app/ranking)。一括再生成: `regenerate-tile-maps.ts`。正典 `blog-data-schema.md` §1.6 |
 | `generateLineSvg` | `line.ts` | `StatsSchema[]` + `LineOptions` | `*-timeseries.json` / `*-trend.json` | ~39 | 多系列折れ線（時系列・年齢階級）|
 | `generateStackedBarSvg` | `stacked-bar.ts` | `StackedData` + `StackedBarOptions` | `*-stacked.json` / `*-breakdown.json` | ~5 | 積み上げ棒グラフ（構成比）|
 | `generateFindingsCardSvg` | `findings-card.ts` | `FindingsCardData`（`{ findings: string[] \| FindingsCardItem[], title?: string }`） | `*-summary-findings.json` / `*-findings.json` | ~54 | 「この記事でわかったこと」要点カード（番号付き circle + テキスト行） |

--- a/.claude/scripts/blog/generate-article-charts.ts
+++ b/.claude/scripts/blog/generate-article-charts.ts
@@ -204,10 +204,11 @@ function genBarChartSvg(data, layoutOverride) {
  * → svg-builder generateChoroplethSvg (ChoroplethItem[])
  */
 function genTileGridMapSvg(data) {
+  const get = (k) => (Array.isArray(data) ? undefined : data[k]);
   const items = Array.isArray(data) ? data : data.data || [];
   if (!items.length) return `<!-- empty data -->`;
-  const title = (Array.isArray(data) ? null : data.title) ?? "都道府県マップ";
-  const unit = (Array.isArray(data) ? null : data.unit) ?? "";
+  const title = get("title") ?? "都道府県マップ";
+  const unit = get("unit") ?? "";
 
   const choroplethItems = items
     .filter((it) => typeof it.value === "number" && isFinite(it.value))
@@ -219,7 +220,18 @@ function genTileGridMapSvg(data) {
     .filter((it) => it.code && it.name);
 
   if (!choroplethItems.length) return `<!-- empty choropleth data -->`;
-  return generateChoroplethSvg(choroplethItems, { title, unit });
+  return generateChoroplethSvg(choroplethItems, {
+    title,
+    unit,
+    subtitle: get("subtitle"),
+    // D3 カラースキーム名 (例 "Blues" / "Viridis" / "RdYlGn")。未指定時は既定 Reds。
+    scheme: get("scheme") ?? get("colorScheme"),
+    reverse: get("reverse"),
+    showValue: get("showValue"),
+    colorMin: get("colorMin"),
+    colorMax: get("colorMax"),
+    legendLabels: get("legendLabels"),
+  });
 }
 
 /**

--- a/.claude/scripts/blog/regenerate-tile-maps.ts
+++ b/.claude/scripts/blog/regenerate-tile-maps.ts
@@ -1,0 +1,231 @@
+#!/usr/bin/env tsx
+/**
+ * regenerate-tile-maps.ts
+ *
+ * 公開済みブログ記事のタイルマップ(choropleth)を統一デザイン(600×700・白文字+縁取り・
+ * タイトル左上)で一括再生成するオーケストレータ。
+ *
+ * ## データ取得ルール (SSOT・捏造禁止)
+ *   データ源は SSOT = R2 `app/ranking/<key>/values.json`(metric config → e-Stat → R2 派生)。
+ *   1. 記事 article.md の `/ranking/<key>` 候補を抽出
+ *   2. 各候補 key × 各年の SSOT 値を、既存地図SVGの表示値(<title>県：値)と照合し metric+年を確定
+ *      (既存SVGは「照合」のみ。値の取得元にはしない = SVGからの逆復元はしない)
+ *   3. 一致率 >= 0.8 を確証できたものだけ、SSOT から型付き data JSON + 出典 manifest を書き、
+ *      `generate-article-charts.ts` 互換の choropleth で再生成
+ *   4. 確証できない地図は flag(個別に metric→key を特定する必要。捏造しない)
+ *
+ * デフォルトは dry-run(staging `.local/regen-tilemaps` に出力 + before/after gallery)。
+ * R2 反映は別途 `diff-push-r2` で行う(本スクリプトは push しない)。
+ *
+ * Usage:
+ *   npx tsx .claude/scripts/blog/regenerate-tile-maps.ts            # 全件 dry-run + gallery
+ *   npx tsx .claude/scripts/blog/regenerate-tile-maps.ts --limit 10 # 先頭10枚のみ
+ *
+ * 正典: .claude/rules/blog-data-schema.md §1.6 / カタログ: blog-svg-chart-standards.md
+ */
+
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { generateChoroplethSvg } from "../../../packages/svg-builder/src/charts/index.ts";
+import { formatTick } from "../../../packages/svg-builder/src/shared/axis.ts";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const PROJECT_ROOT = path.resolve(__dirname, "..", "..", "..");
+const R2_PUBLIC = process.env.R2_PUBLIC_FETCH_URL || "https://storage.stats47.jp";
+const R2 = `${R2_PUBLIC}/app/blog`;
+const RANK = `${R2_PUBLIC}/app/ranking`;
+const STAGE = path.join(PROJECT_ROOT, ".local/regen-tilemaps");
+const LIMIT = process.argv.includes("--limit")
+  ? Number(process.argv[process.argv.indexOf("--limit") + 1])
+  : null;
+
+// 都道府県 名前(短縮/正式)→ 2桁コード
+const PREF: Record<string, string> = {};
+for (const p of JSON.parse(
+  fs.readFileSync(path.join(PROJECT_ROOT, "packages/area/src/data/prefectures.json"), "utf8"),
+)) {
+  const code = String(p.prefCode).slice(0, 2);
+  PREF[p.prefName] = code;
+  PREF[(p.prefName as string).replace(/[都道府県]$/, "")] = code;
+}
+const codeOf = (n: string) => PREF[n] ?? PREF[n.replace(/[都道府県]$/, "")] ?? "";
+const isMapName = (b: string) => /tile-?map|tile-?grid|choropleth|-map$|-map-|地図/i.test(b);
+
+async function ft(u: string) {
+  const r = await fetch(u);
+  if (!r.ok) throw new Error(`HTTP ${r.status}`);
+  return r.text();
+}
+async function fj(u: string) {
+  return JSON.parse(await ft(u));
+}
+async function pMap<T, R>(items: T[], fn: (x: T) => Promise<R>, c: number): Promise<R[]> {
+  const out: R[] = [];
+  let i = 0;
+  const w = async () => {
+    while (i < items.length) {
+      const k = i++;
+      try {
+        out[k] = await fn(items[k]);
+      } catch {
+        (out[k] as unknown) = null;
+      }
+    }
+  };
+  await Promise.all(Array.from({ length: Math.min(c, items.length) }, w));
+  return out;
+}
+
+/** 既存地図SVGの表示値(照合用): name -> "値+単位文字列" */
+function parseMapDisplay(svg: string): Map<string, string> {
+  const m = new Map<string, string>();
+  for (const t of [...svg.matchAll(/<title>([^<]*)<\/title>/g)].map((x) => x[1])) {
+    const i = t.indexOf("：");
+    if (i < 0) continue;
+    m.set(t.slice(0, i).trim(), t.slice(i + 1).trim());
+  }
+  return m;
+}
+
+/** SSOT: ranking values.json の各年 partition */
+async function ssotPartitions(key: string) {
+  const v = await fj(`${RANK}/${key}/values.json`);
+  let item: { unit?: string; title?: string; rankingName?: string } = {};
+  try {
+    const it = await fj(`${RANK}/${key}/item.json`);
+    item = it.item || it || {};
+  } catch {
+    /* item は best-effort */
+  }
+  const unit = item.unit || v.partitions?.[0]?.values?.[0]?.unit || "";
+  return (v.partitions || []).map((p: { yearCode: string; values: unknown[] }) => ({
+    year: p.yearCode,
+    values: p.values as Array<{ areaName: string; value: number; areaCode: string }>,
+    unit,
+    title: item.title || item.rankingName || key,
+  }));
+}
+
+/** SSOT値が既存地図の表示値と一致する割合(0..1)。絶対0.15 or 相対1% を一致とみなす。 */
+function matchRate(
+  ssotVals: Array<{ areaName: string; value: number }>,
+  display: Map<string, string>,
+): number {
+  let ok = 0;
+  let n = 0;
+  for (const v of ssotVals) {
+    const disp = display.get(v.areaName) ?? display.get(v.areaName.replace(/[都道府県]$/, ""));
+    if (!disp) continue;
+    n++;
+    const dnum = disp.replace(/,/g, "").match(/-?[\d.]+/)?.[0];
+    if (!dnum) continue;
+    const sf = parseFloat(formatTick(v.value, 1).replace(/,/g, ""));
+    if (Math.abs(sf - parseFloat(dnum)) <= Math.max(0.15, Math.abs(sf) * 0.01)) ok++;
+  }
+  return n >= 5 ? ok / n : 0;
+}
+
+async function main() {
+  const manifest = await fj(`${R2}/all.json`);
+  const slugs: string[] = (manifest.articles || []).map((a: { slug: string }) => a.slug).filter(Boolean);
+  console.error(`[tilemap] ${slugs.length} 記事を triage`);
+
+  const found = await pMap(
+    slugs,
+    async (slug) => {
+      const md = await ft(`${R2}/${slug}/article.md`);
+      const refs = [...new Set([...md.matchAll(/\]\(data\/([^)]+)\.svg\)/g)].map((m) => m[1]))].filter(isMapName);
+      const keys = [...new Set([...md.matchAll(/\/ranking\/([a-z0-9-]+)/gi)].map((m) => m[1]))];
+      return { slug, refs, keys };
+    },
+    12,
+  );
+  const targets = found
+    .filter((g) => g && g.refs.length)
+    .flatMap((g) => g.refs.map((r) => ({ slug: g.slug, base: r, keys: g.keys })));
+  console.error(`[tilemap] 地図SVG: ${targets.length} 枚`);
+
+  const work = LIMIT ? targets.slice(0, LIMIT) : targets;
+  const results: Array<Record<string, unknown>> = [];
+  for (const t of work) {
+    try {
+      const oldSvg = await ft(`${R2}/${t.slug}/data/${t.base}.svg`);
+      const display = parseMapDisplay(oldSvg);
+      let best: { key: string; year: string; values: Array<{ areaName: string; value: number; areaCode: string }>; unit: string; title: string; rate: number } | null = null;
+      for (const key of t.keys) {
+        let parts;
+        try {
+          parts = await ssotPartitions(key);
+        } catch {
+          continue;
+        }
+        for (const p of parts) {
+          const rate = matchRate(p.values, display);
+          if (!best || rate > best.rate) best = { key, ...p, rate };
+        }
+      }
+      if (!best || best.rate < 0.8) {
+        results.push({ ...t, error: `SSOT照合 失敗 (最大一致 ${best ? Math.round(best.rate * 100) : 0}% / key ${t.keys.length})` });
+        continue;
+      }
+      const items = best.values
+        .map((v) => ({ code: codeOf(v.areaName), name: v.areaName.replace(/[都道府県]$/, ""), value: v.value }))
+        .filter((x) => x.code);
+      const dir = path.join(STAGE, t.slug, "data");
+      fs.mkdirSync(dir, { recursive: true });
+      const json = {
+        title: best.title,
+        subtitle: `${best.year}年`,
+        unit: best.unit,
+        year: best.year,
+        rankingKey: best.key,
+        data: best.values.map((v, i) => ({ rank: i + 1, areaName: v.areaName, value: v.value, areaCode: v.areaCode })),
+      };
+      fs.writeFileSync(path.join(dir, `${t.base}.json`), JSON.stringify(json, null, 2));
+      fs.writeFileSync(
+        path.join(dir, `${t.base}.source.json`),
+        JSON.stringify(
+          {
+            kind: "ranking",
+            rankingKey: best.key,
+            year: best.year,
+            unit: best.unit,
+            source: `r2:app/ranking/${best.key}/values.json`,
+            verifiedMatchRate: Math.round(best.rate * 100),
+            note: "SSOTから取得。既存地図の表示値と照合し metric+年を確定 (SVGから逆復元しない)",
+          },
+          null,
+          2,
+        ),
+      );
+      const newSvg = generateChoroplethSvg(items, { title: best.title, subtitle: `${best.year}年`, unit: best.unit });
+      fs.writeFileSync(path.join(dir, `${t.base}.svg`), newSvg);
+      results.push({ ...t, oldSvg, newSvg, key: best.key, year: best.year, rate: Math.round(best.rate * 100), n: items.length });
+    } catch (e) {
+      results.push({ ...t, error: String((e as Error)?.message || e).slice(0, 120) });
+    }
+  }
+
+  const esc = (s: unknown) => String(s ?? "").replace(/[<>&"]/g, (c) => ({ "<": "&lt;", ">": "&gt;", "&": "&amp;", '"': "&quot;" }[c]!));
+  const cards = results
+    .map((r) =>
+      r.error
+        ? `<section class=row><h3>${esc(r.slug)}/${esc(r.base)} <span style=color:#fca5a5>✗ ${esc(r.error)}</span></h3></section>`
+        : `<section class=row><h3>${esc(r.slug)}/${esc(r.base)} <span>SSOT=${esc(r.key)} ${esc(r.year)}年 一致${esc(r.rate)}% ${esc(r.n)}件</span></h3>
+      <div class=grid><figure><figcaption>BEFORE (現R2)</figcaption><div class=box>${r.oldSvg}</div></figure>
+      <figure><figcaption>AFTER (SSOT再生成)</figcaption><div class=box>${r.newSvg}</div></figure></div></section>`,
+    )
+    .join("\n");
+  const ok = results.filter((r) => !r.error).length;
+  fs.writeFileSync(
+    "/tmp/tilemap-gallery.html",
+    `<!doctype html><meta charset=utf8><title>タイルマップ SSOT再生成</title>
+<style>body{margin:0;font-family:system-ui;background:#0f172a;color:#e2e8f0}main{padding:16px}.row{margin-bottom:24px;border-bottom:1px solid #334155;padding-bottom:14px}h3{font-size:14px}h3 span{color:#94a3b8;font-size:12px;font-weight:400}.grid{display:grid;grid-template-columns:1fr 1fr;gap:14px}figcaption{font-size:12px;color:#94a3b8}.box svg{width:100%;height:auto;display:block}</style>
+<header style="position:sticky;top:0;background:#1e293b;padding:10px 16px"><b>タイルマップ SSOT再生成 dry-run</b> 成功${ok} / 失敗${results.length - ok} (R2未反映)</header><main>${cards}</main>`,
+  );
+  console.error(`[tilemap] SSOT再生成 成功${ok} / 失敗${results.length - ok}`);
+  console.error(`[tilemap] gallery: /tmp/tilemap-gallery.html`);
+}
+
+main();

--- a/.claude/skills/blog/generate-article-charts/SKILL.md
+++ b/.claude/skills/blog/generate-article-charts/SKILL.md
@@ -235,7 +235,9 @@ JSON で制御できるオプション（`data/*-ranking.json` のオブジェ�
 
 #### タイルグリッドマップ
 
-**重要**: タイルグリッドの配置は `packages/visualization/src/d3/constants/tile-grid-layout.ts` の `TILE_GRID_LAYOUT` が**唯一の正（canonical source）**。ハードコードした座標を使わず、以下のグリッド定義から計算すること。
+**統一仕様（2026-06-20）**: 600×700固定 / 全テキスト白+縁取り / タイトル左上・年15px。色は **D3カラースキーム** を `data/*-map.json` の `scheme`（`Blues`/`Viridis`/`RdYlGn`/`RdBu`/`Spectral`/`YlOrRd`… 未指定時 Reds）で指定。`reverse`（反転）/ `showValue`（県名+値）も可。データ源は SSOT（R2 app/ranking）。既存地図の一括統一は `regenerate-tile-maps.ts`。正典 = `.claude/rules/blog-data-schema.md` §1.6。
+
+**重要**: タイルグリッドの配置は `packages/svg-builder/src/charts/choropleth.ts` の `TILE_LAYOUT` が svg-builder 経由の生成では正。`generate-article-charts.ts` は `genTileGridMapSvg` 経由で `generateChoroplethSvg` にディスパッチする。
 
 ```js
 // --- 正規レイアウト定義（tile-grid-layout.ts と同一） ---

--- a/apps/web/wrangler.toml
+++ b/apps/web/wrangler.toml
@@ -54,6 +54,12 @@ name = "stats47"
 [env.production.vars]
 NODE_ENV = "production"
 NEXT_PUBLIC_ENV = "production"
+# ★必須: Workers ランタイムで R2 snapshot 読みを許可する。
+# shouldSkipRemoteR2Read() は CLOUDFLARE_WORKERS!=="true" かつ CI でも S3creds でも
+# R2_PUBLIC_FETCH_URL でもないと true(skip) を返す。これが未設定だと本番 Worker で
+# readRankingItemFromR2 等が読みを skip → loadThemeData null → テーマが error fallback、
+# home featured も空になる (2026-06-20 根本原因)。
+CLOUDFLARE_WORKERS = "true"
 # NextAuth用のシークレット（本番環境用に別途生成してください）
 # openssl rand -base64 32
 # AUTH_SECRET = "your-production-secret-here-minimum-32-characters"

--- a/packages/svg-builder/src/charts/choropleth.ts
+++ b/packages/svg-builder/src/charts/choropleth.ts
@@ -18,6 +18,9 @@
 import { FONT_FAMILY } from "../shared/color";
 import { formatTick } from "../shared/axis";
 import { svgThemeStyle } from "../shared/theme";
+// D3 カラースキーム (d3-scale-chromatic) を「生成時」に評価し、結果の rgb() を静的 SVG へ焼き込む。
+// （SVG 実行時に D3 は不要。）依存はモノレポ root に hoist 済（migration-flow / remotion が宣言）。
+import * as d3chromatic from "d3-scale-chromatic";
 
 export interface ChoroplethItem {
   /** 都道府県コード "01"〜"47"（"01000" 形式も可） */
@@ -43,10 +46,29 @@ export interface ChoroplethOptions {
   colorMax?: number;
   /** 値フォーマット関数（省略時: formatTick） */
   formatValue?: (v: number) => string;
-  /** カラーストップ（省略時: Reds） */
+  /** カラーストップ（省略時: Reds）。`scheme` 指定時は無視される。 */
   colorStops?: Array<{ t: number; r: number; g: number; b: number }>;
+  /**
+   * D3 カラースキーム名（d3-scale-chromatic の `interpolate<Name>`）。
+   * 例: "Reds" / "Blues" / "Greens" / "Oranges" / "Purples" / "Greys" /
+   *     "Viridis" / "Magma" / "YlOrRd" / "BuPu" / "YlGnBu"（連続単/多色相）、
+   *     "RdYlGn" / "RdBu" / "Spectral" / "BrBG" / "PuOr"（発散）など。
+   * 指定時は `colorStops` より優先。未指定時は `colorStops`（既定 Reds）。
+   */
+  scheme?: string;
+  /** カラースケールを反転する（高い値を淡色側にする等）。 */
+  reverse?: boolean;
+  /** 各タイルに県名の下へ値も表示する（省略時: false = 県名のみ）。 */
+  showValue?: boolean;
   /** 凡例の端ラベル [左端, 右端]（省略時: ["安全", "危険"]） */
   legendLabels?: [string, string];
+}
+
+/** D3 スキーム名 → interpolator 関数を解決（無ければ null）。 */
+function resolveInterp(scheme?: string): ((t: number) => string) | null {
+  if (!scheme) return null;
+  const fn = (d3chromatic as Record<string, unknown>)[`interpolate${scheme}`];
+  return typeof fn === "function" ? (fn as (t: number) => string) : null;
 }
 
 // ─── タイルレイアウト ────────────────────────────────────────────
@@ -158,17 +180,11 @@ function nameFontSize(name: string, w: number, h: number): number {
   return 9;
 }
 
-/**
- * 背景色の知覚輝度に基づきテキスト色を返す。
- * 輝度 > 0.5 → 暗い背景向け白文字ではなく濃いグレー（#374151）、
- * 輝度 ≤ 0.5 → 白（#ffffff）。
- */
-function textFill(rgbColor: string): string {
-  const m = rgbColor.match(/rgb\((\d+),(\d+),(\d+)\)/);
-  if (!m) return "#ffffff";
-  const lum =
-    (0.299 * parseInt(m[1]) + 0.587 * parseInt(m[2]) + 0.114 * parseInt(m[3])) / 255;
-  return lum > 0.5 ? "#374151" : "#ffffff";
+/** 概算幅でタイトルフォントをフィット（CJK≈1em / ASCII・半角≈0.55em）。 */
+function fitTitleFont(text: string, availW: number, maxF: number, minF: number): number {
+  const units = [...text].reduce((w, ch) => w + (/[ -~｡-ﾟ]/.test(ch) ? 0.55 : 1.0), 0);
+  if (units <= 0) return maxF;
+  return Math.max(minF, Math.min(maxF, Math.floor(availW / units)));
 }
 
 // ─── SVG 定数 ────────────────────────────────────────────────────
@@ -200,8 +216,18 @@ export function generateChoroplethSvg(
     colorMax,
     formatValue = (v) => formatTick(v, 1),
     colorStops = COLOR_STOPS,
+    scheme,
+    reverse = false,
+    showValue = false,
     legendLabels = ["安全", "危険"],
   } = options;
+
+  // 色の解決: scheme（D3）指定時は interpolator、無ければ colorStops。reverse で反転。
+  const interp = resolveInterp(scheme);
+  const colorOf = (t: number): string => {
+    const tt = reverse ? 1 - t : t;
+    return interp ? interp(tt) : interpolateColor(tt, colorStops);
+  };
 
   // コードを 2 桁に正規化（"01000" → "01"）
   const byCode = new Map(
@@ -219,52 +245,69 @@ export function generateChoroplethSvg(
     if (!item) return "";
 
     const t = toT(item.value);
-    const fill = interpolateColor(t, colorStops);
+    const fill = colorOf(t);
     const nfs = nameFontSize(item.name, tile.w, tile.h);
 
     const cx = tile.x + tile.w / 2;
-    // 名前を縦中央に配置（baseline = タイル中心 + cap-height 補正）
-    const nameY = tile.y + tile.h / 2 + nfs * 0.38;
-
     const valStr = formatValue(item.value);
+    // テキストは全て白。濃い縁取り(paint-order stroke)+ ソフトシャドウで
+    // 淡色タイルでも背景に依らず読めるようにする（白/黒の切替はしない）。
+    const strokeW = Math.max(1.1, nfs * 0.18).toFixed(1);
 
-    const tc = textFill(fill);
-    const filterAttr = tc === "#ffffff" ? ` filter="url(#txt-shadow)"` : "";
+    const tspans = showValue
+      ? [
+          `      <tspan x="${cx}" y="${(tile.y + tile.h / 2 - 0.5).toFixed(1)}" font-size="${nfs}" font-weight="700">${item.name}</tspan>`,
+          `      <tspan x="${cx}" y="${(tile.y + tile.h / 2 + Math.max(6, nfs - 1.5) + 1).toFixed(1)}" font-size="${Math.max(6, nfs - 1.5).toFixed(1)}" font-weight="600">${valStr}${unit}</tspan>`,
+        ]
+      : [
+          // 名前を縦中央に配置（baseline = タイル中心 + cap-height 補正）
+          `      <tspan x="${cx}" y="${(tile.y + tile.h / 2 + nfs * 0.38).toFixed(1)}" font-size="${nfs}" font-weight="700">${item.name}</tspan>`,
+        ];
 
     return [
       `  <g aria-label="${item.name} ${valStr}${unit}">`,
       `    <title>${item.name}：${valStr}${unit}</title>`,
       `    <rect x="${tile.x}" y="${tile.y}" width="${tile.w}" height="${tile.h}" rx="3" fill="${fill}" stroke="#ffffff" stroke-width="1"/>`,
-      `    <text${filterAttr} font-family="${FONT_FAMILY}" fill="${tc}" text-anchor="middle">`,
-      `      <tspan x="${cx}" y="${nameY.toFixed(1)}" font-size="${nfs}" font-weight="700">${item.name}</tspan>`,
+      `    <text font-family="${FONT_FAMILY}" fill="#ffffff" text-anchor="middle" paint-order="stroke" stroke="#1f2937" stroke-width="${strokeW}" stroke-linejoin="round" filter="url(#txt-halo-dark)">`,
+      ...tspans,
       `    </text>`,
       `  </g>`,
     ].join("\n");
   });
 
-  // タイトル（バーチャートと同スタイル：14px bold #333 + subtitle は tspan でインライン）
-  const titleText = subtitle
-    ? `${title}<tspan font-size="10" font-weight="normal" class="svg-tick">　${subtitle}</tspan>`
-    : title;
-  const titleLine = `  <text x="${W / 2}" y="22" text-anchor="middle" font-size="14" font-weight="bold" class="svg-title">${titleText}</text>`;
+  // タイトルは左上の余白（日本のタイル配置で空く領域）に左寄せで配置。年は別行・大きめ。
+  const TITLE_X = 28;
+  const titleFont = fitTitleFont(title, 430, 22, 15);
+  const titleLine = [
+    `  <text x="${TITLE_X}" y="58" font-size="${titleFont}" font-weight="bold" class="svg-title">${title}</text>`,
+    subtitle
+      ? `  <text x="${TITLE_X}" y="${58 + titleFont + 12}" font-size="15" class="svg-tick">${subtitle}</text>`
+      : "",
+  ]
+    .filter(Boolean)
+    .join("\n");
 
   // 凡例（グラデーションバー + 最小・中間・最大ラベル）
   const loStr = formatValue(lo);
   const midStr = formatValue((lo + hi) / 2);
   const hiStr = formatValue(hi);
-  // グラデーションストップを colorStops から生成
+  // グラデーションストップ: scheme 指定時は interpolator を等間隔サンプル、無ければ colorStops。
   const toHex = (n: number) => n.toString(16).padStart(2, "0");
-  const gradientStops = colorStops
-    .map((s) => `      <stop offset="${Math.round(s.t * 100)}%"   stop-color="#${toHex(s.r)}${toHex(s.g)}${toHex(s.b)}"/>`)
-    .join("\n");
+  const gradientStops = interp
+    ? [0, 0.25, 0.5, 0.75, 1]
+        .map((t) => `      <stop offset="${t * 100}%"   stop-color="${colorOf(t)}"/>`)
+        .join("\n")
+    : colorStops
+        .map((s) => `      <stop offset="${Math.round(s.t * 100)}%"   stop-color="#${toHex(s.r)}${toHex(s.g)}${toHex(s.b)}"/>`)
+        .join("\n");
   // コンパクト凡例（沖縄右側: x=96〜236, y=625〜647）
   const legend = [
     `  <defs>`,
     `    <linearGradient id="choropleth-lg" x1="0" x2="1">`,
     gradientStops,
     `    </linearGradient>`,
-    `    <filter id="txt-shadow" x="-40%" y="-40%" width="180%" height="180%">`,
-    `      <feDropShadow dx="0" dy="0" stdDeviation="1.3" flood-color="#000000" flood-opacity="0.6"/>`,
+    `    <filter id="txt-halo-dark" x="-40%" y="-40%" width="180%" height="180%">`,
+    `      <feDropShadow dx="0" dy="0" stdDeviation="1.3" flood-color="#000000" flood-opacity="0.7"/>`,
     `    </filter>`,
     `  </defs>`,
     `  <text x="${BAR_X - 4}" y="${BAR_Y + 8}" font-size="8" class="svg-tick" text-anchor="end">${legendLabels[0]}</text>`,


### PR DESCRIPTION
## 真因
本番テーマページ（および home featured 等）が空/error fallback だったのは、`shouldSkipRemoteR2Read()` が **本番 Worker ランタイムで R2 snapshot 読みを skip** していたため。

`shouldSkipRemoteR2Read()` は `CLOUDFLARE_WORKERS==="true"` / CI / S3creds / `R2_PUBLIC_FETCH_URL` のいずれも無ければ true(skip) を返すが、`[env.production.vars]` に **`CLOUDFLARE_WORKERS` が未設定**だった（`R2_PUBLIC_URL`/`NEXT_PUBLIC_R2_PUBLIC_URL` はあるが `R2_PUBLIC_FETCH_URL` ではない）。→ `readRankingItemFromR2` 等が空を返し `loadThemeData` が null → error fallback。

セッション冒頭の R2 remote-only 移行（`shouldSkipRemoteR2Read` 導入）が、本番に `CLOUDFLARE_WORKERS=true` が無いケースを考慮していなかった regression。

## 修正
`[env.production.vars]` に `CLOUDFLARE_WORKERS = "true"` を追加。これで本番 Worker ランタイムで snapshot 読みが許可され、テーマ/home featured/ranking SSR が描画される。

（先行: force-dynamic 化 + loadThemeData の R2 統一 + e-Stat 廃止も併せて本番で有効になる）

## 検証
デプロイ後、本番 /themes/* で error fallback 解消 + ダッシュボード描画、home の「注目のランキング」復活を確認する。

🤖 Generated with [Claude Code](https://claude.com/claude-code)