### PR TITLE
feat(cwv): [auto] LCP 改修案 for /themes

### DIFF
--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -26,10 +26,21 @@
 
 import { Suspense } from "react";
 
-import NextTopLoader from "nextjs-toploader";
+import dynamic from "next/dynamic";
+
 import { Toaster } from "sonner";
 
 import "./globals.css";
+
+/**
+ * NextTopLoader はルート遷移時の進捗バー専用 (初回 LCP 時点では非表示)。
+ * 静的 import だとレイアウト共有チャンクに同梱され critical-path JS を肥大化させ、
+ * LCP 候補 (PageHeader description <p>) のペイントを遅延させる。
+ * dynamic + ssr:false で初回バンドルから切り離す (route 遷移時のみ chunk fetch)。
+ */
+const NextTopLoader = dynamic(() => import("nextjs-toploader"), {
+  ssr: false,
+});
 
 import { Footer } from "@/components/organisms/Footer/Footer";
 import Header from "@/components/organisms/Header";


### PR DESCRIPTION
## Auto-generated CWV improvement PR

**警告**: この PR は Claude (Anthropic Cloud Routine) が自動生成しました。merge 前に人手レビュー必須。

- **URL**: https://stats47.jp/themes (mobile LCP 5735ms、PSI Alert #501)
- **対象ファイル**: `apps/web/src/app/layout.tsx`
- **過去施策ヒント**: dynamic import + ssr:false で critical-path JS を削減 (T1-PSI-LCP-02 系)
- **目標**: LCP < 3.5s (mobile)

### 実測 (2026-06-21 PSI / [PSI Alert] Issue #501)

| URL | Strategy | Perf | LCP | LCP element |
|---|---|---|---|---|
| /themes | mobile | **66** 🚨 | **5735ms** 🚨 | `header.mb-6 > div.mt-1 > div.min-w-0 > p.mt-2` |
| /areas | mobile | 85 | **4375ms** 🚨 | (同上 PageHeader description) |
| /blog | mobile | 84 | **3452ms** 🚨 | (above-fold 画像) |
| /about | mobile | 89 | **3301ms** 🚨 | (同上 PageHeader description) |
| /themes/local-economy | mobile | 84 | **3301ms** 🚨 | (同上 PageHeader description) |
| /search | mobile | 88 | **3001ms** 🚨 | (同上 PageHeader description) |
| /themes/labor-wages | mobile | 87 | **2777ms** 🚨 | (同上 PageHeader description) |

LCP 違反 18 ページ中 14 ページが **同じ LCP element** (`PageHeader > p.mt-2` の description text) を指している。SSR HTML 内のプレーンテキストが 2-5s 遅延しているのは layout 共有の critical-path JS が LCP ペイントをブロックしているため。

### 改修内容

`apps/web/src/app/layout.tsx` の `NextTopLoader` (nextjs-toploader) を **`dynamic(...)` + `ssr: false`** に変換。

`NextTopLoader` は **ルート遷移時の進捗バー専用**で、初回 LCP 時点では非表示・非アクティブ。static import だと layout 共有チャンクに同梱され critical-path JS を肥大化させていた。dynamic + ssr:false で初回バンドルから切り離す (route 遷移時に chunk fetch される、機能影響なし)。

```diff
- import NextTopLoader from "nextjs-toploader";
+ import dynamic from "next/dynamic";
+ const NextTopLoader = dynamic(() => import("nextjs-toploader"), {
+   ssr: false,
+ });
```

- **scope**: layout の 1 import のみ。
- props 互換性維持 (`nextTopLoaderConfig` spread はそのまま動く)。
- 既存のテーマプロバイダー / Toaster / Header / Footer 構造は不変。

### suggest-cwv-candidates との差分

`node .claude/scripts/psi/suggest-cwv-candidates.mjs --url https://stats47.jp/themes` は以下を返した:

| File | Hint |
|---|---|
| `apps/web/src/app/themes/[themeSlug]/page.tsx` | server component 化 / cookies() 撤去 |
| `apps/web/src/app/themes/page.tsx` | server component 化 / cookies() 撤去 |
| `apps/web/src/features/theme-dashboard/components/ThemeLeafletMap.tsx` | dynamic import + tile preload |

調査の結果:
- themes 配下の page.tsx は既に server component 化済 / cookies() 不使用 → 提案ヒント該当せず
- `ThemeLeafletMap.tsx` は親 `ThemeDashboardTabbed.tsx` から既に `dynamic({ssr:false})` で import 済 + 内部 `LeafletChoroplethMap` / `TileSwitcher` も dynamic 化済 → 追加最適化余地が小さい
- 一方で LCP element は全違反ページ共通の `PageHeader > p.mt-2` → 真の bottleneck は **layout 共有チャンク**

→ layout.tsx の non-critical client 部品 (NextTopLoader) を defer する方が **18 ページ同時改善**につながると判断 (前週 PR #481 が `BannerAd` の LCP element selector を grep して候補スクリプトの提案外を選んだのと同じ判断パターン)。

### レビュー観点

- [ ] dynamic import の skeleton が適切 (NextTopLoader は initial render で非表示なので不要)
- [ ] 既存 props 互換性が維持されている (`nextTopLoaderConfig` spread が動くこと)
- [ ] PSI で LCP 改善を実測 (mobile < 3.5s)
- [ ] route 遷移時に NextTopLoader が正常に表示される (機能 regression がないこと)

### 検証コマンド (merge 後)

```bash
curl "https://www.googleapis.com/pagespeedonline/v5/runPagespeed?url=https://stats47.jp/themes&strategy=mobile&category=performance"
```

### 次フェーズ候補 (本 PR 後)

- `Toaster` (sonner) を同様に dynamic 化 (notification trigger 時のみ必要)
- `AdSenseScript` / `GoogleAnalytics` を `next/script` の `strategy="lazyOnload"` で遅延
- `A8LinkManager` を `requestIdleCallback` 後にマウント

### 関連

- 親 plan: `docs/02_実装計画/seo-todo-unify-phase-1-3.md` Sprint 5
- PSI Alert: #501
- 前週 PR: #481 (`/themes/labor-wages` BannerAd lazy-load・未 merge)

🤖 Generated by Anthropic Cloud Routine `stats47-weekly-cwv-pr`

https://claude.ai/code/session_01TExorrfPjsrV9nGFZkU5AR

---
_Generated by [Claude Code](https://claude.ai/code/session_01TExorrfPjsrV9nGFZkU5AR)_