### PR TITLE
ci: カバレッジ閾値の単一ソース化 (PR #543 反映)

### DIFF
--- a/.github/workflows/pr-quality-check.yml
+++ b/.github/workflows/pr-quality-check.yml
@@ -161,15 +161,11 @@ jobs:
                 const functions = total.functions.pct.toFixed(2);
                 const branches = total.branches.pct.toFixed(2);
                 
-                // 閾値チェック用の絵文字とバッジ
-                const threshold = 100;
-                const getEmoji = (value) => value >= threshold ? '✅' : '⚠️';
-                const getBadge = (value) => {
-                  if (value >= 80) return '🟢';
-                  if (value >= 50) return '🟡';
-                  if (value >= threshold) return '🟠';
-                  return '🔴';
-                };
+                // 回帰防止 floor (単一ソース coverage-thresholds.json を vitest と共有)。目標値ではない。
+                const ct = JSON.parse(fs.readFileSync(path.join(process.cwd(), 'apps/web', 'coverage-thresholds.json'), 'utf8'));
+                const floor = { lines: ct.lines, statements: ct.statements, functions: ct.functions, branches: ct.branches };
+                // floor 以上=🟢 / floor-10pt 以内=🟡 / 未満=🔴
+                const getBadge = (value, f) => value >= f ? '🟢' : value >= f - 10 ? '🟡' : '🔴';
                 
                 // ファイル別のカバレッジ（上位10件、低カバレッジ優先）
                 const fileCoverage = Object.entries(summary)
@@ -184,8 +180,8 @@ jobs:
                   .sort((a, b) => a.lines - b.lines) // 低い順にソート
                   .slice(0, 10);
                 
-                const lowCoverageFiles = fileCoverage.filter(f => f.lines < threshold);
-                const highCoverageFiles = fileCoverage.filter(f => f.lines >= threshold);
+                const lowCoverageFiles = fileCoverage.filter(f => f.lines < floor.lines);
+                const highCoverageFiles = fileCoverage.filter(f => f.lines >= floor.lines);
                 
                 let fileList = '';
                 if (lowCoverageFiles.length > 0) {
@@ -207,12 +203,12 @@ jobs:
                 
                 | Metric | Coverage | Status |
                 |--------|----------|--------|
-                | Lines | ${lines}% | ${getBadge(parseFloat(lines))} ${getEmoji(parseFloat(lines))} |
-                | Statements | ${statements}% | ${getBadge(parseFloat(statements))} ${getEmoji(parseFloat(statements))} |
-                | Functions | ${functions}% | ${getBadge(parseFloat(functions))} ${getEmoji(parseFloat(functions))} |
-                | Branches | ${branches}% | ${getBadge(parseFloat(branches))} ${getEmoji(parseFloat(branches))} |
-                
-                **Target:** ${threshold}% (minimum threshold)
+                | Lines | ${lines}% | ${getBadge(parseFloat(lines), floor.lines)} |
+                | Statements | ${statements}% | ${getBadge(parseFloat(statements), floor.statements)} |
+                | Functions | ${functions}% | ${getBadge(parseFloat(functions), floor.functions)} |
+                | Branches | ${branches}% | ${getBadge(parseFloat(branches), floor.branches)} |
+
+                **Floor (回帰防止線・目標ではありません):** Lines ${floor.lines}% / Statements ${floor.statements}% / Functions ${floor.functions}% / Branches ${floor.branches}% — vitest が enforce (未達で CI 失敗)。分母はロジック層のみ (src/app 等 E2E 担当は除外)。
                 
                 📥 [Download full coverage report](${workflowUrl})${fileList}
                 
@@ -238,38 +234,9 @@ jobs:
               console.error('Failed to generate coverage comment:', error);
             }
 
-      - name: 📈 Check coverage thresholds
-        run: |
-          node -e "
-            const fs = require('fs');
-            const summary = JSON.parse(fs.readFileSync('apps/web/coverage/coverage-summary.json', 'utf8'));
-            const total = summary.total;
-            const threshold = 10;
-
-            const metrics = {
-              lines: total.lines.pct,
-              statements: total.statements.pct,
-              functions: total.functions.pct,
-              branches: total.branches.pct
-            };
-            
-            const failed = Object.entries(metrics).filter(([_, value]) => value < threshold);
-            
-            if (failed.length > 0) {
-              console.error('❌ Coverage thresholds not met:');
-              failed.forEach(([metric, value]) => {
-                console.error(\`  \${metric}: \${value.toFixed(2)}% < \${threshold}%\`);
-              });
-              process.exit(1);
-            } else {
-              console.log('✅ All coverage thresholds met!');
-              Object.entries(metrics).forEach(([metric, value]) => {
-                const status = value >= threshold ? '✅' : '⚠️';
-                console.log(\`  \${status} \${metric}: \${value.toFixed(2)}%\`);
-              });
-            }
-          "
-        continue-on-error: false # カバレッジ閾値100%を必須とする
+      # 注: カバレッジ閾値の enforce は上の「Run Unit Tests with Coverage」step に一本化。
+      # vitest.config.ts が coverage-thresholds.json (単一ソース) を読み floor 未達で exit 1 する。
+      # 旧「Check coverage thresholds」step (閾値リテラル 10 を再ハードコード) は重複のため削除。
 
       - name: 🏗️ Build Check
         run: npm run build -w apps/web

--- a/apps/web/coverage-thresholds.json
+++ b/apps/web/coverage-thresholds.json
@@ -1,0 +1,7 @@
+{
+  "_comment": "カバレッジの回帰防止 floor (目標値ではない)。閾値の単一ソース。vitest.config.ts と pr-quality-check.yml のコメント step が本ファイルを読む。分母はロジック層のみ (src/app 等 E2E 担当は vitest.config の coverage.exclude で除外)。実測 (2026-07-06: lines/stmts 26.9 / branch 51.7 / funcs 27.0) から約5pt 切り下げ。カバレッジが十分上がったら手動で bump する (README 参照)。",
+  "lines": 22,
+  "statements": 22,
+  "functions": 22,
+  "branches": 46
+}

--- a/apps/web/tests/README.md
+++ b/apps/web/tests/README.md
@@ -16,6 +16,14 @@ npm run test:coverage # カバレッジ付き実行
 - テストファイル: `src/**/*.test.ts(x)`, `src/**/__tests__/**`
 - CI: `.github/workflows/pr-quality-check.yml`
 
+### カバレッジ方針（回帰防止 floor・単一ソース）
+
+カバレッジは「目標 100%」ではなく **「下げない floor（回帰防止線）」** で運用します。
+
+- **単一ソース**: `apps/web/coverage-thresholds.json`（lines/statements/functions/branches）。`vitest.config.ts` がこれを読んで enforce（未達で `test:coverage` が exit 1）し、CI のカバレッジコメントも同ファイルを表示する。**閾値を他の場所にハードコードしない**（過去に CI と vitest で 100/10 に分裂した反省）。
+- **分母はロジック層のみ**: `src/app/**`（page/layout/route/OGP/sitemap）・`src/middleware.ts`・`src/providers`・`src/store` は SSG/ISR/R2 依存の結線コードで **E2E 担当**のため `coverage.exclude` で除外。unit の分母に入れない。
+- **floor の bump**: floor は自動追随しない。カバレッジが十分上がったら、四半期または大型 PR の節目に `coverage-thresholds.json` を手動で引き上げる（放置すると形骸化する）。緑=十分ではなく「floor を割っていない」だけ。
+
 ## 2. E2E テスト（Playwright）
 
 Next.js 開発サーバーを起動し、実際のブラウザでページ遷移・操作・表示を検証します。

--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -1,7 +1,14 @@
+import { readFileSync } from "fs";
 import path from "path";
 
 import react from "@vitejs/plugin-react";
 import { coverageConfigDefaults, defineConfig } from "vitest/config";
+
+// カバレッジ閾値 (回帰防止 floor) の単一ソース。pr-quality-check.yml のコメント step も
+// 同ファイルを読むため、ここと CI で値がドリフトしない。
+const coverageThresholds = JSON.parse(
+  readFileSync(path.resolve(__dirname, "./coverage-thresholds.json"), "utf8"),
+) as { lines: number; statements: number; functions: number; branches: number };
 
 export default defineConfig({
   plugins: [react()],
@@ -52,13 +59,20 @@ export default defineConfig({
         "**/scripts/**",
         "**/.local/**",
         "**/public/**",
+        // App Router の結線コード (page/layout/route/OGP/sitemap) は SSG/ISR/R2 依存で
+        // unit テスト非対象。ページ遷移・API・SEO は E2E (Playwright) 担当 (tests/README.md)。
+        "src/app/**",
+        "src/middleware.ts",
+        "src/providers/**",
+        "src/store/**",
       ],
       include: ["src/**/*.{ts,tsx}"],
+      // 閾値は coverage-thresholds.json が単一ソース (回帰防止 floor)。未達で vitest が exit 1。
       thresholds: {
-        lines: 10,
-        functions: 10,
-        branches: 10,
-        statements: 10,
+        lines: coverageThresholds.lines,
+        statements: coverageThresholds.statements,
+        functions: coverageThresholds.functions,
+        branches: coverageThresholds.branches,
       },
     },
   },


### PR DESCRIPTION
## 概要

PR #543（カバレッジ閾値の単一ソース化）を main へ反映する。

- `apps/web/coverage-thresholds.json` を新設し、vitest.config.ts と CI コメント step が本ファイルを単一ソースとして読む
- 回帰防止 floor（lines/statements/functions=22・branches=46）を vitest が enforce（現カバレッジ約27%に対し保守的な floor で失敗しない）
- 分母をロジック層に限定（src/app 等 E2E 担当は coverage.exclude で除外）

app のランタイムコードは不変（テスト設定・CI のみ）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)