### PR TITLE
fix(prod): ranking/areas 全件の notFound 永久固着を修正

### DIFF
--- a/.claude/rules/nextjs-ssg-preservation.md
+++ b/.claude/rules/nextjs-ssg-preservation.md
@@ -90,19 +90,67 @@ dynamic な部分を別の child layout に切り出し、影響範囲を route 
 - [ ] SSG ページ（`generateStaticParams` 持ち page）の挙動を `next build` で確認したか？
 - [ ] Cloudflare Pages デプロイ前にローカル `next build` が `○ Static` として該当ページを出しているか確認したか？
 
+## 失敗事例: R2 依存ページに generateStaticParams を付けると notFound が永久固着 (2026-06-22)
+
+**R2 snapshot を読んで描画する動的 route に `generateStaticParams` を付けてはならない。** 付けると
+そのページは `● (SSG)` として **ビルド時に prerender** されるが、`next build` 時点では R2 を読めない
+(Worker binding が無い・S3 creds も公開 URL も build env に渡らない)。R2 read が null/throw に落ちると
+ページは **notFound として prerender** され、**この OpenNext 構成では ISR 再生成が効かない**ため
+(`x-nextjs-stale-time: 4294967294` = 実質無限)、再デプロイまで「〜が見つかりません」が**永久配信**される。
+
+### 症状 (本番で確認)
+
+- `/ranking/<key>` 全件が「ランキングが見つかりません」(HTTP 200・タイトルだけ fallback)
+- `/areas/<code>` が「地域の特徴が見つかりません」、`/areas/<code>/cities/<city>` が「市区町村が見つかりません」
+- レスポンスヘッダ: `x-nextjs-prerender: 1` / `x-nextjs-cache: STALE` / `x-nextjs-stale-time: 4294967294`
+- 一方 `/` (force-dynamic)・`/category/<key>`・`/areas/<code>/<themeSlug>` (generateStaticParams 無し=`ƒ`) は正常
+  → **ランタイムの R2 binding は正常**。問題は「ビルド時に焼かれた notFound が固着」しているページに限定
+
+### 原因の連鎖
+
+1. `generateStaticParams` が静的キー列 (`KNOWN_RANKING_KEYS` / 47県 / `PHASE_1_SSG_CITIES`) を返す → 全件 `● SSG`
+2. ビルド時のページ描画で R2 read (`readRankingItemFromR2` 等) が `ok(null)` を返す
+   (`isNextProductionBuild()` ガード or 空 miniflare R2) → `notFound()` で prerender
+3. ISR が効かないため、その notFound prerender が再デプロイまで配信され続ける
+
+### 正しいパターン (R2 依存の動的 route)
+
+**`generateStaticParams` を付けず `revalidate` だけ置く** → `ƒ`(オンデマンド ISR)。ランタイムに R2 を
+読んで初回描画 → 結果を ISR キャッシュ。`category` / `areas/[areaCode]/[themeSlug]` がこの方式で正常稼働。
+
+```typescript
+// ✅ R2 を読む動的 route: generateStaticParams を付けない
+export const revalidate = 86400;   // ƒ (オンデマンド) になり、ランタイムで R2 を読む
+// ❌ export const generateStaticParams = ...   // ● SSG 化 → build 時 R2 不可 → notFound 固着
+
+// 例外: blog/[slug]・survey/[surveyKey] は generateStaticParams を持つが、ビルド時に
+// R2 を読んで GOOD な内容を prerender できる (build ガードが無い) ため `● SSG` のままで正常。
+// 「build 時に実データを読めるか」で判定する。読めないなら ƒ にする。
+```
+
+> SSG にしたい (build 時に R2 を読んで静的化) 場合は、build env に R2 read 経路を与える必要があるが、
+> 全件 (例: ranking 2575 件) を build で読むと generateStaticParams が肥大化し build が重くなる (不採用)。
+> R2 依存ページは原則 `ƒ` オンデマンド ISR を採用する。
+
 ## 検証コマンド
 
 ```bash
 # ローカルで SSG / Dynamic 区分を確認
 cd apps/web && npm run build 2>&1 | grep -E "Route|○|ƒ|Static|Dynamic" | head -50
 
-# ranking/[rankingKey] が ○ Static (SSG) のままか確認
-# ƒ Dynamic に変わっていたら本ルール違反
+# R2 依存ページ (ranking/[rankingKey]・areas/[areaCode]・areas/[areaCode]/cities/[cityCode]) は
+# ƒ (Dynamic) であること。● (SSG) になっていたら generateStaticParams 混入 → notFound 固着の再発。
+#
+# 本番でデプロイ後に notFound 固着が無いか実測:
+curl -s -A "Mozilla/5.0 (compatible; Googlebot/2.1)" https://stats47.jp/ranking/annual-sunshine-duration \
+  | grep -o '<title>[^<]*</title>'   # 「ランキングが見つかりません」なら固着
 ```
 
-`next build` 出力で `○ (Static)` が `ƒ (Dynamic)` になっていれば、cookies()/headers() の流入経路が混入している。
+`next build` で R2 依存ページが `● (Static)` になっていれば、generateStaticParams の混入 = notFound 固着の再発。
+(逆に cookies()/headers() の混入は静的コンテンツページを `ƒ` 化する別事象 — 上の cookies ルールを参照)
 
 ## 関連
 
 - 失敗 commit: `ebad87c2 fix: revert EXP-004 layout async cookies() — ranking pages 500 fix` (2026-05-10)
-- auto memory: `feedback_nextjs_ssg_cookies.md`
+- 失敗事例 (本ファイル §generateStaticParams 固着): 2026-06-22 — ranking 全件 + areas/cities が notFound 固着
+- 関連 memory: `feedback_nextjs_ssg_cookies.md` / `feedback_cloudflare_workers_env_r2_skip.md` / `feedback_home_pure_ssg_r2_empty.md`

--- a/apps/web/src/app/areas/[areaCode]/cities/[cityCode]/page.tsx
+++ b/apps/web/src/app/areas/[areaCode]/cities/[cityCode]/page.tsx
@@ -13,7 +13,6 @@ import {
   CityPageFooter,
   getCityRouteContext,
 } from "@/features/area-profile";
-import { PHASE_1_SSG_CITIES } from "@/features/area-profile/constants/stage-1-cities";
 import { readCityProfile } from "@/features/area-profile/server";
 import { listCategories } from "@/features/category/server";
 
@@ -56,9 +55,16 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
   };
 }
 
-export function generateStaticParams() {
-  return PHASE_1_SSG_CITIES;
-}
+/**
+ * オンデマンド ISR（24時間）。
+ *
+ * generateStaticParams は付けない。付けると対象市区町村が `●` SSG 化され、ビルド時に R2 から
+ * city profile を読めず notFound として prerender される。この OpenNext 構成では ISR 再生成が
+ * 効かず「市区町村が見つかりません」が永久固着する（2026-06-22 障害）。generateStaticParams なし =
+ * `ƒ`（オンデマンド）でランタイムに R2 を読んで描画する（ranking / areas と同方式）。
+ * 詳細: .claude/rules/nextjs-ssg-preservation.md
+ */
+export const revalidate = 86400;
 
 export default async function CityPage({ params }: PageProps) {
   const { areaCode, cityCode } = await params;

--- a/apps/web/src/app/areas/[areaCode]/page.tsx
+++ b/apps/web/src/app/areas/[areaCode]/page.tsx
@@ -1,7 +1,6 @@
 import Link from "next/link";
 import { notFound } from "next/navigation";
 
-import { fetchPrefectures } from "@stats47/area";
 import {
     Breadcrumb,
     BreadcrumbItem,
@@ -38,14 +37,16 @@ import { AdSenseAd, RANKING_SIDEBAR_TOP } from "@/lib/google-adsense";
 import type { Metadata } from "next";
 
 
-/** 24時間 ISR */
+/**
+ * オンデマンド ISR（24時間）。
+ *
+ * generateStaticParams は付けない。付けると 47 県が `●` SSG 化され、ビルド時に R2 から
+ * area profile を読めず notFound として prerender される。この OpenNext 構成では ISR 再生成が
+ * 効かず「地域の特徴が見つかりません」が永久固着する（2026-06-22 障害）。generateStaticParams
+ * なし = `ƒ`（オンデマンド）でランタイムに R2 を読んで描画する（ranking / areas/[themeSlug] と同方式）。
+ * 詳細: .claude/rules/nextjs-ssg-preservation.md
+ */
 export const revalidate = 86400;
-
-/** ビルド時に全47都道府県を事前生成 */
-export function generateStaticParams() {
-    const prefectures = fetchPrefectures();
-    return prefectures.map((p) => ({ areaCode: p.prefCode }));
-}
 
 interface PageProps {
     params: Promise<{ areaCode: string }>;

--- a/apps/web/src/app/ranking/[rankingKey]/page.tsx
+++ b/apps/web/src/app/ranking/[rankingKey]/page.tsx
@@ -7,7 +7,8 @@
  * ## 責務
  * 1. **データ取得**: R2 snapshot からランキング定義（`rankingItem`）と統計値（`rankingValues`）を取得する。
  * 2. **SEO**: 動的メタデータ（タイトル・description）と構造化データ（JSON-LD）を生成する。
- * 3. **SSG + ISR**: `generateStaticParams` で全 rankingKey を事前生成し、24時間 ISR で再検証する。
+ * 3. **オンデマンド ISR**: `generateStaticParams` を持たず `ƒ`（オンデマンド）で描画し、
+ *    ランタイムに R2 を読んで 24時間 ISR キャッシュする（build 時 R2 不可で notFound 固着を回避）。
  *    年度切替はクライアント側で Server Action を呼び出し、ページ遷移なしで更新する。
  *
  * ## Composition Pattern
@@ -33,15 +34,21 @@ import {
   RankingPageClientShell,
   getRankingPageMetadata,
   RankingPageHeadAssets,
-  getRankingStaticParams,
   loadRankingPageModel,
 } from "@/features/ranking/server";
 
-/** 24時間 ISR */
+/**
+ * オンデマンド ISR（24時間）。
+ *
+ * generateStaticParams は付けない。付けると全 rankingKey が `●` SSG 化され、
+ * ビルド時に R2 (`app/ranking/<key>/item.json`) を読めず（readRankingItemFromR2 が
+ * build 時は ok(null) を返す）notFound として prerender される。この OpenNext 構成では
+ * ISR 再生成が効かず「ランキングが見つかりません」が永久固着する（2026-06-22 障害）。
+ * generateStaticParams なし = `ƒ`（オンデマンド）でランタイムに R2 を読んで描画し、
+ * 初回描画結果を ISR キャッシュする（category / areas/[areaCode]/[themeSlug] と同方式）。
+ * 詳細: .claude/rules/nextjs-ssg-preservation.md
+ */
 export const revalidate = 86400;
-
-/** ビルド時に全 rankingKey を事前生成（DB利用不可時はISRに委ねる） */
-export const generateStaticParams = getRankingStaticParams;
 
 /** ページコンポーネントの Props 型 */
 interface PageProps {


### PR DESCRIPTION
## 概要

本番で **`/ranking/*` 全件・`/areas/*`・`/areas/*/cities/*` が「〜が見つかりません」を永久配信** していた障害の hotfix。

## 原因

これらは `generateStaticParams` で静的キー列（`KNOWN_RANKING_KEYS` / 47県 / `PHASE_1_SSG_CITIES`）を返すため `● SSG` として **ビルド時に prerender** される。しかし `next build` 時点では R2 を読めず（Worker binding なし・build env に S3 creds / 公開 URL なし）、ページ描画の R2 read が `ok(null)` に落ちて **notFound として prerender** される。

この OpenNext 構成では **ISR 再生成が効かない**（`x-nextjs-stale-time: 4294967294`）ため、その notFound prerender が再デプロイまで配信され続けていた。

- ランタイムの R2 binding 自体は正常（`/`・`/category/*`・`/areas/*/[themeSlug]` は稼働中）
- `/blog/*`・`/survey/*` は `● SSG` だが build 時に R2 を読んで GOOD な内容を prerender できるため正常

## 修正

3 route から `generateStaticParams` を撤去し `revalidate` のみ残す → `ƒ`（オンデマンド ISR）化。ランタイムに R2 を読んで初回描画し ISR キャッシュする。**`category` / `areas/[areaCode]/[themeSlug]` と同方式（本番稼働実績あり）**。

- `apps/web/src/app/ranking/[rankingKey]/page.tsx`
- `apps/web/src/app/areas/[areaCode]/page.tsx`
- `apps/web/src/app/areas/[areaCode]/cities/[cityCode]/page.tsx`

再発防止を `.claude/rules/nextjs-ssg-preservation.md` に記録。

## 検証

- `npx tsc --noEmit -p apps/web/tsconfig.json` → 0 errors
- ESLint（3 files）→ 0 errors
- デプロイ後に本番実測（Googlebot UA で `/ranking/annual-sunshine-duration` が 200 + 実タイトル）+ CDN purge

🤖 Generated with [Claude Code](https://claude.com/claude-code)