### PR TITLE
feat(youtube): 1ヶ月分の予約仕込みキュー + 日次消化 cron (量産実験)

### DIFF
--- a/.claude/scripts/gallery/server.mjs
+++ b/.claude/scripts/gallery/server.mjs
@@ -281,7 +281,7 @@ function buildInventory() {
         domain: e.domain,
         content_key: e.content_key,
         post_type: e.type,
-        scheduled_at: `${e.date} ${e.time || "09:00"}`,
+        scheduled_at: `${e.date} ${e.time || "08:00"}`,
         _source: `ig-schedule (${e._file})`,
         status: "scheduled-json-only",
       });
@@ -405,7 +405,7 @@ async function probeR2(domain, contentKey) {
 }
 
 // ─── IG 予約登録 (schedule JSON + posts.json 同時) ─────────────
-function scheduleIg({ date, time = "09:00", type, domain, content_key, caption }) {
+function scheduleIg({ date, time = "08:00", type, domain, content_key, caption }) {
   if (!date || !type || !domain || !content_key) throw new Error("date/type/domain/content_key は必須");
   if (!/^\d{4}-\d{2}-\d{2}$/.test(date)) throw new Error("date は YYYY-MM-DD");
   if (date < jstDateStr()) throw new Error("過去日は指定不可");

--- a/.claude/scripts/instagram/post-from-schedule.cjs
+++ b/.claude/scripts/instagram/post-from-schedule.cjs
@@ -110,7 +110,7 @@ function loadPostedSet() {
 }
 
 /**
- * 当日エントリのうち「time (JST, 既定 "09:00") が現在時刻以前」かつ「未投稿
+ * 当日エントリのうち「time (JST, 既定 "08:00") が現在時刻以前」かつ「未投稿
  * (ig-posted-log に無い)」の最早 1 件を返す。
  * 1 日複数本対応: cron を 1 日複数回発火させ、各実行が 1 件だけ消化する。
  * 既投稿分は workflow が commit する ig-posted-log で除外されるため二重投稿しない。
@@ -125,7 +125,7 @@ async function findTodayEntry() {
   const posted = loadPostedSet();
   const due = JSON.parse(fs.readFileSync(file, "utf-8"))
     .filter((e) => e.date === today)
-    .map((e) => ({ ...e, time: e.time || "09:00" }))
+    .map((e) => ({ ...e, time: e.time || "08:00" })) // time 無しの旧形式は朝枠 (08:03 cron) で配信
     .sort((a, b) => a.time.localeCompare(b.time))
     .filter((e) => !posted.has(`${e.date}|${e.content_key}`));
   if (!due.length) return null;

--- a/.claude/skills/sns/generate-instagram-schedule/SKILL.md
+++ b/.claude/skills/sns/generate-instagram-schedule/SKILL.md
@@ -50,18 +50,16 @@ node .claude/scripts/instagram/generate-schedule.cjs \
 
 ## 生成後の手順
 
-1. 出力された schedule JSON を確認し、`post-from-schedule.cjs` のデフォルトパスを更新:
-   - `.claude/scripts/instagram/post-from-schedule.cjs` の `IG_SCHEDULE_FILE` デフォルト値
-   - `.github/workflows/post-instagram-scheduled.yml` のコメント
+1. 出力された schedule JSON を確認する。**スクリプト側の編集は不要**
+   (2026-07-07〜 `post-from-schedule.cjs` が当日エントリを含む週ファイルを自動選択する。
+   エントリに `time` "HH:MM" JST を持たせると 08:03/12:03/19:03 の該当 cron 枠で配信、
+   未指定は 08:00 扱い。同一日に複数エントリ可 — 各 cron 実行が未投稿の最早 1 件を消化)。
 
-2. 変更を commit → main merge:
+2. schedule JSON を commit → **main へ反映** (cron は main checkout で動くため):
    ```bash
-   git checkout -b feature/instagram-wXX-schedule
-   git add .claude/state/instagram-wXX-schedule.json \
-            .claude/scripts/instagram/post-from-schedule.cjs \
-            .github/workflows/post-instagram-scheduled.yml
+   git add .claude/state/instagram-wXX-schedule.json
    git commit -m "feat(instagram): WXX スケジュール追加"
-   gh pr create --base develop ...
+   # develop 経由で develop→main PR (通常デプロイフローに同乗)
    ```
 
 3. 不足アセットがある場合:

--- a/.claude/skills/sns/sns-weekly-plan/SKILL.md
+++ b/.claude/skills/sns/sns-weekly-plan/SKILL.md
@@ -45,8 +45,9 @@ W19-W25 で 6 週連続投稿ゼロになった (計画外タスク優先で SNS
 /generate-instagram-schedule    # 今週枠のスケジュール生成 (重複防止内蔵)
 # 角度量産が要れば /post-ig-6angles、静止画/リール素材は /render-sns-stills
 ```
-生成した schedule は GHA `post-instagram-scheduled.yml` が毎日 09:03 に自動投稿する
-(state: `.claude/state/instagram-*-schedule.json`)。
+生成した schedule は GHA `post-instagram-scheduled.yml` (cron 08:03/12:03/19:03 JST の 3 回) が
+自動投稿する。各実行はエントリの `time` (JST、未指定は 08:00 扱い) が現在時刻以前で未投稿の最早 1 件
+だけを投稿する (state: `.claude/state/instagram-*-schedule.json`、二重投稿は ig-posted-log で防止)。
 
 ### Step 4: X — 定型ストック量産 (週 14-21 本) + 引用RT
 

--- a/.claude/state/youtube-upload-queue.json
+++ b/.claude/state/youtube-upload-queue.json
@@ -1,0 +1,422 @@
+[
+  {
+    "key": "japanese-population",
+    "video_url": "https://api.github.com/repos/uruhayato373/stats47/releases/assets/473480927",
+    "title": "日本人人口、東京一極はいつ加速した？｜47都道府県の推移 1980→2024",
+    "description": "47都道府県の日本人人口45年分をバーチャートレースで可視化。東京一極集中の進み方が一目でわかります。\n\n▼ 最新年の全47都道府県ランキングはこちら\nhttps://stats47.jp/ranking/japanese-population?utm_source=youtube&utm_medium=social&utm_campaign=japanese-population&utm_content=bcr\n\n出典: 政府統計 (e-Stat ほか) を stats47.jp が加工・可視化\n#都道府県 #ランキング #統計 #人口",
+    "tags": "都道府県,ランキング,統計,推移,バーチャートレース,人口",
+    "privacy": "private",
+    "publish_at": "2026-07-12T19:00:00+09:00",
+    "content_key": "bcr-japanese-population-1980-2024",
+    "metric_keys": [
+      "japanese-population"
+    ],
+    "status": "pending"
+  },
+  {
+    "key": "japanese-movers-in",
+    "video_url": "https://api.github.com/repos/uruhayato373/stats47/releases/assets/473480923",
+    "title": "転入者数は全国で4割減った｜47都道府県ランキングの推移 1977→2024",
+    "description": "都道府県別の転入者数48年分の推移。人の移動が細る中でも首都圏の吸引力は健在です。\n\n▼ 最新年の全47都道府県ランキングはこちら\nhttps://stats47.jp/ranking/japanese-movers-in?utm_source=youtube&utm_medium=social&utm_campaign=japanese-movers-in&utm_content=bcr\n\n出典: 政府統計 (e-Stat ほか) を stats47.jp が加工・可視化\n#都道府県 #ランキング #統計 #転入",
+    "tags": "都道府県,ランキング,統計,推移,バーチャートレース,転入,人口移動",
+    "privacy": "private",
+    "publish_at": "2026-07-13T19:00:00+09:00",
+    "content_key": "bcr-japanese-movers-in-1977-2024",
+    "metric_keys": [
+      "japanese-movers-in"
+    ],
+    "status": "pending"
+  },
+  {
+    "key": "japanese-movers-out",
+    "video_url": "https://api.github.com/repos/uruhayato373/stats47/releases/assets/473480926",
+    "title": "転出者数が最も多い県はどこ？｜47都道府県の推移 1975→2024",
+    "description": "都道府県別の転出者数50年分の推移。地方から都市への流れの変遷を追えます。\n\n▼ 最新年の全47都道府県ランキングはこちら\nhttps://stats47.jp/ranking/japanese-movers-out?utm_source=youtube&utm_medium=social&utm_campaign=japanese-movers-out&utm_content=bcr\n\n出典: 政府統計 (e-Stat ほか) を stats47.jp が加工・可視化\n#都道府県 #ランキング #統計 #転出",
+    "tags": "都道府県,ランキング,統計,推移,バーチャートレース,転出,人口移動",
+    "privacy": "private",
+    "publish_at": "2026-07-14T19:00:00+09:00",
+    "content_key": "bcr-japanese-movers-out-1975-2024",
+    "metric_keys": [
+      "japanese-movers-out"
+    ],
+    "status": "pending"
+  },
+  {
+    "key": "marriages",
+    "video_url": "https://api.github.com/repos/uruhayato373/stats47/releases/assets/473480932",
+    "title": "婚姻件数はこの49年で半減した｜47都道府県ランキングの推移 1975→2023",
+    "description": "都道府県別の婚姻件数49年分の推移。全国で半減という大きな変化を可視化しました。\n\n▼ 最新年の全47都道府県ランキングはこちら\nhttps://stats47.jp/ranking/marriages?utm_source=youtube&utm_medium=social&utm_campaign=marriages&utm_content=bcr\n\n出典: 政府統計 (e-Stat ほか) を stats47.jp が加工・可視化\n#都道府県 #ランキング #統計 #婚姻",
+    "tags": "都道府県,ランキング,統計,推移,バーチャートレース,婚姻,結婚",
+    "privacy": "private",
+    "publish_at": "2026-07-15T19:00:00+09:00",
+    "content_key": "bcr-marriages-1975-2023",
+    "metric_keys": [
+      "marriages"
+    ],
+    "status": "pending"
+  },
+  {
+    "key": "divorces",
+    "video_url": "https://api.github.com/repos/uruhayato373/stats47/releases/assets/473480907",
+    "title": "離婚件数は1.5倍に増えた｜47都道府県ランキングの推移 1975→2023",
+    "description": "都道府県別の離婚件数49年分の推移。増加のピークと近年の落ち着きまで見えます。\n\n▼ 最新年の全47都道府県ランキングはこちら\nhttps://stats47.jp/ranking/divorces?utm_source=youtube&utm_medium=social&utm_campaign=divorces&utm_content=bcr\n\n出典: 政府統計 (e-Stat ほか) を stats47.jp が加工・可視化\n#都道府県 #ランキング #統計 #離婚",
+    "tags": "都道府県,ランキング,統計,推移,バーチャートレース,離婚",
+    "privacy": "private",
+    "publish_at": "2026-07-16T19:00:00+09:00",
+    "content_key": "bcr-divorces-1975-2023",
+    "metric_keys": [
+      "divorces"
+    ],
+    "status": "pending"
+  },
+  {
+    "key": "flush-toilet-population-ratio",
+    "video_url": "https://api.github.com/repos/uruhayato373/stats47/releases/assets/473480911",
+    "title": "水洗トイレはこうして全国に広がった｜水洗化率の推移 1975→2021",
+    "description": "水洗化人口比率37年分の推移。生活インフラが全国に行き渡る過程をランキングで辿ります。\n\n▼ 最新年の全47都道府県ランキングはこちら\nhttps://stats47.jp/ranking/flush-toilet-population-ratio?utm_source=youtube&utm_medium=social&utm_campaign=flush-toilet-population-ratio&utm_content=bcr\n\n出典: 政府統計 (e-Stat ほか) を stats47.jp が加工・可視化\n#都道府県 #ランキング #統計 #水洗化",
+    "tags": "都道府県,ランキング,統計,推移,バーチャートレース,水洗化,生活インフラ",
+    "privacy": "private",
+    "publish_at": "2026-07-17T19:00:00+09:00",
+    "content_key": "bcr-flush-toilet-population-ratio-1975-2021",
+    "metric_keys": [
+      "flush-toilet-population-ratio"
+    ],
+    "status": "pending"
+  },
+  {
+    "key": "registered-foreigner-population",
+    "video_url": "https://api.github.com/repos/uruhayato373/stats47/releases/assets/473480956",
+    "title": "外国人登録人口は2.4倍に増えた｜47都道府県の推移 1986→2011",
+    "description": "外国人登録人口の推移(1986-2011)。バブル期から震災前夜までの国際化の歩みです。\n\n▼ 最新年の全47都道府県ランキングはこちら\nhttps://stats47.jp/ranking/registered-foreigner-population?utm_source=youtube&utm_medium=social&utm_campaign=registered-foreigner-population&utm_content=bcr\n\n出典: 政府統計 (e-Stat ほか) を stats47.jp が加工・可視化\n#都道府県 #ランキング #統計 #外国人",
+    "tags": "都道府県,ランキング,統計,推移,バーチャートレース,外国人,国際化",
+    "privacy": "private",
+    "publish_at": "2026-07-18T19:00:00+09:00",
+    "content_key": "bcr-registered-foreigner-population-1986-2011",
+    "metric_keys": [
+      "registered-foreigner-population"
+    ],
+    "status": "pending"
+  },
+  {
+    "key": "traffic-accident-count",
+    "video_url": "https://api.github.com/repos/uruhayato373/stats47/releases/assets/473480962",
+    "title": "交通事故はこの50年で4割減った｜47都道府県ランキングの推移 1975→2024",
+    "description": "都道府県別の交通事故発生件数50年分。ピーク時からの減少がどの県でも進んでいます。\n\n▼ 最新年の全47都道府県ランキングはこちら\nhttps://stats47.jp/ranking/traffic-accident-count?utm_source=youtube&utm_medium=social&utm_campaign=traffic-accident-count&utm_content=bcr\n\n出典: 政府統計 (e-Stat ほか) を stats47.jp が加工・可視化\n#都道府県 #ランキング #統計 #交通事故",
+    "tags": "都道府県,ランキング,統計,推移,バーチャートレース,交通事故,交通安全",
+    "privacy": "private",
+    "publish_at": "2026-07-19T19:00:00+09:00",
+    "content_key": "bcr-traffic-accident-count-1975-2024",
+    "metric_keys": [
+      "traffic-accident-count"
+    ],
+    "status": "pending"
+  },
+  {
+    "key": "building-fire-count",
+    "video_url": "https://api.github.com/repos/uruhayato373/stats47/releases/assets/473480892",
+    "title": "建物火災は半分近くまで減った｜47都道府県ランキングの推移 1975→2023",
+    "description": "都道府県別の建物火災出火件数49年分の推移。防火対策の進歩が数字に表れています。\n\n▼ 最新年の全47都道府県ランキングはこちら\nhttps://stats47.jp/ranking/building-fire-count?utm_source=youtube&utm_medium=social&utm_campaign=building-fire-count&utm_content=bcr\n\n出典: 政府統計 (e-Stat ほか) を stats47.jp が加工・可視化\n#都道府県 #ランキング #統計 #火災",
+    "tags": "都道府県,ランキング,統計,推移,バーチャートレース,火災,防災",
+    "privacy": "private",
+    "publish_at": "2026-07-20T19:00:00+09:00",
+    "content_key": "bcr-building-fire-count-1975-2023",
+    "metric_keys": [
+      "building-fire-count"
+    ],
+    "status": "pending"
+  },
+  {
+    "key": "residential-telephone-subscription-count-per-1000",
+    "video_url": "https://api.github.com/repos/uruhayato373/stats47/releases/assets/473480957",
+    "title": "固定電話の栄枯盛衰｜住宅用電話加入数の推移 1975→2024",
+    "description": "人口千人あたり住宅用電話加入数の推移。普及から携帯への置き換わりまで、一つの時代の記録です。\n\n▼ 最新年の全47都道府県ランキングはこちら\nhttps://stats47.jp/ranking/residential-telephone-subscription-count-per-1000?utm_source=youtube&utm_medium=social&utm_campaign=residential-telephone-subscription-count-per-1000&utm_content=bcr\n\n出典: 政府統計 (e-Stat ほか) を stats47.jp が加工・可視化\n#都道府県 #ランキング #統計 #固定電話",
+    "tags": "都道府県,ランキング,統計,推移,バーチャートレース,固定電話,通信",
+    "privacy": "private",
+    "publish_at": "2026-07-21T19:00:00+09:00",
+    "content_key": "bcr-residential-telephone-subscription-count-per-1000-1975-2024",
+    "metric_keys": [
+      "residential-telephone-subscription-count-per-1000"
+    ],
+    "status": "pending"
+  },
+  {
+    "key": "university-count",
+    "video_url": "https://api.github.com/repos/uruhayato373/stats47/releases/assets/473480965",
+    "title": "大学の数はこの50年で倍増した｜47都道府県ランキングの推移 1975→2024",
+    "description": "都道府県別の大学数50年分の推移。大学が増え続けた50年を可視化しました。\n\n▼ 最新年の全47都道府県ランキングはこちら\nhttps://stats47.jp/ranking/university-count?utm_source=youtube&utm_medium=social&utm_campaign=university-count&utm_content=bcr\n\n出典: 政府統計 (e-Stat ほか) を stats47.jp が加工・可視化\n#都道府県 #ランキング #統計 #大学",
+    "tags": "都道府県,ランキング,統計,推移,バーチャートレース,大学,教育",
+    "privacy": "private",
+    "publish_at": "2026-07-22T19:00:00+09:00",
+    "content_key": "bcr-university-count-1975-2024",
+    "metric_keys": [
+      "university-count"
+    ],
+    "status": "pending"
+  },
+  {
+    "key": "junior-college-count",
+    "video_url": "https://api.github.com/repos/uruhayato373/stats47/releases/assets/473480929",
+    "title": "短大は4割が消えた｜短期大学数の推移 1975→2024",
+    "description": "都道府県別の短期大学数50年分の推移。ピーク時から4割減という構造変化が見えます。\n\n▼ 最新年の全47都道府県ランキングはこちら\nhttps://stats47.jp/ranking/junior-college-count?utm_source=youtube&utm_medium=social&utm_campaign=junior-college-count&utm_content=bcr\n\n出典: 政府統計 (e-Stat ほか) を stats47.jp が加工・可視化\n#都道府県 #ランキング #統計 #短大",
+    "tags": "都道府県,ランキング,統計,推移,バーチャートレース,短大,教育",
+    "privacy": "private",
+    "publish_at": "2026-07-23T19:00:00+09:00",
+    "content_key": "bcr-junior-college-count-1975-2024",
+    "metric_keys": [
+      "junior-college-count"
+    ],
+    "status": "pending"
+  },
+  {
+    "key": "new-graduate-starting-salary-university-male",
+    "video_url": "https://api.github.com/repos/uruhayato373/stats47/releases/assets/473480938",
+    "title": "大卒初任給はどれだけ上がった？｜47都道府県の推移 1981→2019",
+    "description": "都道府県別の大卒初任給(男性)の推移。昭和から平成にかけての伸びと地域差を追えます。\n\n▼ 最新年の全47都道府県ランキングはこちら\nhttps://stats47.jp/ranking/new-graduate-starting-salary-university-male?utm_source=youtube&utm_medium=social&utm_campaign=new-graduate-starting-salary-university-male&utm_content=bcr\n\n出典: 政府統計 (e-Stat ほか) を stats47.jp が加工・可視化\n#都道府県 #ランキング #統計 #初任給",
+    "tags": "都道府県,ランキング,統計,推移,バーチャートレース,初任給,給与",
+    "privacy": "private",
+    "publish_at": "2026-07-24T19:00:00+09:00",
+    "content_key": "bcr-new-graduate-starting-salary-university-male-1981-2019",
+    "metric_keys": [
+      "new-graduate-starting-salary-university-male"
+    ],
+    "status": "pending"
+  },
+  {
+    "key": "new-graduate-starting-salary-highschool-male",
+    "video_url": "https://api.github.com/repos/uruhayato373/stats47/releases/assets/473480934",
+    "title": "高卒初任給、昭和から平成の40年｜47都道府県の推移 1980→2019",
+    "description": "都道府県別の高卒初任給(男性)40年分の推移。85%増の中身を県別に見られます。\n\n▼ 最新年の全47都道府県ランキングはこちら\nhttps://stats47.jp/ranking/new-graduate-starting-salary-highschool-male?utm_source=youtube&utm_medium=social&utm_campaign=new-graduate-starting-salary-highschool-male&utm_content=bcr\n\n出典: 政府統計 (e-Stat ほか) を stats47.jp が加工・可視化\n#都道府県 #ランキング #統計 #初任給",
+    "tags": "都道府県,ランキング,統計,推移,バーチャートレース,初任給,給与",
+    "privacy": "private",
+    "publish_at": "2026-07-25T19:00:00+09:00",
+    "content_key": "bcr-new-graduate-starting-salary-highschool-male-1980-2019",
+    "metric_keys": [
+      "new-graduate-starting-salary-highschool-male"
+    ],
+    "status": "pending"
+  },
+  {
+    "key": "physicians-in-medical-facilities",
+    "video_url": "https://api.github.com/repos/uruhayato373/stats47/releases/assets/473480955",
+    "title": "医師数は2.6倍に増えた｜47都道府県ランキングの推移 1975→2022",
+    "description": "都道府県別の医療施設従事医師数の推移。医療体制の拡充と地域差の変遷です。\n\n▼ 最新年の全47都道府県ランキングはこちら\nhttps://stats47.jp/ranking/physicians-in-medical-facilities?utm_source=youtube&utm_medium=social&utm_campaign=physicians-in-medical-facilities&utm_content=bcr\n\n出典: 政府統計 (e-Stat ほか) を stats47.jp が加工・可視化\n#都道府県 #ランキング #統計 #医師",
+    "tags": "都道府県,ランキング,統計,推移,バーチャートレース,医師,医療",
+    "privacy": "private",
+    "publish_at": "2026-07-26T19:00:00+09:00",
+    "content_key": "bcr-physicians-in-medical-facilities-1975-2022",
+    "metric_keys": [
+      "physicians-in-medical-facilities"
+    ],
+    "status": "pending"
+  },
+  {
+    "key": "general-hospital-bed-count",
+    "video_url": "https://api.github.com/repos/uruhayato373/stats47/releases/assets/473480914",
+    "title": "一般病院のベッド数はどう変わった？｜47都道府県の推移 1975→2023",
+    "description": "都道府県別の一般病院病床数49年分の推移。増加から適正化への転換が見えます。\n\n▼ 最新年の全47都道府県ランキングはこちら\nhttps://stats47.jp/ranking/general-hospital-bed-count?utm_source=youtube&utm_medium=social&utm_campaign=general-hospital-bed-count&utm_content=bcr\n\n出典: 政府統計 (e-Stat ほか) を stats47.jp が加工・可視化\n#都道府県 #ランキング #統計 #病床",
+    "tags": "都道府県,ランキング,統計,推移,バーチャートレース,病床,医療",
+    "privacy": "private",
+    "publish_at": "2026-07-27T19:00:00+09:00",
+    "content_key": "bcr-general-hospital-bed-count-1975-2023",
+    "metric_keys": [
+      "general-hospital-bed-count"
+    ],
+    "status": "pending"
+  },
+  {
+    "key": "pharmacy-count-per-100k",
+    "video_url": "https://api.github.com/repos/uruhayato373/stats47/releases/assets/473480953",
+    "title": "薬局は人口比で倍増した｜47都道府県ランキングの推移 1981→2023",
+    "description": "人口10万人あたり薬局数の推移。医薬分業の進展で薬局が身近になった42年です。\n\n▼ 最新年の全47都道府県ランキングはこちら\nhttps://stats47.jp/ranking/pharmacy-count-per-100k?utm_source=youtube&utm_medium=social&utm_campaign=pharmacy-count-per-100k&utm_content=bcr\n\n出典: 政府統計 (e-Stat ほか) を stats47.jp が加工・可視化\n#都道府県 #ランキング #統計 #薬局",
+    "tags": "都道府県,ランキング,統計,推移,バーチャートレース,薬局,医療",
+    "privacy": "private",
+    "publish_at": "2026-07-28T19:00:00+09:00",
+    "content_key": "bcr-pharmacy-count-per-100k-1981-2023",
+    "metric_keys": [
+      "pharmacy-count-per-100k"
+    ],
+    "status": "pending"
+  },
+  {
+    "key": "floor-area-new-owner-dwelling",
+    "video_url": "https://api.github.com/repos/uruhayato373/stats47/releases/assets/473480909",
+    "title": "新築持ち家は1割狭くなった｜床面積の推移 1981→2024",
+    "description": "着工新設持ち家住宅の床面積の推移。家の広さの地域差と縮小トレンドを可視化しました。\n\n▼ 最新年の全47都道府県ランキングはこちら\nhttps://stats47.jp/ranking/floor-area-new-owner-dwelling?utm_source=youtube&utm_medium=social&utm_campaign=floor-area-new-owner-dwelling&utm_content=bcr\n\n出典: 政府統計 (e-Stat ほか) を stats47.jp が加工・可視化\n#都道府県 #ランキング #統計 #住宅",
+    "tags": "都道府県,ランキング,統計,推移,バーチャートレース,住宅,持ち家",
+    "privacy": "private",
+    "publish_at": "2026-07-29T19:00:00+09:00",
+    "content_key": "bcr-floor-area-new-owner-dwelling-1981-2024",
+    "metric_keys": [
+      "floor-area-new-owner-dwelling"
+    ],
+    "status": "pending"
+  },
+  {
+    "key": "new-owner-occupied-housing-ratio",
+    "video_url": "https://api.github.com/repos/uruhayato373/stats47/releases/assets/473480941",
+    "title": "持ち家離れは本当か？｜着工新設持ち家比率の推移 1977→2024",
+    "description": "着工新設に占める持ち家比率48年分の推移。持ち家志向の変化を県別に追えます。\n\n▼ 最新年の全47都道府県ランキングはこちら\nhttps://stats47.jp/ranking/new-owner-occupied-housing-ratio?utm_source=youtube&utm_medium=social&utm_campaign=new-owner-occupied-housing-ratio&utm_content=bcr\n\n出典: 政府統計 (e-Stat ほか) を stats47.jp が加工・可視化\n#都道府県 #ランキング #統計 #住宅",
+    "tags": "都道府県,ランキング,統計,推移,バーチャートレース,住宅,持ち家",
+    "privacy": "private",
+    "publish_at": "2026-07-30T19:00:00+09:00",
+    "content_key": "bcr-new-owner-occupied-housing-ratio-1977-2024",
+    "metric_keys": [
+      "new-owner-occupied-housing-ratio"
+    ],
+    "status": "pending"
+  },
+  {
+    "key": "per-taxpayer-taxable-income",
+    "video_url": "https://api.github.com/repos/uruhayato373/stats47/releases/assets/473480942",
+    "title": "課税対象所得、東京の独走はいつから？｜47都道府県の推移 1985→2024",
+    "description": "納税者1人あたり課税対象所得40年分の推移。バブル・失われた30年・近年の回復まで。\n\n▼ 最新年の全47都道府県ランキングはこちら\nhttps://stats47.jp/ranking/per-taxpayer-taxable-income?utm_source=youtube&utm_medium=social&utm_campaign=per-taxpayer-taxable-income&utm_content=bcr\n\n出典: 政府統計 (e-Stat ほか) を stats47.jp が加工・可視化\n#都道府県 #ランキング #統計 #所得",
+    "tags": "都道府県,ランキング,統計,推移,バーチャートレース,所得,年収",
+    "privacy": "private",
+    "publish_at": "2026-07-31T19:00:00+09:00",
+    "content_key": "bcr-per-taxpayer-taxable-income-1985-2024",
+    "metric_keys": [
+      "per-taxpayer-taxable-income"
+    ],
+    "status": "pending"
+  },
+  {
+    "key": "household-head-income-worker-households-per-month",
+    "video_url": "https://api.github.com/repos/uruhayato373/stats47/releases/assets/473480915",
+    "title": "世帯主の月収は2.2倍になった｜47都道府県の推移 1975→2024",
+    "description": "勤労者世帯の世帯主収入(月額)の推移。50年でどの県がどれだけ伸びたかが見えます。\n\n▼ 最新年の全47都道府県ランキングはこちら\nhttps://stats47.jp/ranking/household-head-income-worker-households-per-month?utm_source=youtube&utm_medium=social&utm_campaign=household-head-income-worker-households-per-month&utm_content=bcr\n\n出典: 政府統計 (e-Stat ほか) を stats47.jp が加工・可視化\n#都道府県 #ランキング #統計 #収入",
+    "tags": "都道府県,ランキング,統計,推移,バーチャートレース,収入,家計",
+    "privacy": "private",
+    "publish_at": "2026-08-01T19:00:00+09:00",
+    "content_key": "bcr-household-head-income-worker-households-per-month-1975-2024",
+    "metric_keys": [
+      "household-head-income-worker-households-per-month"
+    ],
+    "status": "pending"
+  },
+  {
+    "key": "lowest-temperature",
+    "video_url": "https://api.github.com/repos/uruhayato373/stats47/releases/assets/473480930",
+    "title": "最も冷え込む県はどこ？｜最低気温ランキングの推移 1984→2024",
+    "description": "都道府県別の最低気温の推移。年ごとの寒波と温暖化のせめぎ合いをランキングで。\n\n▼ 最新年の全47都道府県ランキングはこちら\nhttps://stats47.jp/ranking/lowest-temperature?utm_source=youtube&utm_medium=social&utm_campaign=lowest-temperature&utm_content=bcr\n\n出典: 政府統計 (e-Stat ほか) を stats47.jp が加工・可視化\n#都道府県 #ランキング #統計 #気温",
+    "tags": "都道府県,ランキング,統計,推移,バーチャートレース,気温,気象",
+    "privacy": "private",
+    "publish_at": "2026-08-02T19:00:00+09:00",
+    "content_key": "bcr-lowest-temperature-1984-2024",
+    "metric_keys": [
+      "lowest-temperature"
+    ],
+    "status": "pending"
+  },
+  {
+    "key": "coffee-consumption-quantity",
+    "video_url": "https://api.github.com/repos/uruhayato373/stats47/releases/assets/473480891",
+    "title": "コーヒー消費量1位は意外なあの県｜47都道府県の推移 2007→2024",
+    "description": "都道府県別のコーヒー消費量18年分の推移。1位の顔ぶれに驚くはず…ではなく実データでご確認を。\n\n▼ 最新年の全47都道府県ランキングはこちら\nhttps://stats47.jp/ranking/coffee-consumption-quantity?utm_source=youtube&utm_medium=social&utm_campaign=coffee-consumption-quantity&utm_content=bcr\n\n出典: 政府統計 (e-Stat ほか) を stats47.jp が加工・可視化\n#都道府県 #ランキング #統計 #コーヒー",
+    "tags": "都道府県,ランキング,統計,推移,バーチャートレース,コーヒー,家計調査",
+    "privacy": "private",
+    "publish_at": "2026-08-03T19:00:00+09:00",
+    "content_key": "bcr-coffee-consumption-quantity-2007-2024",
+    "metric_keys": [
+      "coffee-consumption-quantity"
+    ],
+    "status": "pending"
+  },
+  {
+    "key": "beer-consumption-quantity",
+    "video_url": "https://api.github.com/repos/uruhayato373/stats47/releases/assets/473480893",
+    "title": "ビール離れは地方から？｜消費量ランキングの推移 2007→2024",
+    "description": "都道府県別のビール消費量18年分の推移。2割減の中で強い県・弱い県が分かれます。\n\n▼ 最新年の全47都道府県ランキングはこちら\nhttps://stats47.jp/ranking/beer-consumption-quantity?utm_source=youtube&utm_medium=social&utm_campaign=beer-consumption-quantity&utm_content=bcr\n\n出典: 政府統計 (e-Stat ほか) を stats47.jp が加工・可視化\n#都道府県 #ランキング #統計 #ビール",
+    "tags": "都道府県,ランキング,統計,推移,バーチャートレース,ビール,家計調査",
+    "privacy": "private",
+    "publish_at": "2026-08-04T19:00:00+09:00",
+    "content_key": "bcr-beer-consumption-quantity-2007-2024",
+    "metric_keys": [
+      "beer-consumption-quantity"
+    ],
+    "status": "pending"
+  },
+  {
+    "key": "sake-consumption-quantity",
+    "video_url": "https://api.github.com/repos/uruhayato373/stats47/releases/assets/473480959",
+    "title": "日本酒をいちばん飲む県はどこ？｜消費量の推移 2007→2024",
+    "description": "都道府県別の清酒消費量18年分の推移。酒どころの意地と全国的な日本酒離れが同居しています。\n\n▼ 最新年の全47都道府県ランキングはこちら\nhttps://stats47.jp/ranking/sake-consumption-quantity?utm_source=youtube&utm_medium=social&utm_campaign=sake-consumption-quantity&utm_content=bcr\n\n出典: 政府統計 (e-Stat ほか) を stats47.jp が加工・可視化\n#都道府県 #ランキング #統計 #日本酒",
+    "tags": "都道府県,ランキング,統計,推移,バーチャートレース,日本酒,家計調査",
+    "privacy": "private",
+    "publish_at": "2026-08-05T19:00:00+09:00",
+    "content_key": "bcr-sake-consumption-quantity-2007-2024",
+    "metric_keys": [
+      "sake-consumption-quantity"
+    ],
+    "status": "pending"
+  },
+  {
+    "key": "beef-consumption-quantity",
+    "video_url": "https://api.github.com/repos/uruhayato373/stats47/releases/assets/473480889",
+    "title": "牛肉を最も食べるのは西日本？｜消費量ランキングの推移 2007→2024",
+    "description": "都道府県別の牛肉消費量18年分の推移。東西の食文化差がはっきり出るテーマです。\n\n▼ 最新年の全47都道府県ランキングはこちら\nhttps://stats47.jp/ranking/beef-consumption-quantity?utm_source=youtube&utm_medium=social&utm_campaign=beef-consumption-quantity&utm_content=bcr\n\n出典: 政府統計 (e-Stat ほか) を stats47.jp が加工・可視化\n#都道府県 #ランキング #統計 #牛肉",
+    "tags": "都道府県,ランキング,統計,推移,バーチャートレース,牛肉,食文化",
+    "privacy": "private",
+    "publish_at": "2026-08-06T19:00:00+09:00",
+    "content_key": "bcr-beef-consumption-quantity-2007-2024",
+    "metric_keys": [
+      "beef-consumption-quantity"
+    ],
+    "status": "pending"
+  },
+  {
+    "key": "chicken-consumption-quantity",
+    "video_url": "https://api.github.com/repos/uruhayato373/stats47/releases/assets/473480890",
+    "title": "鶏肉消費は1.5倍に伸びた｜47都道府県ランキングの推移 2007→2024",
+    "description": "都道府県別の鶏肉消費量18年分の推移。健康志向の追い風で全国的に増えています。\n\n▼ 最新年の全47都道府県ランキングはこちら\nhttps://stats47.jp/ranking/chicken-consumption-quantity?utm_source=youtube&utm_medium=social&utm_campaign=chicken-consumption-quantity&utm_content=bcr\n\n出典: 政府統計 (e-Stat ほか) を stats47.jp が加工・可視化\n#都道府県 #ランキング #統計 #鶏肉",
+    "tags": "都道府県,ランキング,統計,推移,バーチャートレース,鶏肉,食文化",
+    "privacy": "private",
+    "publish_at": "2026-08-07T19:00:00+09:00",
+    "content_key": "bcr-chicken-consumption-quantity-2007-2024",
+    "metric_keys": [
+      "chicken-consumption-quantity"
+    ],
+    "status": "pending"
+  },
+  {
+    "key": "white-bread-consumption-quantity",
+    "video_url": "https://api.github.com/repos/uruhayato373/stats47/releases/assets/473480973",
+    "title": "食パン王国は入れ替わった｜消費量ランキングの推移 2007→2024",
+    "description": "都道府県別の食パン消費量18年分の推移。関西の強さと首位交代のドラマが見どころです。\n\n▼ 最新年の全47都道府県ランキングはこちら\nhttps://stats47.jp/ranking/white-bread-consumption-quantity?utm_source=youtube&utm_medium=social&utm_campaign=white-bread-consumption-quantity&utm_content=bcr\n\n出典: 政府統計 (e-Stat ほか) を stats47.jp が加工・可視化\n#都道府県 #ランキング #統計 #食パン",
+    "tags": "都道府県,ランキング,統計,推移,バーチャートレース,食パン,家計調査",
+    "privacy": "private",
+    "publish_at": "2026-08-08T19:00:00+09:00",
+    "content_key": "bcr-white-bread-consumption-quantity-2007-2024",
+    "metric_keys": [
+      "white-bread-consumption-quantity"
+    ],
+    "status": "pending"
+  },
+  {
+    "key": "train-fare-consumption-expenditure",
+    "video_url": "https://api.github.com/repos/uruhayato373/stats47/releases/assets/473480964",
+    "title": "電車にお金をかける県はどこ？｜鉄道運賃支出の推移 2007→2024",
+    "description": "都道府県別の鉄道運賃支出18年分の推移。首都圏と地方の移動スタイルの差が数字に出ます。\n\n▼ 最新年の全47都道府県ランキングはこちら\nhttps://stats47.jp/ranking/train-fare-consumption-expenditure?utm_source=youtube&utm_medium=social&utm_campaign=train-fare-consumption-expenditure&utm_content=bcr\n\n出典: 政府統計 (e-Stat ほか) を stats47.jp が加工・可視化\n#都道府県 #ランキング #統計 #鉄道",
+    "tags": "都道府県,ランキング,統計,推移,バーチャートレース,鉄道,交通費",
+    "privacy": "private",
+    "publish_at": "2026-08-09T19:00:00+09:00",
+    "content_key": "bcr-train-fare-consumption-expenditure-2007-2024",
+    "metric_keys": [
+      "train-fare-consumption-expenditure"
+    ],
+    "status": "pending"
+  },
+  {
+    "key": "vet-fee-consumption-expenditure",
+    "video_url": "https://api.github.com/repos/uruhayato373/stats47/releases/assets/473480966",
+    "title": "ペットの医療費は倍増した｜動物病院代支出の推移 2007→2024",
+    "description": "都道府県別の動物病院代支出18年分の推移。ペットの家族化で支出は倍増しています。\n\n▼ 最新年の全47都道府県ランキングはこちら\nhttps://stats47.jp/ranking/vet-fee-consumption-expenditure?utm_source=youtube&utm_medium=social&utm_campaign=vet-fee-consumption-expenditure&utm_content=bcr\n\n出典: 政府統計 (e-Stat ほか) を stats47.jp が加工・可視化\n#都道府県 #ランキング #統計 #ペット",
+    "tags": "都道府県,ランキング,統計,推移,バーチャートレース,ペット,動物病院",
+    "privacy": "private",
+    "publish_at": "2026-08-10T19:00:00+09:00",
+    "content_key": "bcr-vet-fee-consumption-expenditure-2007-2024",
+    "metric_keys": [
+      "vet-fee-consumption-expenditure"
+    ],
+    "status": "pending"
+  }
+]

--- a/.github/workflows/youtube-upload-queue.yml
+++ b/.github/workflows/youtube-upload-queue.yml
@@ -1,0 +1,150 @@
+name: 📤 YouTube Upload Queue (daily)
+
+# YouTube 量産実験の「1ヶ月分予約仕込み」を日次で自動消化する。
+# .claude/state/youtube-upload-queue.json の pending エントリを 1 日最大 N 件 (既定 5)
+# アップロードし (privacy=private + publish_at 予約)、YouTube 側が publish_at に自動公開する。
+# API クォータ (videos.insert=1600units / 既定 10,000units/日 ≈ 6本) を超えないため
+# 一括ではなく日次バッチにする。正典: docs/10_SNS戦略/07_YouTube量産実験.md §Phase 3
+#
+# - cron 17:30 JST = クォータ日次リセット (太平洋時間 0:00 = 16:00 JST) の直後
+# - 動画は GitHub Release アセットから fetch (ローカル R2 creds 不要)
+# - 各アップロードで upload.js 内のガード (budget: 公開予定日 1日1本 / duplicate 5層) が走る
+# - 失敗エントリは status=failed にして次へ進む (毒エントリでバッチを止めない。再試行は
+#   status を pending に手で戻す)
+# - schedule トリガーは default branch (main) の workflow 定義で発火し、実行は develop を
+#   checkout して develop に commit-back する (youtube-shadowban-diagnose.yml と同パターン)
+
+on:
+  schedule:
+    - cron: "30 8 * * *" # 17:30 JST
+  workflow_dispatch:
+    inputs:
+      count:
+        description: "今回処理する最大本数 (クォータ ≈6/日以内)"
+        required: false
+        default: "5"
+
+permissions:
+  contents: write
+
+concurrency:
+  group: youtube-upload # 単発リクエスト経路 (youtube-upload.yml) と直列化
+  cancel-in-progress: false
+
+jobs:
+  process-queue:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - name: 🧰 Checkout develop
+        uses: actions/checkout@v4
+        with:
+          ref: develop
+          fetch-depth: 1
+
+      - name: 🔎 Check pending
+        id: precheck
+        run: |
+          QUEUE=.claude/state/youtube-upload-queue.json
+          if [ ! -f "$QUEUE" ]; then
+            echo "queue ファイル無し、skip"
+            echo "pending=0" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          PENDING=$(jq '[.[] | select(.status=="pending")] | length' "$QUEUE")
+          echo "pending=$PENDING" >> "$GITHUB_OUTPUT"
+          echo "pending: $PENDING 件"
+
+      - name: 🟢 Setup Node.js
+        if: steps.precheck.outputs.pending != '0'
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "npm"
+
+      - name: 📦 Install dependencies
+        if: steps.precheck.outputs.pending != '0'
+        run: npm ci
+
+      - name: 🔐 Write .env.local from secrets
+        if: steps.precheck.outputs.pending != '0'
+        run: |
+          {
+            echo "GOOGLE_OAUTH_CLIENT_ID=${{ secrets.GOOGLE_OAUTH_CLIENT_ID }}"
+            echo "GOOGLE_OAUTH_CLIENT_SECRET=${{ secrets.GOOGLE_OAUTH_CLIENT_SECRET }}"
+            echo "GOOGLE_OAUTH_REFRESH_TOKEN=${{ secrets.GOOGLE_OAUTH_REFRESH_TOKEN }}"
+            echo "YOUTUBE_CHANNEL_ID=UCdRiwDSX1aUd0dSd7Cs08Kg"
+          } > .env.local
+
+      - name: 📤 Process queue (up to N per day)
+        if: steps.precheck.outputs.pending != '0'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          COUNT: ${{ inputs.count || '5' }}
+        run: |
+          QUEUE=.claude/state/youtube-upload-queue.json
+          LEN=$(jq length "$QUEUE")
+          DONE=0
+          FAILED=0
+          for i in $(seq 0 $((LEN - 1))); do
+            [ "$DONE" -lt "$COUNT" ] || break
+            STATUS=$(jq -r ".[$i].status" "$QUEUE")
+            [ "$STATUS" = "pending" ] || continue
+            KEY=$(jq -r ".[$i].key" "$QUEUE")
+            VURL=$(jq -r ".[$i].video_url" "$QUEUE")
+            TITLE=$(jq -r ".[$i].title" "$QUEUE")
+            PUBAT=$(jq -r ".[$i].publish_at" "$QUEUE")
+            echo "────────── [$i] $KEY → publish $PUBAT"
+            if [ -z "$VURL" ] || [ "$VURL" = "null" ]; then
+              jq ".[$i].status=\"failed\" | .[$i].error=\"video_url が空\"" "$QUEUE" > q.tmp && mv q.tmp "$QUEUE"
+              FAILED=$((FAILED + 1)); continue
+            fi
+            if ! curl -fL -H "Authorization: token $GH_TOKEN" -H "Accept: application/octet-stream" "$VURL" -o video.mp4; then
+              jq ".[$i].status=\"failed\" | .[$i].error=\"video fetch 失敗\"" "$QUEUE" > q.tmp && mv q.tmp "$QUEUE"
+              FAILED=$((FAILED + 1)); continue
+            fi
+            echo "video.mp4 $(stat -c%s video.mp4) bytes"
+            if node .claude/scripts/youtube/upload.js video.mp4 \
+                 --title "$TITLE" \
+                 --description "$(jq -r ".[$i].description" "$QUEUE")" \
+                 --tags "$(jq -r ".[$i].tags" "$QUEUE")" \
+                 --privacy private --schedule "$PUBAT" \
+                 --content-key "$(jq -r ".[$i].content_key" "$QUEUE")" \
+                 --post-type long --domain ranking --template bcr \
+                 --metric-keys "$(jq -c ".[$i].metric_keys" "$QUEUE")"; then
+              jq ".[$i].status=\"uploaded\" | .[$i].uploaded_at=\"$(date -u +%Y-%m-%dT%H:%M:%SZ)\"" "$QUEUE" > q.tmp && mv q.tmp "$QUEUE"
+              DONE=$((DONE + 1))
+            else
+              jq ".[$i].status=\"failed\" | .[$i].error=\"upload.js exit != 0\"" "$QUEUE" > q.tmp && mv q.tmp "$QUEUE"
+              FAILED=$((FAILED + 1))
+            fi
+            rm -f video.mp4
+            sleep 20
+          done
+          REMAIN=$(jq '[.[] | select(.status=="pending")] | length' "$QUEUE")
+          echo "uploaded=$DONE failed=$FAILED remaining_pending=$REMAIN"
+          {
+            echo "# YouTube Upload Queue — $(TZ=Asia/Tokyo date +%Y-%m-%d)"
+            echo ""
+            echo "- uploaded: $DONE / failed: $FAILED / pending 残: $REMAIN"
+            jq -r '.[] | select(.status=="failed") | "- ❌ \(.key): \(.error // "?")"' "$QUEUE"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: 🧹 Remove secrets file
+        if: always()
+        run: rm -f .env.local
+
+      - name: 📤 Commit queue + ledger back to develop
+        if: always() && steps.precheck.outputs.pending != '0'
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add .claude/state/sns/posts.json .claude/state/youtube-upload-queue.json
+          if git diff --cached --quiet; then
+            echo "変更なし、コミットをスキップ"
+            exit 0
+          fi
+          git commit -m "chore(youtube): upload queue 消化 [skip ci]"
+          git fetch origin develop
+          git rebase origin/develop
+          git push origin HEAD:develop

--- a/docs/01_技術設計/06_自動化インベントリ.md
+++ b/docs/01_技術設計/06_自動化インベントリ.md
@@ -55,7 +55,7 @@ stats47 の全自動化タスクの静的な真実源。**新規追加・削除�
 
 | workflow | cron (UTC) | 日本時間 | 目的 | ステータス | 関連 |
 |---|---|---|---|---|---|
-| `post-instagram-scheduled.yml` | `3 0 * * *` | 毎日 09:03 JST | `.claude/state/instagram-w18-schedule.json` 参照、今日と一致するエントリがあれば IG 投稿（IG API 予約非対応の代替） | 運用中 | #127 |
+| `post-instagram-scheduled.yml` | `3 23 * * *` / `3 3 * * *` / `3 10 * * *` | 毎日 08:03 / 12:03 / 19:03 JST | `.claude/state/instagram-w*-schedule.json`（当日を含む週ファイルを自動選択）参照。各実行が「time <= 現在時刻 かつ ig-posted-log 未記録」の最早 1 件を IG 投稿（IG API 予約非対応の代替。1 日複数本対応 2026-07-11〜） | 運用中 | #127 |
 
 ### CI/CD・品質保証系（push trigger）
 

--- a/docs/01_技術設計/06_自動化インベントリ.md
+++ b/docs/01_技術設計/06_自動化インベントリ.md
@@ -72,6 +72,7 @@ stats47 の全自動化タスクの静的な真実源。**新規追加・削除�
 | `sync-snapshots.yml` (sync-ranking-keys job) | dispatch | KNOWN/SITEMAP keys 再生成 + **新規 ranking の OGP/カードを即生成→R2** (公開時フック) | 運用中 |
 | `youtube-upload.yml` | push to develop (`.claude/state/youtube-upload-request.json`) + dispatch | YouTube 投稿ブリッジ (量産実験)。リクエストファイルの動画 URL (GitHub Release アセット等) を fetch → CI secrets の OAuth で `upload.js` 実行 (budget/duplicate ガード内蔵) → posts.json commit-back。本番デプロイ不要 | 運用中 (2026-07-11〜) |
 | `youtube-shadowban-diagnose.yml` | push to develop (自ファイル) + dispatch | シャドウバン診断 (read-only)。CI secrets の OAuth で `diagnose-shadowban.js` を実行し verdict を artifact/step summary に出力 | 運用中 (2026-07-11〜) |
+| `youtube-upload-queue.yml` | `30 8 * * *` (17:30 JST) + dispatch | YouTube 予約仕込みキューの日次消化 (量産実験)。`.claude/state/youtube-upload-queue.json` の pending を 1 日最大 5 本、Release アセット fetch → `upload.js` で private + publish_at 予約アップロード (クォータ 1600units×5 < 10,000/日)。失敗は status=failed で隔離、queue/posts.json を commit-back | 運用中 (2026-07-11〜) |
 
 ---
 

--- a/docs/10_SNS戦略/07_YouTube量産実験.md
+++ b/docs/10_SNS戦略/07_YouTube量産実験.md
@@ -110,7 +110,13 @@ tags: [youtube, sns, shadowban, experiment]
 ### Phase 3: 自動化（CI 投稿経路）
 - [x] upload workflow 新設（`youtube-upload.yml`。CI シークレットの OAuth 流用、認証手間ゼロ）
 - [x] 動画の受け渡し設計（ローカル render → **GitHub Release アセット** → CI fetch。R2 creds 不要）
-- [ ] 日次 N 本のスケジューリング（量産 go 判定後: リクエストファイルの一括仕込み or cron 化）
+- [x] **日次 N 本のスケジューリング（2026-07-11 実装・ユーザー指示で初速判定を待たず仕込み開始）**:
+  `.claude/state/youtube-upload-queue.json`（30 本の仕込みキュー: title/description/tags/publish_at/
+  video_url=Release アセット）+ `.github/workflows/youtube-upload-queue.yml`（cron 17:30 JST =
+  クォータ日次リセット直後。pending を 1 日最大 5 本 upload.js で予約アップロード
+  (privacy=private + `--schedule` publish_at)、YouTube 側が publish_at に自動公開。
+  クォータ videos.insert=1600units×5=8,000 < 10,000/日。失敗エントリは status=failed で隔離）。
+  publish_at は 2026-07-12〜08-10 の毎日 19:00 JST（1日1本ガードと整合）
 - **注意**: 日次量産は必ず `check-youtube-duplicate.cjs` を通し、テーマ/タイトルを毎回変える
   （2026-04 の再発防止）。
 
@@ -225,7 +231,10 @@ recent=投稿停止期の比較）。**投稿停止期には verdict は無効**
 - 実験フラグ: `.claude/state/youtube-experiment.json`（dailyLimit=1 / monthlyLimit=31。削除で月 1 復帰）
 - 認証: `.claude/scripts/youtube/oauth-setup.js`
 - 投稿: `.claude/scripts/youtube/upload.js` / **CI 経路: `.github/workflows/youtube-upload.yml` +
-  `.claude/state/youtube-upload-request.json`（リクエストファイル）**
+  `.claude/state/youtube-upload-request.json`（リクエストファイル・単発用）**
+- **予約仕込みキュー（1ヶ月分の量産予約・2026-07-11〜）**: `.claude/state/youtube-upload-queue.json` +
+  `.github/workflows/youtube-upload-queue.yml`（日次 cron 17:30 JST が pending を 5 本/日消化 →
+  private + publish_at 予約。動画は Release `yt-bcr-2026-07` のアセット）
 - 診断: `.claude/scripts/youtube/diagnose-shadowban.js` / `.github/workflows/youtube-shadowban-diagnose.yml`
 - 動画: `apps/remotion` / `bar-chart-race` skill
 - 投稿台帳（SSOT）: `.claude/state/sns/posts.json`


### PR DESCRIPTION
## 概要

YouTube 量産実験の 1 ヶ月分予約 (2026-07-12〜08-10、毎日 19:00 JST 公開・1日1本ガード整合)。ユーザー明示指示 (2026-07-11) により初速判定を待たず仕込み開始。

## 変更

- **youtube-upload-queue.yml** (新規): cron 17:30 JST (クォータ日次リセット直後) に `.claude/state/youtube-upload-queue.json` の pending を 1 日最大 5 本、Release `yt-bcr-2026-07` アセットを fetch → `upload.js` で private + publish_at 予約アップロード。upload.js 内で budget (公開予定日 1日1本) / duplicate (5層) ガードが走る。失敗エントリは status=failed で隔離
- **youtube-upload-queue.json** (新規): 30 本の仕込みキュー (title/description/tags/publish_at/video_url)
- 手順書 (07_YouTube量産実験.md) Phase 3 と自動化インベントリを更新
- 同梱 (develop 先行分): IG 1日3本化のドリフト是正 (time 既定 08:00・インベントリ・skill docs)

## cron が main で動くためのマージです

schedule トリガーは default branch (main) の workflow 定義で発火し、実行は develop を checkout して develop に commit-back します (diagnose workflow と同パターン)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)